### PR TITLE
fix(darwin): register oscar as a known user so shell changes apply

### DIFF
--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -108,11 +108,15 @@ in
         };
       };
 
-      darwin.homebrew.casks = [
-        "arc"
-        "domzilla-caffeine"
-        "proton-mail"
-      ];
+      darwin = {
+        users.knownUsers = [ "oscar" ];
+        users.users.oscar.uid = 501;
+        homebrew.casks = [
+          "arc"
+          "domzilla-caffeine"
+          "proton-mail"
+        ];
+      };
 
       homeManager = { pkgs, ... }: {
         # age uses this key when rekeying home-manager-level secrets. At


### PR DESCRIPTION
## Summary
- nix-darwin only applies declarative shell changes (`users.users.<name>.shell`) via `dscl` for users listed in `users.knownUsers` — this repo never added oscar to that list, so the fish-shell setting from the `user-shell` battery was silently a no-op on Oscars-MacBook-Pro.
- Adds `users.knownUsers = [ "oscar" ]` and `users.users.oscar.uid = 501` (oscar's actual macOS uid) under the `darwin` class in the oscar user aspect, so nix-darwin manages the existing account instead of skipping it.

## Test plan
- [x] Ran `darwin-rebuild switch --flake .#Oscars-MacBook-Pro` — confirmed `dscl . -read /Users/oscar UserShell` now reports the fish path
- [ ] Reviewer confirms a fresh terminal session starts in fish

🤖 Generated with [Claude Code](https://claude.com/claude-code)