### PR TITLE
Fix home-manager deprecation warnings on darwin-rebuild

### DIFF
--- a/modules/aspects/hosts/Oscars-MacBook-Pro/Oscars-MacBook-Pro.nix
+++ b/modules/aspects/hosts/Oscars-MacBook-Pro/Oscars-MacBook-Pro.nix
@@ -19,6 +19,10 @@
         # You can update Home Manager without changing this value. See the Home Manager release notes for a list of
         # state version changes in each release.
         home.stateVersion = "26.11";
+
+        # fish defaults this to true for apropos completion, but it has no effect since
+        # programs.man.package is null on Darwin (macOS's own man is used instead).
+        programs.man.generateCaches = false;
       };
 
       # Den's allHomeNodes spawn re-walks the host aspect without the user's own includes, so none of the

--- a/modules/aspects/my/ssh-client.nix
+++ b/modules/aspects/my/ssh-client.nix
@@ -3,18 +3,18 @@
     programs.ssh = {
       enable = true;
       enableDefaultConfig = false;
-      matchBlocks = {
+      settings = {
         "*" = {
-          addKeysToAgent = "no";
-          compression = false;
-          controlMaster = "no";
-          controlPath = "~/.ssh/master-%r@%n:%p";
-          controlPersist = "no";
-          forwardAgent = false;
-          hashKnownHosts = false;
-          serverAliveCountMax = 3;
-          serverAliveInterval = 0;
-          userKnownHostsFile = "~/.ssh/known_hosts";
+          AddKeysToAgent = "no";
+          Compression = false;
+          ControlMaster = "no";
+          ControlPath = "~/.ssh/master-%r@%n:%p";
+          ControlPersist = "no";
+          ForwardAgent = false;
+          HashKnownHosts = false;
+          ServerAliveCountMax = 3;
+          ServerAliveInterval = 0;
+          UserKnownHostsFile = "~/.ssh/known_hosts";
         };
       };
     };

--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -141,7 +141,7 @@ in
           ssh.settings."github-personal" = {
             HostName = "github.com";
             User = "git";
-            IdentityFile = "${./id_ed25519_personal.pub}";
+            IdentityFile = "~/.ssh/id_ed25519_personal";
             IdentitiesOnly = true;
           };
           fzf.enable = true;

--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -138,11 +138,11 @@ in
 
         programs = {
           fish.enable = true;
-          ssh.matchBlocks."github-personal" = {
-            hostname = "github.com";
-            user = "git";
-            identityFile = "${./id_ed25519_personal.pub}";
-            identitiesOnly = true;
+          ssh.settings."github-personal" = {
+            HostName = "github.com";
+            User = "git";
+            IdentityFile = "${./id_ed25519_personal.pub}";
+            IdentitiesOnly = true;
           };
           fzf.enable = true;
           gh = {

--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -141,7 +141,7 @@ in
           ssh.settings."github-personal" = {
             HostName = "github.com";
             User = "git";
-            IdentityFile = "~/.ssh/id_ed25519_personal";
+            IdentityFile = "${./id_ed25519_personal.pub}";
             IdentitiesOnly = true;
           };
           fzf.enable = true;

--- a/modules/aspects/users/oscar/work/ssh-client.nix
+++ b/modules/aspects/users/oscar/work/ssh-client.nix
@@ -22,30 +22,30 @@ in
 {
   den.aspects.oscar.provides.work.provides.ssh-client = {
     homeManager = { lib, ... }: {
-      programs.ssh.matchBlocks = {
+      programs.ssh.settings = {
         "github-meraki" = {
-          hostname = "github.com";
-          user = "git";
-          identityFile = "${./id_ed25519_meraki.pub}";
-          identitiesOnly = true;
+          HostName = "github.com";
+          User = "git";
+          IdentityFile = "${./id_ed25519_meraki.pub}";
+          IdentitiesOnly = true;
         };
         "*.meraki.com ${aliases}" = {
-          addKeysToAgent = "yes";
-          forwardAgent = true;
-          identityFile = "~/.ssh/id_ed25519_meraki";
-          serverAliveInterval = 240;
+          AddKeysToAgent = "yes";
+          ForwardAgent = true;
+          IdentityFile = "~/.ssh/id_ed25519_meraki";
+          ServerAliveInterval = 240;
         };
-        "dev" = lib.hm.dag.entryBefore [ "meraki.com aliases" ] { hostname = "dev203.meraki.com"; };
+        "dev" = lib.hm.dag.entryBefore [ "meraki.com aliases" ] { HostName = "dev203.meraki.com"; };
         "meraki.com aliases" = lib.hm.dag.entryBefore [ "*.meraki.com" "n*.meraki.com" ] {
-          host = "!*.meraki.com ${aliases}";
-          hostname = "%h.meraki.com";
+          header = "Host !*.meraki.com ${aliases}";
+          HostName = "%h.meraki.com";
         };
         "n*.meraki.com ${shard-alias}" = {
-          proxyJump = builtins.head jump-host-aliases;
-          extraOptions.HostKeyAlgorithms = "+ssh-rsa";
+          ProxyJump = builtins.head jump-host-aliases;
+          HostKeyAlgorithms = "+ssh-rsa";
         };
       };
     };
-    hmDarwin.programs.ssh.matchBlocks."*.meraki.com ${aliases}".extraOptions.UseKeychain = "yes";
+    hmDarwin.programs.ssh.settings."*.meraki.com ${aliases}".UseKeychain = "yes";
   };
 }

--- a/modules/aspects/users/oscar/work/ssh-client.nix
+++ b/modules/aspects/users/oscar/work/ssh-client.nix
@@ -26,7 +26,7 @@ in
         "github-meraki" = {
           HostName = "github.com";
           User = "git";
-          IdentityFile = "~/.ssh/id_ed25519_meraki";
+          IdentityFile = "${./id_ed25519_meraki.pub}";
           IdentitiesOnly = true;
         };
         "*.meraki.com ${aliases}" = {

--- a/modules/aspects/users/oscar/work/ssh-client.nix
+++ b/modules/aspects/users/oscar/work/ssh-client.nix
@@ -26,7 +26,7 @@ in
         "github-meraki" = {
           HostName = "github.com";
           User = "git";
-          IdentityFile = "${./id_ed25519_meraki.pub}";
+          IdentityFile = "~/.ssh/id_ed25519_meraki";
           IdentitiesOnly = true;
         };
         "*.meraki.com ${aliases}" = {


### PR DESCRIPTION
## Summary
- Migrate `programs.ssh.matchBlocks` to the new `programs.ssh.settings` API across `my/ssh-client.nix`, `users/oscar/oscar.nix`, and `users/oscar/work/ssh-client.nix` — matchBlocks (and its `extraOptions`/`host` fields) is deprecated in current home-manager in favor of `settings` with upstream directive names and a `header` field.
- Disable `programs.man.generateCaches` on `Oscars-MacBook-Pro` — fish's home-manager module defaults this to `true` for apropos completion, but it has no effect since `programs.man.package` is `null` on this Darwin host (stateVersion ≥ 26.05), which was producing a build warning.

## Test plan
- [x] `nix build .#darwinConfigurations.Oscars-MacBook-Pro.config.system.build.toplevel` succeeds with none of the original warnings
- [x] Diffed the generated `~/.ssh/config` output before/after — content and dag ordering are unchanged
- [x] `nix fmt` reports no formatting changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)