### PR TITLE
Force-install Stylus extension for Zen

### DIFF
--- a/modules/aspects/users/oscar/zen-browser.nix
+++ b/modules/aspects/users/oscar/zen-browser.nix
@@ -46,6 +46,7 @@ in
               "addon@darkreader.org" = mkExtension "darkreader";
               "uBlock0@raymondhill.net" = mkExtension "ublock-origin";
               "@testpilot-containers" = mkExtension "multi-account-containers";
+              "{7a7a4a92-a2a0-41d1-9fd7-1e92480d612d}" = mkExtension "styl-us";
             };
         };
 


### PR DESCRIPTION
## Summary
- Adds the Stylus extension (custom per-site userstyles) to Oscar's Zen Browser force-installed extension policy in [modules/aspects/users/oscar/zen-browser.nix](modules/aspects/users/oscar/zen-browser.nix).
- Stylix's `zen-browser` target only themes the browser's own chrome (userChrome/userContent CSS) — it doesn't manage per-site userstyles, which is what Stylus is for, so it's added the same way as the other extensions.

## Test plan
- [x] `nix build .#darwinConfigurations.Oscars-MacBook-Pro.config.system.build.toplevel` succeeds with no new warnings/errors.
- [x] Verified the generated `app.zen-browser.zen.plist` includes Stylus's force-install entry (GUID `{7a7a4a92-a2a0-41d1-9fd7-1e92480d612d}`, AMO slug `styl-us`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)