### PR TITLE
feat: add cache.xinux.uz as secondary CachyOS kernel cache

### DIFF
--- a/modules/aspects/my/cachyos-kernel.nix
+++ b/modules/aspects/my/cachyos-kernel.nix
@@ -39,8 +39,14 @@
         }:
         {
           nix.settings = {
-            extra-substituters = [ "https://attic.xuyh0120.win/lantian" ];
-            extra-trusted-public-keys = [ "lantian:EeAUQ+W+6r7EtwnmYjeVwx5kOGEBpjlBfPlzGlTNvHc=" ];
+            extra-substituters = [
+              "https://attic.xuyh0120.win/lantian"
+              "https://cache.xinux.uz"
+            ];
+            extra-trusted-public-keys = [
+              "lantian:EeAUQ+W+6r7EtwnmYjeVwx5kOGEBpjlBfPlzGlTNvHc="
+              "cache.xinux.uz:BXCrtqejFjWzWEB9YuGB7X2MV4ttBur1N8BkwQRdH+0="
+            ];
           };
 
           nixpkgs.overlays = [


### PR DESCRIPTION
## Summary
- Adds `https://cache.xinux.uz` as a secondary substituter in the `cachyos-kernel` aspect alongside the existing `attic.xuyh0120.win/lantian` cache
- Adds the corresponding trusted public key `cache.xinux.uz:BXCrtqejFjWzWEB9YuGB7X2MV4ttBur1N8BkwQRdH+0=`

🤖 Generated with [Claude Code](https://claude.com/claude-code)