### PR TITLE
Change harmony to linux-cachyos-server (non-lto)

### DIFF
--- a/modules/aspects/hosts/harmony/harmony.nix
+++ b/modules/aspects/hosts/harmony/harmony.nix
@@ -5,7 +5,7 @@
       (auto-upgrade { allowReboot = true; })
       autobrr
       boot
-      (cachyos-kernel { variant = "server-lto"; })
+      (cachyos-kernel { variant = "server"; })
       cross-seed
       gluetun
       homepage


### PR DESCRIPTION
LTO is no longer covered by the binary cache.