### PR TITLE
fix(den): remove dev203 host stub that caused agenix self-parent error

### DIFF
--- a/modules/den.nix
+++ b/modules/den.nix
@@ -17,11 +17,6 @@
     };
   };
 
-  den.hosts.x86_64-linux."dev203.meraki.com" = {
-    work = true;
-    users.omarshal = { };
-  };
-
   den.homes.x86_64-linux."omarshal@dev203.meraki.com" = {
     aspect = den.aspects.oscar;
     work = true;


### PR DESCRIPTION
The stub host entry for dev203.meraki.com with users.omarshal was creating a self-parent edge in den's scope graph: the standalone den.homes entity and the host's user entity resolved to the same scope, causing agenix-edit-view to fail with "spawnNode spawn root equals its parent scope".

The host stub is unnecessary — den.aspects.oscar.provides."dev203.meraki.com" resolves correctly from the standalone den.homes entry alone.