### PR TITLE
fix(logseq): drop graph-server management

### DIFF
--- a/modules/aspects/my/logseq.nix
+++ b/modules/aspects/my/logseq.nix
@@ -10,8 +10,6 @@
     };
   };
 
-  den.quirks.logseq-graphs.description = "Logseq graph server definitions, each { name [, rootDir] }";
-
   my.logseq =
     {
       cli-only ? false,
@@ -24,76 +22,5 @@
         ]
         ++ lib.optional (!cli-only) inputs.nix-logseq-git-flake.packages.${pkgs.system}.logseq;
       };
-
-      hmLinux =
-        {
-          pkgs,
-          lib,
-          logseq-graphs,
-          ...
-        }:
-        let
-          cliExe = "${inputs.nix-logseq-git-flake.packages.${pkgs.system}.logseq-cli}/bin/logseq-cli";
-          serverStart =
-            graph:
-            "${cliExe} server start --graph ${lib.escapeShellArg graph.name}"
-            + (if graph ? rootDir then " --root-dir ${lib.escapeShellArg graph.rootDir}" else "");
-          serverStop = graph: "${cliExe} server stop --graph ${lib.escapeShellArg graph.name}";
-        in
-        {
-          systemd.user.services = lib.listToAttrs (
-            map (graph: {
-              name = "logseq-graph-${graph.name}";
-              value = {
-                Unit.Description = "Logseq graph server for ${graph.name}";
-                Service = {
-                  Type = "oneshot";
-                  RemainAfterExit = true;
-                  ExecStart = serverStart graph;
-                  ExecStop = serverStop graph;
-                };
-                Install.WantedBy = [ "default.target" ];
-              };
-            }) logseq-graphs
-          );
-        };
-
-      hmDarwin =
-        {
-          pkgs,
-          lib,
-          logseq-graphs,
-          ...
-        }:
-        let
-          cliExe = "${inputs.nix-logseq-git-flake.packages.${pkgs.system}.logseq-cli}/bin/logseq-cli";
-          serverStart =
-            graph:
-            "${cliExe} server start --graph ${lib.escapeShellArg graph.name}"
-            + (if graph ? rootDir then " --root-dir ${lib.escapeShellArg graph.rootDir}" else "");
-        in
-        {
-          launchd.agents = lib.listToAttrs (
-            map (graph: {
-              name = "logseq-graph-${graph.name}";
-              value = {
-                enable = true;
-                config = {
-                  Label = "com.logseq.graph.${graph.name}";
-                  ProgramArguments = [
-                    "/bin/sh"
-                    "-c"
-                    "exec ${serverStart graph}"
-                  ];
-                  RunAtLoad = true;
-                  KeepAlive.Crashed = true;
-                  ThrottleInterval = 30;
-                  StandardOutPath = "/tmp/logseq-graph-${graph.name}.log";
-                  StandardErrorPath = "/tmp/logseq-graph-${graph.name}.log";
-                };
-              };
-            }) logseq-graphs
-          );
-        };
     };
 }

--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -32,8 +32,6 @@ in
           { };
     in
     {
-      logseq-graphs = [ { name = "Personal"; } ];
-
       includes = [
         den.aspects.oscar.provides.work
         den._.primary-user
@@ -77,8 +75,8 @@ in
         };
 
         # See the comment on provides.oscar in OMARSHAL-M-2FD2.nix for why these sentinels are needed:
-        # this home entity's re-walked spawn scope doesn't re-run my.logseq's own includes, so hmLinux
-        # is absent at compile time without this and the forward falls through to resolveSourceFallback.
+        # this home entity's re-walked spawn scope doesn't re-run the user aspect's own includes, so
+        # hmLinux is absent at compile time without this and the forward falls through to resolveSourceFallback.
         hmLinux = { };
         hmDarwin = { };
         hmAarch64 = { };

--- a/modules/aspects/users/oscar/work/work.nix
+++ b/modules/aspects/users/oscar/work/work.nix
@@ -29,8 +29,6 @@ in
         builtins.attrValues den.aspects.oscar.provides.work.provides ++ (lib.optional (scope.graphical or false) my.slack)
       );
 
-      logseq-graphs = lib.optional (scope.work or false) { name = "Meraki"; };
-
       darwin.homebrew.casks = lib.optionals ((scope.work or false) && (scope.graphical or false)) [ "codex-app" ];
 
       homeManager = { pkgs, ... }: {


### PR DESCRIPTION
## Summary

- `logseq-cli server start` actually starts a db-worker node, not an API server as assumed in #399 — there's no need to manage per-graph server processes myself
- Removes the `logseq-graphs` den quirk and the `hmLinux`/`hmDarwin` systemd-user-service / launchd-agent generation from `my.logseq`
- Removes the graph declarations (`logseq-graphs = [...]`) from `oscar.nix` and `work.nix`
- `my.logseq` now only installs the `logseq` / `logseq-cli` packages (plus the `cli-only` toggle), same as before the graph-server feature was added

The `hmLinux`/`hmDarwin`/`hmAarch64`/`hm64bit` sentinel keys added in #399 to fix the Den `allHomeNodes` self-parent spawn issue are kept — other aspects (gpg, ghostty, discord, etc.) still populate those classes, so the sentinels remain necessary.

## Test plan

- [x] `nix run .#write-flake` then `nix fmt` — no changes to `flake.nix`
- [x] `nix eval` each of `darwinConfigurations.OMARSHAL-M-2FD2`, `nixosConfigurations.harmony`, `nixosConfigurations.melaan`, and `homeConfigurations."omarshal@dev203.meraki.com"` — all resolve cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)