### PR TITLE
Disable Ghostty auto-update prompt

### DIFF
--- a/modules/aspects/my/ghostty.nix
+++ b/modules/aspects/my/ghostty.nix
@@ -5,6 +5,7 @@
       settings = {
         keybind = [ "global:super+Backquote=toggle_quick_terminal" ];
         macos-option-as-alt = true;
+        auto-update = "off";
       };
     };
 


### PR DESCRIPTION
## Summary
- Sets `auto-update = "off"` in Ghostty's config so it stops asking to enable automatic updates
- The flake already pins and manages the Ghostty version, so the built-in updater is redundant

## Test plan
- [ ] `darwin-rebuild switch --flake .#Oscars-MacBook-Pro`
- [ ] `ghostty +show-config | grep auto-update` shows `off`
- [ ] Relaunch Ghostty and confirm the update prompt no longer appears