### PR TITLE
feat(oscar): add codex-app homebrew cask for work+graphical hosts

### DIFF
--- a/modules/aspects/users/oscar/work/work.nix
+++ b/modules/aspects/users/oscar/work/work.nix
@@ -12,6 +12,8 @@
         builtins.attrValues den.aspects.oscar.provides.work.provides ++ (lib.optional (host.graphical or false) my.slack)
       );
 
+      darwin.homebrew.casks = lib.optionals ((host.work or false) && (host.graphical or false)) [ "codex-app" ];
+
       homeManager =
         { pkgs, ... }:
         {


### PR DESCRIPTION
## What changed

Adds `codex-app` as a Homebrew cask in the work aspect (`modules/aspects/users/oscar/work/work.nix`), gated on both `host.work` and `host.graphical` being true.

## Why

Codex is a GUI app, so it only makes sense to install it on graphical work machines (currently `OMARSHAL-M-2FD2`).

## Notes for reviewer

- Used `(host.work or false) && (host.graphical or false)` with explicit parentheses — `or` has higher precedence than `&&` in Nix, so parens are required for correct evaluation.