### PR TITLE
feat(claude): rename aspect and add claude desktop cask

### DIFF
--- a/modules/aspects/my/claude.nix
+++ b/modules/aspects/my/claude.nix
@@ -4,8 +4,10 @@
     inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  my.claude-code = {
+  my.claude = {
     includes = [ (den._.unfree [ "claude-code" ]) ];
+
+    darwin.homebrew.casks = [ "claude" ];
 
     homeManager = { config, pkgs, ... }: {
       # Declared here (not in a top-level secrets block) so it lands in the

--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -37,7 +37,7 @@ in
         den._.primary-user
         (den._.user-shell "fish")
         my.bat
-        my.claude-code
+        my.claude
         my.direnv
         my.emacs
         (my.git {


### PR DESCRIPTION
## Summary

- Renames `my.claude-code` aspect to `my.claude` (file `claude-code.nix` → `claude.nix`)
- Adds the `claude` Homebrew cask for Darwin (Claude desktop app)
- Updates the include in `oscar.nix` to reference `my.claude`

🤖 Generated with [Claude Code](https://claude.com/claude-code)