### PR TITLE
feat(den): add substituters quirk for declarative binary cache configuration

### DIFF
--- a/modules/aspects/defaults.nix
+++ b/modules/aspects/defaults.nix
@@ -6,6 +6,8 @@
   ...
 }:
 let
+  inherit (den.lib.policy) pipe;
+  exposeSubstituters = pipe.from "substituters" [ pipe.expose ];
   hmPlatforms =
     { aspect-chain, ... }:
     den._.forward {
@@ -93,6 +95,7 @@ in
           secrets
           my.fonts
           my.nix
+          exposeSubstituters
         ];
 
         os.system.configurationRevision = self.rev or self.dirtyRev or null;

--- a/modules/aspects/defaults.nix
+++ b/modules/aspects/defaults.nix
@@ -79,7 +79,13 @@ in
     ];
 
     quirks.substituters = {
-      description = "Binary cache substituter declarations";
+      description = ''
+        Binary cache substituter declarations. Each value should be an
+        attrset (or list of attrsets) of the form:
+          { substituter = "https://..."; publicKey = "<name>:<key>"; }
+        Collected values populate nix.settings.extra-substituters /
+        extra-trusted-public-keys and flake.nixConfig for bootstrap.
+      '';
     };
 
     schema = {

--- a/modules/aspects/defaults.nix
+++ b/modules/aspects/defaults.nix
@@ -76,7 +76,12 @@ in
       my.stylix
     ];
 
+    quirks.substituters = {
+      description = "Binary cache substituter declarations";
+    };
+
     schema = {
+      flake.includes = [ my.nix ];
       home.includes = [
         secrets
         my.nix

--- a/modules/aspects/my/cachyos-kernel.nix
+++ b/modules/aspects/my/cachyos-kernel.nix
@@ -30,6 +30,11 @@
       variant ? "latest-lto",
     }:
     {
+      substituters = {
+        substituter = "https://attic.xuyh0120.win/lantian";
+        publicKey = "lantian:EeAUQ+W+6r7EtwnmYjeVwx5kOGEBpjlBfPlzGlTNvHc=";
+      };
+
       nixos =
         {
           config,
@@ -38,11 +43,6 @@
           ...
         }:
         {
-          nix.settings = {
-            extra-substituters = [ "https://attic.xuyh0120.win/lantian" ];
-            extra-trusted-public-keys = [ "lantian:EeAUQ+W+6r7EtwnmYjeVwx5kOGEBpjlBfPlzGlTNvHc=" ];
-          };
-
           nixpkgs.overlays = [
             # Use the exact kernel versions as defined in nix-cachyos-kernel repo.
             # Guarantees binary cache availability.

--- a/modules/aspects/my/nix.nix
+++ b/modules/aspects/my/nix.nix
@@ -80,7 +80,7 @@ in
         { nix.optimise.automatic = true; }
       ];
 
-    flake = { substituters, lib, ... }: {
+    flake = { substituters, ... }: {
       flake.nixConfig = {
         extra-substituters = lib.unique (map (s: s.substituter) substituters);
         extra-trusted-public-keys = lib.unique (map (s: s.publicKey) substituters);

--- a/modules/aspects/my/nix.nix
+++ b/modules/aspects/my/nix.nix
@@ -87,10 +87,10 @@
         };
       };
 
-    flake = { substituters, ... }: {
+    flake = { substituters, lib, ... }: {
       flake.nixConfig = {
-        extra-substituters = map (s: s.substituter) substituters;
-        extra-trusted-public-keys = map (s: s.publicKey) substituters;
+        extra-substituters = lib.unique (map (s: s.substituter) substituters);
+        extra-trusted-public-keys = lib.unique (map (s: s.publicKey) substituters);
       };
     };
   };

--- a/modules/aspects/my/nix.nix
+++ b/modules/aspects/my/nix.nix
@@ -1,34 +1,16 @@
-{ lib, ... }:
-let
-  nixConfig = { config, pkgs, ... }: {
-    nix = {
-      extraOptions = ''
-        !include ${config.age.secrets.nix-access-tokens.path}
-      '';
-      gc = {
-        automatic = true;
-        options = "--delete-older-than 7d";
-      };
-      package = pkgs.lixPackageSets.stable.lix;
-      settings = {
-        experimental-features = [
-          "nix-command"
-          "flakes"
-        ];
-        extra-substituters = [
-          "https://nix-community.cachix.org"
-          "https://oscarmarshall.cachix.org"
-        ];
-        extra-trusted-public-keys = [
-          "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-          "oscarmarshall.cachix.org-1:Fa13vGeBXoJ7jWpvnalg/PCRTtvCpyuHUFL5jQXt/9w="
-        ];
-      };
-    };
-  };
-in
-{
+{ lib, ... }: {
   my.nix = {
+    substituters = [
+      {
+        substituter = "https://nix-community.cachix.org";
+        publicKey = "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=";
+      }
+      {
+        substituter = "https://oscarmarshall.cachix.org";
+        publicKey = "oscarmarshall.cachix.org-1:Fa13vGeBXoJ7jWpvnalg/PCRTtvCpyuHUFL5jQXt/9w=";
+      }
+    ];
+
     secrets = { secrets, ... }: {
       nix-github-access-token = {
         rekeyFile = ../../../secrets/nix-github-access-token.age;
@@ -48,13 +30,68 @@ in
       };
     };
 
-    homeManager = nixConfig;
+    homeManager =
+      {
+        substituters,
+        config,
+        pkgs,
+        ...
+      }:
+      {
+        nix = {
+          extraOptions = ''
+            !include ${config.age.secrets.nix-access-tokens.path}
+          '';
+          gc = {
+            automatic = true;
+            options = "--delete-older-than 7d";
+          };
+          package = pkgs.lixPackageSets.stable.lix;
+          settings = {
+            experimental-features = [
+              "nix-command"
+              "flakes"
+            ];
+            extra-substituters = map (s: s.substituter) substituters;
+            extra-trusted-public-keys = map (s: s.publicKey) substituters;
+          };
+        };
+      };
 
     os =
-      { config, pkgs, ... }:
-      lib.mkMerge [
-        (nixConfig { inherit config pkgs; })
-        { nix.optimise.automatic = true; }
-      ];
+      {
+        substituters,
+        config,
+        pkgs,
+        ...
+      }:
+      {
+        nix = {
+          extraOptions = ''
+            !include ${config.age.secrets.nix-access-tokens.path}
+          '';
+          gc = {
+            automatic = true;
+            options = "--delete-older-than 7d";
+          };
+          package = pkgs.lixPackageSets.stable.lix;
+          settings = {
+            experimental-features = [
+              "nix-command"
+              "flakes"
+            ];
+            extra-substituters = map (s: s.substituter) substituters;
+            extra-trusted-public-keys = map (s: s.publicKey) substituters;
+          };
+          optimise.automatic = true;
+        };
+      };
+
+    flake = { substituters, ... }: {
+      flake.nixConfig = {
+        extra-substituters = map (s: s.substituter) substituters;
+        extra-trusted-public-keys = map (s: s.publicKey) substituters;
+      };
+    };
   };
 }

--- a/modules/aspects/my/nix.nix
+++ b/modules/aspects/my/nix.nix
@@ -1,4 +1,33 @@
-{ lib, ... }: {
+{ lib, ... }:
+let
+  mkNixConfig =
+    {
+      substituters,
+      config,
+      pkgs,
+    }:
+    {
+      nix = {
+        extraOptions = ''
+          !include ${config.age.secrets.nix-access-tokens.path}
+        '';
+        gc = {
+          automatic = true;
+          options = "--delete-older-than 7d";
+        };
+        package = pkgs.lixPackageSets.stable.lix;
+        settings = {
+          experimental-features = [
+            "nix-command"
+            "flakes"
+          ];
+          extra-substituters = map (s: s.substituter) substituters;
+          extra-trusted-public-keys = map (s: s.publicKey) substituters;
+        };
+      };
+    };
+in
+{
   my.nix = {
     substituters = [
       {
@@ -37,26 +66,7 @@
         pkgs,
         ...
       }:
-      {
-        nix = {
-          extraOptions = ''
-            !include ${config.age.secrets.nix-access-tokens.path}
-          '';
-          gc = {
-            automatic = true;
-            options = "--delete-older-than 7d";
-          };
-          package = pkgs.lixPackageSets.stable.lix;
-          settings = {
-            experimental-features = [
-              "nix-command"
-              "flakes"
-            ];
-            extra-substituters = map (s: s.substituter) substituters;
-            extra-trusted-public-keys = map (s: s.publicKey) substituters;
-          };
-        };
-      };
+      mkNixConfig { inherit substituters config pkgs; };
 
     os =
       {
@@ -65,27 +75,10 @@
         pkgs,
         ...
       }:
-      {
-        nix = {
-          extraOptions = ''
-            !include ${config.age.secrets.nix-access-tokens.path}
-          '';
-          gc = {
-            automatic = true;
-            options = "--delete-older-than 7d";
-          };
-          package = pkgs.lixPackageSets.stable.lix;
-          settings = {
-            experimental-features = [
-              "nix-command"
-              "flakes"
-            ];
-            extra-substituters = map (s: s.substituter) substituters;
-            extra-trusted-public-keys = map (s: s.publicKey) substituters;
-          };
-          optimise.automatic = true;
-        };
-      };
+      lib.mkMerge [
+        (mkNixConfig { inherit substituters config pkgs; })
+        { nix.optimise.automatic = true; }
+      ];
 
     flake = { substituters, lib, ... }: {
       flake.nixConfig = {


### PR DESCRIPTION
## Summary

- Declares \`den.quirks.substituters\` so any aspect can emit \`{ substituter, publicKey }\` entries
- \`os\` and \`homeManager\` classes in \`my.nix\` consume the quirk to populate \`nix.settings.extra-substituters/extra-trusted-public-keys\`
- \`flake\` class in \`my.nix\` populates \`flake.nixConfig\` from the quirk, so caches are consulted on the **first** \`nixos-rebuild switch\` (bootstrap catch-22 fix)
- \`pipe.expose\` policy added to \`schema.host.includes\` — every host automatically bubbles its substituters up to the flake scope, so host-specific aspects (e.g. \`cachyos-kernel\`) reach \`nixConfig\` without any master list
- Converts \`cachyos-kernel\` to emit on the quirk instead of hardcoding \`nix.settings\`
- \`lib.unique\` deduplicates the common substituters that all hosts expose

Any future aspect that needs a binary cache just emits on \`substituters\` — nothing else needs to change.

## Test plan

- [x] \`nix build .#darwinConfigurations.OMARSHAL-M-2FD2.config.system.build.toplevel\` passes
- [ ] Verify \`nix flake show\` includes \`nixConfig\` with all expected substituters (nix-community, oscarmarshall, lantian)
- [ ] Confirm a new-machine bootstrap uses the cache on the first rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)