### PR TITLE
Follow system light/dark appearance in Ghostty, Fish, and Zen

### DIFF
--- a/modules/aspects/my/fish.nix
+++ b/modules/aspects/my/fish.nix
@@ -1,0 +1,18 @@
+{
+  my.fish.homeManager = {
+    programs.fish = {
+      enable = true;
+
+      # Fish 4.4+ bundles Catppuccin (with light/dark variants baked into
+      # each flavor) as a built-in theme; `theme choose` re-applies whichever
+      # variant matches the terminal's reported background color, and reacts
+      # live when that changes (e.g. Ghostty switching between its own
+      # light/dark themes).
+      interactiveShellInit = "fish_config theme choose catppuccin-mocha";
+    };
+
+    # Superseded by the reactive theme above; Stylix's target only ever sets
+    # the static (dark-only) base16 colors.
+    stylix.targets.fish.enable = false;
+  };
+}

--- a/modules/aspects/my/ghostty.nix
+++ b/modules/aspects/my/ghostty.nix
@@ -1,11 +1,17 @@
 {
   my.ghostty = {
-    homeManager.programs.ghostty = {
-      enable = true;
-      settings = {
-        keybind = [ "global:super+Backquote=toggle_quick_terminal" ];
-        macos-option-as-alt = true;
-        auto-update = "off";
+    homeManager = { lib, ... }: {
+      programs.ghostty = {
+        enable = true;
+        settings = {
+          keybind = [ "global:super+Backquote=toggle_quick_terminal" ];
+          macos-option-as-alt = true;
+          auto-update = "off";
+
+          # Follow the system light/dark appearance instead of Stylix's single
+          # (dark-only) base16 theme.
+          theme = lib.mkForce "light:Catppuccin Latte,dark:Catppuccin Mocha";
+        };
       };
     };
 

--- a/modules/aspects/users/adelline/adelline.nix
+++ b/modules/aspects/users/adelline/adelline.nix
@@ -5,6 +5,7 @@
       (den._.user-shell "fish")
       my.discord
       my.chrome
+      my.fish
       my.ghostty
       my.steam
       my.zoom
@@ -33,7 +34,6 @@
 
       programs = {
         direnv.enable = true;
-        fish.enable = true;
         git.enable = true;
       };
     };

--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -40,6 +40,7 @@ in
         my.claude
         my.direnv
         my.emacs
+        my.fish
         (my.git {
           inherit name;
           email = "3111765+OscarMarshall@users.noreply.github.com";
@@ -137,7 +138,6 @@ in
           ];
 
         programs = {
-          fish.enable = true;
           ssh.settings."github-personal" = {
             HostName = "github.com";
             User = "git";

--- a/modules/aspects/users/oscar/zen-browser.nix
+++ b/modules/aspects/users/oscar/zen-browser.nix
@@ -63,6 +63,11 @@ in
       # Required for theming to apply: the module system can't both detect
       # declared zen-browser profile names and use them, so it's repeated here.
       stylix.targets.zen-browser.profileNames = [ profileName ];
+
+      # Zen already follows the system light/dark appearance on its own, which
+      # conflicts with Stylix's injected (single-flavor) userChrome/userContent
+      # CSS. Disable the CSS injection and let Zen handle its own theming.
+      stylix.targets.zen-browser.enableCss = false;
     };
   };
 }


### PR DESCRIPTION
## Summary

Stylix applies a single static (dark) Catppuccin flavor everywhere, but a
few apps can natively follow the OS light/dark appearance on their own —
this wires those up instead of leaving them stuck on Stylix's baseline.

- **Ghostty**: force `theme = light:Catppuccin Latte,dark:Catppuccin Mocha`
  (via `lib.mkForce`, overriding Stylix's static `theme = "stylix"`).
  Ghostty watches macOS appearance changes and switches live.
- **Fish**: 4.4+ ships Catppuccin (with light/dark variants baked into each
  flavor) as a built-in theme, so `fish_config theme choose
  catppuccin-mocha` in `interactiveShellInit` picks the variant matching
  the terminal's reported background (OSC 11) and reacts live — including
  to Ghostty's own switch above. Stylix's static fish target is disabled
  since it's now fully superseded.
- **Zen Browser**: it already follows the system appearance on its own,
  which conflicts with Stylix's injected single-flavor
  userChrome/userContent CSS, so that CSS injection is disabled
  (`stylix.targets.zen-browser.enableCss = false`).

Emacs already handles this today (the `system-appearance` patch +
`ns-system-appearance-change-functions` hook in the doom config flips
`catppuccin-flavor` between `latte`/`mocha`), so it's untouched.

New `modules/aspects/my/fish.nix` aspect replaces the ad hoc
`programs.fish.enable = true` in both `oscar.nix` and `adelline.nix`.

## Test plan

- [x] `nix build .#darwinConfigurations.Oscars-MacBook-Pro.config.system.build.toplevel` succeeds
- [x] Verified generated `ghostty-config` contains `theme = light:Catppuccin Latte,dark:Catppuccin Mocha`
- [x] Verified generated `config.fish` calls `fish_config theme choose catppuccin-mocha` and no longer sources Stylix's static `base16-catppuccin-mocha.fish`
- [x] Verified home-manager-files no longer contains Zen's `userChrome.css`/`userContent.css`
- [x] `nix eval` against `nixosConfigurations.melaan` (adelline, Linux) confirms the same `programs.ghostty.settings.theme` and `programs.fish.interactiveShellInit` values
- [x] `nix fmt` clean