### PR TITLE
fix(proton-pass): run ssh-agent in gui launchd domain

### DIFF
--- a/modules/aspects/my/proton-pass.nix
+++ b/modules/aspects/my/proton-pass.nix
@@ -2,6 +2,14 @@
   my.proton-pass = {
     includes = [ (den._.unfree [ "proton-pass-cli" ]) ];
 
-    homeManager.services.proton-pass-agent.enable = true;
+    homeManager = {
+      services.proton-pass-agent.enable = true;
+
+      # Upstream defaults this agent to the launchd "user" domain, which has no
+      # window-server session. Keychain access for the DB encryption key needs
+      # the Aqua session (the "gui" domain) or it fails with -25308
+      # (errSecInteractionNotAllowed).
+      launchd.agents.proton-pass-agent.domain = "gui";
+    };
   };
 }

--- a/modules/aspects/my/proton-pass.nix
+++ b/modules/aspects/my/proton-pass.nix
@@ -2,14 +2,12 @@
   my.proton-pass = {
     includes = [ (den._.unfree [ "proton-pass-cli" ]) ];
 
-    homeManager = {
-      services.proton-pass-agent.enable = true;
+    homeManager.services.proton-pass-agent.enable = true;
 
-      # Upstream defaults this agent to the launchd "user" domain, which has no
-      # window-server session. Keychain access for the DB encryption key needs
-      # the Aqua session (the "gui" domain) or it fails with -25308
-      # (errSecInteractionNotAllowed).
-      launchd.agents.proton-pass-agent.domain = "gui";
-    };
+    # Upstream defaults this agent to the launchd "user" domain, which has no
+    # window-server session. Keychain access for the DB encryption key needs
+    # the Aqua session (the "gui" domain) or it fails with -25308
+    # (errSecInteractionNotAllowed).
+    hmDarwin.launchd.agents.proton-pass-agent.domain = "gui";
   };
 }


### PR DESCRIPTION
## Summary
- The Proton Pass SSH agent (`services.proton-pass-agent`) was crash-looping on macOS: it launched in the launchd `"user"` domain, which has no window-server session, so `pass-cli` couldn't unlock its Keychain-protected database key and failed immediately with `-25308` (`errSecInteractionNotAllowed`). `KeepAlive = true` kept restarting it forever, leaving `SSH_AUTH_SOCK` with nothing listening.
- Fix: override `launchd.agents.proton-pass-agent.domain = "gui"` so the agent bootstraps into the Aqua session where Keychain access works.

## Verification
- `nix build .#darwinConfigurations.OMARSHAL-M-2FD2.config.system.build.toplevel` succeeds and the generated `.domain` output changed from `user` to `gui`.
- Applied with `darwin-rebuild switch` on the affected machine — `launchctl list` now shows a live PID with exit status 0, the stderr log shows `SSH agent started successfully!`, and `ssh-add -l` (via `SSH_AUTH_SOCK`) lists both configured keys.

## Test plan
- [x] `nix build` succeeds
- [x] Applied on macOS host and confirmed the agent starts and keys load via `ssh-add -l`