### PR TITLE
Add declarative Zen Browser config for Oscar's profile

### DIFF
--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -64,6 +64,7 @@ in
           prusa-slicer
           steam
           zen-browser
+          den.aspects.oscar.provides.zen-browser
         ]
       );
 

--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -52,21 +52,17 @@ in
         (my.logseq { cli-only = !(scope.graphical or false); })
         userAspect
       ]
-      ++ lib.optionals (scope.graphical or false) (
-        with my;
-        [
-          (catppuccin { })
-          discord
-          doc-browser
-          ghostty
-          orca-slicer
-          programmer-dvorak
-          prusa-slicer
-          steam
-          zen-browser
-          den.aspects.oscar.provides.zen-browser
-        ]
-      );
+      ++ lib.optionals (scope.graphical or false) [
+        (my.catppuccin { })
+        my.discord
+        my.doc-browser
+        my.ghostty
+        my.orca-slicer
+        my.programmer-dvorak
+        my.prusa-slicer
+        my.steam
+        den.aspects.oscar.provides.zen-browser
+      ];
 
       provides."dev203.meraki.com" = {
         homeManager = {

--- a/modules/aspects/users/oscar/zen-browser.nix
+++ b/modules/aspects/users/oscar/zen-browser.nix
@@ -1,3 +1,6 @@
+let
+  profileName = "default";
+in
 {
   den.aspects.oscar.provides.zen-browser.homeManager = {
     programs.zen-browser = {
@@ -19,7 +22,7 @@
           "@testpilot-containers" = mkExtension "multi-account-containers";
         };
 
-      profiles.default.settings = {
+      profiles.${profileName}.settings = {
         "zen.view.compact.enable-at-startup" = true;
         "zen.workspaces.force-container-workspace" = true;
         "zen.workspaces.continue-where-left-off" = true;
@@ -31,6 +34,6 @@
 
     # Required for theming to apply: the module system can't both detect
     # declared zen-browser profile names and use them, so it's repeated here.
-    stylix.targets.zen-browser.profileNames = [ "default" ];
+    stylix.targets.zen-browser.profileNames = [ profileName ];
   };
 }

--- a/modules/aspects/users/oscar/zen-browser.nix
+++ b/modules/aspects/users/oscar/zen-browser.nix
@@ -1,62 +1,67 @@
+{ my, ... }:
 let
   profileName = "default";
 in
 {
-  den.aspects.oscar.provides.zen-browser.homeManager = {
-    programs.zen-browser = {
-      darwinDefaultsId = "app.zen-browser.zen";
+  den.aspects.oscar.provides.zen-browser = {
+    includes = [ my.zen-browser ];
 
-      # No-op on Darwin (it only wires up xdg.mimeApps); already the actual
-      # default browser here via macOS's LaunchServices, set outside Nix.
-      setAsDefaultBrowser = true;
+    homeManager = {
+      programs.zen-browser = {
+        darwinDefaultsId = "app.zen-browser.zen";
 
-      policies = {
-        # Updates come from `nix flake update` + rebuild; the browser's own
-        # updater can't write into the read-only /nix/store install anyway.
-        DisableAppUpdate = true;
-        DisableTelemetry = true;
-        DisableFirefoxStudies = true;
-        DisableFeedbackCommands = true;
-        DontCheckDefaultBrowser = true;
-        NoDefaultBookmarks = true;
-        DisablePocket = true;
-        OfferToSaveLogins = false;
-        EnableTrackingProtection = {
-          Value = true;
-          Locked = true;
-          Cryptomining = true;
-          Fingerprinting = true;
+        # No-op on Darwin (it only wires up xdg.mimeApps); already the actual
+        # default browser here via macOS's LaunchServices, set outside Nix.
+        setAsDefaultBrowser = true;
+
+        policies = {
+          # Updates come from `nix flake update` + rebuild; the browser's own
+          # updater can't write into the read-only /nix/store install anyway.
+          DisableAppUpdate = true;
+          DisableTelemetry = true;
+          DisableFirefoxStudies = true;
+          DisableFeedbackCommands = true;
+          DontCheckDefaultBrowser = true;
+          NoDefaultBookmarks = true;
+          DisablePocket = true;
+          OfferToSaveLogins = false;
+          EnableTrackingProtection = {
+            Value = true;
+            Locked = true;
+            Cryptomining = true;
+            Fingerprinting = true;
+          };
+
+          ExtensionSettings =
+            let
+              mkExtension = slug: {
+                install_url = "https://addons.mozilla.org/firefox/downloads/latest/${slug}/latest.xpi";
+                installation_mode = "force_installed";
+              };
+            in
+            {
+              "78272b6fa58f4a1abaac99321d503a20@proton.me" = mkExtension "proton-pass";
+              "firefox@tampermonkey.net" = mkExtension "tampermonkey";
+              "jid1-MnnxcxisBPnSXQ@jetpack" = mkExtension "privacy-badger17";
+              "addon@darkreader.org" = mkExtension "darkreader";
+              "uBlock0@raymondhill.net" = mkExtension "ublock-origin";
+              "@testpilot-containers" = mkExtension "multi-account-containers";
+            };
         };
 
-        ExtensionSettings =
-          let
-            mkExtension = slug: {
-              install_url = "https://addons.mozilla.org/firefox/downloads/latest/${slug}/latest.xpi";
-              installation_mode = "force_installed";
-            };
-          in
-          {
-            "78272b6fa58f4a1abaac99321d503a20@proton.me" = mkExtension "proton-pass";
-            "firefox@tampermonkey.net" = mkExtension "tampermonkey";
-            "jid1-MnnxcxisBPnSXQ@jetpack" = mkExtension "privacy-badger17";
-            "addon@darkreader.org" = mkExtension "darkreader";
-            "uBlock0@raymondhill.net" = mkExtension "ublock-origin";
-            "@testpilot-containers" = mkExtension "multi-account-containers";
-          };
+        profiles.${profileName}.settings = {
+          "zen.view.compact.enable-at-startup" = true;
+          "zen.workspaces.force-container-workspace" = true;
+          "zen.workspaces.continue-where-left-off" = true;
+          "sidebar.visibility" = "hide-sidebar";
+          "signon.rememberSignons" = false;
+          "browser.contentblocking.category" = "standard";
+        };
       };
 
-      profiles.${profileName}.settings = {
-        "zen.view.compact.enable-at-startup" = true;
-        "zen.workspaces.force-container-workspace" = true;
-        "zen.workspaces.continue-where-left-off" = true;
-        "sidebar.visibility" = "hide-sidebar";
-        "signon.rememberSignons" = false;
-        "browser.contentblocking.category" = "standard";
-      };
+      # Required for theming to apply: the module system can't both detect
+      # declared zen-browser profile names and use them, so it's repeated here.
+      stylix.targets.zen-browser.profileNames = [ profileName ];
     };
-
-    # Required for theming to apply: the module system can't both detect
-    # declared zen-browser profile names and use them, so it's repeated here.
-    stylix.targets.zen-browser.profileNames = [ profileName ];
   };
 }

--- a/modules/aspects/users/oscar/zen-browser.nix
+++ b/modules/aspects/users/oscar/zen-browser.nix
@@ -6,6 +6,10 @@ in
     programs.zen-browser = {
       darwinDefaultsId = "app.zen-browser.zen";
 
+      # No-op on Darwin (it only wires up xdg.mimeApps); already the actual
+      # default browser here via macOS's LaunchServices, set outside Nix.
+      setAsDefaultBrowser = true;
+
       policies = {
         # Updates come from `nix flake update` + rebuild; the browser's own
         # updater can't write into the read-only /nix/store install anyway.

--- a/modules/aspects/users/oscar/zen-browser.nix
+++ b/modules/aspects/users/oscar/zen-browser.nix
@@ -1,0 +1,36 @@
+{
+  den.aspects.oscar.provides.zen-browser.homeManager = {
+    programs.zen-browser = {
+      darwinDefaultsId = "app.zen-browser.zen";
+
+      policies.ExtensionSettings =
+        let
+          mkExtension = slug: {
+            install_url = "https://addons.mozilla.org/firefox/downloads/latest/${slug}/latest.xpi";
+            installation_mode = "force_installed";
+          };
+        in
+        {
+          "78272b6fa58f4a1abaac99321d503a20@proton.me" = mkExtension "proton-pass";
+          "firefox@tampermonkey.net" = mkExtension "tampermonkey";
+          "jid1-MnnxcxisBPnSXQ@jetpack" = mkExtension "privacy-badger17";
+          "addon@darkreader.org" = mkExtension "darkreader";
+          "uBlock0@raymondhill.net" = mkExtension "ublock-origin";
+          "@testpilot-containers" = mkExtension "multi-account-containers";
+        };
+
+      profiles.default.settings = {
+        "zen.view.compact.enable-at-startup" = true;
+        "zen.workspaces.force-container-workspace" = true;
+        "zen.workspaces.continue-where-left-off" = true;
+        "sidebar.visibility" = "hide-sidebar";
+        "signon.rememberSignons" = false;
+        "browser.contentblocking.category" = "standard";
+      };
+    };
+
+    # Required for theming to apply: the module system can't both detect
+    # declared zen-browser profile names and use them, so it's repeated here.
+    stylix.targets.zen-browser.profileNames = [ "default" ];
+  };
+}

--- a/modules/aspects/users/oscar/zen-browser.nix
+++ b/modules/aspects/users/oscar/zen-browser.nix
@@ -6,21 +6,40 @@ in
     programs.zen-browser = {
       darwinDefaultsId = "app.zen-browser.zen";
 
-      policies.ExtensionSettings =
-        let
-          mkExtension = slug: {
-            install_url = "https://addons.mozilla.org/firefox/downloads/latest/${slug}/latest.xpi";
-            installation_mode = "force_installed";
-          };
-        in
-        {
-          "78272b6fa58f4a1abaac99321d503a20@proton.me" = mkExtension "proton-pass";
-          "firefox@tampermonkey.net" = mkExtension "tampermonkey";
-          "jid1-MnnxcxisBPnSXQ@jetpack" = mkExtension "privacy-badger17";
-          "addon@darkreader.org" = mkExtension "darkreader";
-          "uBlock0@raymondhill.net" = mkExtension "ublock-origin";
-          "@testpilot-containers" = mkExtension "multi-account-containers";
+      policies = {
+        # Updates come from `nix flake update` + rebuild; the browser's own
+        # updater can't write into the read-only /nix/store install anyway.
+        DisableAppUpdate = true;
+        DisableTelemetry = true;
+        DisableFirefoxStudies = true;
+        DisableFeedbackCommands = true;
+        DontCheckDefaultBrowser = true;
+        NoDefaultBookmarks = true;
+        DisablePocket = true;
+        OfferToSaveLogins = false;
+        EnableTrackingProtection = {
+          Value = true;
+          Locked = true;
+          Cryptomining = true;
+          Fingerprinting = true;
         };
+
+        ExtensionSettings =
+          let
+            mkExtension = slug: {
+              install_url = "https://addons.mozilla.org/firefox/downloads/latest/${slug}/latest.xpi";
+              installation_mode = "force_installed";
+            };
+          in
+          {
+            "78272b6fa58f4a1abaac99321d503a20@proton.me" = mkExtension "proton-pass";
+            "firefox@tampermonkey.net" = mkExtension "tampermonkey";
+            "jid1-MnnxcxisBPnSXQ@jetpack" = mkExtension "privacy-badger17";
+            "addon@darkreader.org" = mkExtension "darkreader";
+            "uBlock0@raymondhill.net" = mkExtension "ublock-origin";
+            "@testpilot-containers" = mkExtension "multi-account-containers";
+          };
+      };
 
       profiles.${profileName}.settings = {
         "zen.view.compact.enable-at-startup" = true;


### PR DESCRIPTION
## Summary
- Declares the real, live Zen Browser (Twilight) profile via `programs.zen-browser`: force-installed extensions (Proton Pass, Tampermonkey, Privacy Badger, Dark Reader, uBlock Origin, Multi-Account Containers) via enterprise policy, a handful of `zen.*`/privacy settings, and Stylix theming (`userChrome`/`userContent` CSS, fonts) wired up via `stylix.targets.zen-browser.profileNames`.
- Config lives in a new `den.aspects.oscar.provides.zen-browser` sub-aspect ([modules/aspects/users/oscar/zen-browser.nix](modules/aspects/users/oscar/zen-browser.nix)), following the same pattern as the existing `provides.work` aspect, rather than being inlined in `oscar.nix`.
- The declared profile is a fresh, Nix-managed profile named `default` — intentionally *not* pointed at Oscar's existing browsing profile (which has its own history/passwords/pins), to avoid clobbering `profiles.ini` or the live profile directory on first activation.

## Notes for reviewer
- On first `darwin-rebuild switch`, Home Manager will hit a "file already exists" conflict on `~/Library/Application Support/zen/profiles.ini` since it's already a real file written by Zen. Back it up and remove it once before switching:
  ```
  cp "$HOME/Library/Application Support/zen/profiles.ini" ~/zen-profiles.ini.bak
  rm "$HOME/Library/Application Support/zen/profiles.ini"
  ```
- Force-installing the listed extensions via enterprise policy will mark any already-installed copies of the same extensions as policy-managed (locked from removal via the UI).
- Verified via `nix build .#darwinConfigurations.Oscars-MacBook-Pro.config.system.build.toplevel` with no warnings/errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)