### PR TITLE
fix(nix): make nix-access-tokens secret world-readable

### DIFF
--- a/modules/aspects/my/nix.nix
+++ b/modules/aspects/my/nix.nix
@@ -8,6 +8,8 @@
           intermediary = true;
         };
 
+        # World-readable: nix fetches via the client process, not the daemon,
+        # so all users need to read this for authenticated GitHub API access.
         nix-access-tokens.mode = "0444";
         nix-access-tokens.generator = {
           dependencies = { inherit (secrets) github-access-token; };

--- a/modules/aspects/my/nix.nix
+++ b/modules/aspects/my/nix.nix
@@ -8,6 +8,7 @@
           intermediary = true;
         };
 
+        nix-access-tokens.mode = "0444";
         nix-access-tokens.generator = {
           dependencies = { inherit (secrets) github-access-token; };
           script =


### PR DESCRIPTION
## Summary

- The `nix-access-tokens` agenix secret (which injects `access-tokens = github.com=<token>` into `nix.conf` via `!include`) was only readable by root
- Nix fetching from GitHub is done by the **client** process, not the daemon, so regular users couldn't read the token and fell back to unauthenticated requests, hitting GitHub API rate limits
- Sets `mode = "0444"` on the secret so all users can read it

## Test plan

- [ ] Rebuild and restart the nix daemon
- [ ] Run `nix flake metadata github:NixOS/nixpkgs/nixos-unstable --no-use-registries --refresh` as a non-root user — should resolve without a 403 rate limit error

🤖 Generated with [Claude Code](https://claude.com/claude-code)