### PR TITLE
chore(ci): remove Cachix pin on Darwin tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,13 +75,6 @@ jobs:
           name: oscarmarshall
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           extraPullNames: nix-community
-          # cachix 1.11.1 crashes when it traverses unreadable symlinks inside
-          # nix-doom-emacs-unstraightened store paths. Pin to nixpkgs commit
-          # acde43339d72 (Nov 2025, cachix 1.9.1) which handles such errors
-          # gracefully instead of crashing.
-          installCommand:
-            nix-env --quiet -j8 -iA cachix -f
-            https://github.com/NixOS/nixpkgs/archive/acde43339d727890337fe174b16a9bd0027e96fc.tar.gz
 
       - run: nix flake metadata
 


### PR DESCRIPTION
## Summary
- nix-doom-emacs-unstraightened now includes [marienz/nix-doom-emacs-unstraightened@fa9bce6](https://github.com/marienz/nix-doom-emacs-unstraightened/commit/fa9bce6649981b02f613ee7f03573da70a882b26), so cachix 1.11.1 no longer crashes on unreadable symlinks in its store paths.
- Removes the pinned `installCommand` (nixpkgs commit `acde43339d72`, cachix 1.9.1) from the Darwin test job, letting it use the default cachix-action install like the Linux job.

## Test plan
- [ ] CI passes on `build-darwin` job