### PR TITLE
Clear stale keyboard-layout cache on darwin-rebuild switch

### DIFF
--- a/modules/aspects/my/programmer-dvorak.nix
+++ b/modules/aspects/my/programmer-dvorak.nix
@@ -1,5 +1,13 @@
 {
   my.programmer-dvorak = {
+    # macOS caches the list of installed keyboard layouts (com.apple.IntlDataCache.le*) and only
+    # rescans it at boot, so a newly (un)installed .bundle won't show up in System Settings ->
+    # Keyboard -> Input Sources until the cache is cleared and the machine is rebooted.
+    darwin.system.activationScripts.postActivation.text = ''
+      rm -f /System/Library/Caches/com.apple.IntlDataCache.le*
+      rm -f /private/var/folders/*/*/C/com.apple.IntlDataCache.le*
+    '';
+
     # macOS ships plain Dvorak but not Programmer Dvorak, so the layout is fetched from
     # https://www.kaufmann.no/roland/dvorak/ (the same author as xkeyboard-config's "dvp" variant)
     # and installed per-user rather than system-wide, so it never becomes the default for other


### PR DESCRIPTION
## Summary
- macOS caches the list of installed keyboard layouts in `com.apple.IntlDataCache.le*` and only rescans it at boot. After #433 added the Programmer Dvorak bundle, it wasn't showing up as selectable in System Settings even after `darwin-rebuild switch`.
- Adds a `system.activationScripts.postActivation` step to `my.programmer-dvorak` that clears the stale cache (both the system-wide file and the per-session copy under `/private/var/folders`) on every switch, so a subsequent reboot picks up newly (un)installed keyboard layouts without a manual `sudo rm` first.

## Test plan
- [x] `nix build .#darwinConfigurations.Oscars-MacBook-Pro.config.system.build.toplevel` succeeds
- [x] Applied via `darwin-rebuild switch`; confirmed Programmer Dvorak became selectable and enabled in System Settings > Keyboard > Input Sources after a reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)