### PR TITLE
Rework nginx virtual-host sub-aspect into a Den quirk

### DIFF
--- a/modules/aspects/my/autobrr.nix
+++ b/modules/aspects/my/autobrr.nix
@@ -1,10 +1,14 @@
-{ my, ... }: {
+{
   my.autobrr =
     let
       port = 7474;
     in
     {
-      includes = [ (my.nginx._.virtual-host "autobrr.harmony.silverlight-nex.us" port) ];
+      virtual-host = {
+        name = "autobrr";
+        url = "autobrr.harmony.silverlight-nex.us";
+        inherit port;
+      };
 
       secrets.autobrr-session-secret.generator.script = "alnum";
 

--- a/modules/aspects/my/homepage.nix
+++ b/modules/aspects/my/homepage.nix
@@ -1,11 +1,16 @@
-{ my, ... }:
 let
   port = 8082;
   port' = toString port;
 in
 {
+  den.quirks.homepage-entry.description = "Homepage dashboard service entries";
+
   my.homepage = {
-    includes = with my; [ (nginx._.virtual-host "harmony.silverlight-nex.us" port) ];
+    virtual-host = {
+      name = "homepage";
+      url = "harmony.silverlight-nex.us";
+      inherit port;
+    };
 
     secrets = { secrets, ... }: {
       "homepage-dashboard.env".generator = {
@@ -31,98 +36,64 @@ in
       };
     };
 
-    nixos = { config, ... }: {
-      services.homepage-dashboard = {
-        enable = true;
-        environmentFile = config.age.secrets."homepage-dashboard.env".path;
-        allowedHosts = "localhost:${port'},127.0.0.1:${port'},harmony.silverlight-nex.us";
-        widgets = [
-          {
-            glances = {
-              url = "http://127.0.0.1:${toString config.services.glances.port}";
-              version = 4;
-              cputemp = true;
-              uptime = true;
-              disk = [
-                "/"
-                "/metalminds"
-              ];
-              expanded = true;
-            };
+    nixos =
+      {
+        config,
+        virtual-host,
+        homepage-entry,
+        lib,
+        ...
+      }:
+      let
+        hosts = lib.listToAttrs (map (host: lib.nameValuePair host.name host) virtual-host);
+        urlFor = name: "https://${hosts.${name}.url}";
+
+        groups = lib.unique (map (entry: entry.group) homepage-entry);
+        entryToService = entry: {
+          ${entry.label} = {
+            inherit (entry) href description;
           }
-        ];
-        services = [
-          {
-            "Media" = [
-              {
-                "Plex" = {
-                  href = "https://plex.harmony.silverlight-nex.us";
-                  description = "Media server";
-                };
-              }
-            ];
-          }
-          {
-            "Arr Stack" = [
-              {
-                "Radarr" = {
-                  href = "https://radarr.harmony.silverlight-nex.us";
-                  description = "Movie organizer/manager";
-                  widget = {
-                    type = "radarr";
-                    url = "https://radarr.harmony.silverlight-nex.us";
-                    key = "{{HOMEPAGE_VAR_RADARR_API_KEY}}";
-                    enableQueue = true;
-                  };
-                };
-              }
-              {
-                "Sonarr" = {
-                  href = "https://sonarr.harmony.silverlight-nex.us";
-                  description = "Show organizer/manager";
-                  widget = {
-                    type = "sonarr";
-                    url = "https://sonarr.harmony.silverlight-nex.us";
-                    key = "{{HOMEPAGE_VAR_SONARR_API_KEY}}";
-                    enableQueue = true;
-                  };
-                };
-              }
-              {
-                "Prowlarr" = {
-                  href = "https://prowlarr.harmony.silverlight-nex.us";
-                  description = "Indexer manager/proxy";
-                  widget = {
-                    type = "prowlarr";
-                    url = "https://prowlarr.harmony.silverlight-nex.us";
-                    key = "{{HOMEPAGE_VAR_PROWLARR_API_KEY}}";
-                  };
-                };
-              }
-              {
-                "Profilarr" = {
-                  href = "https://profilarr.harmony.silverlight-nex.us";
-                  description = "Radarr/Sonarr custom format manager";
-                };
-              }
-            ];
-          }
-        ];
-        bookmarks = [
-          {
-            "Servers" = [
-              {
-                "Harmony" = [
-                  {
-                    abbr = "HA";
-                    href = "https://harmony.silverlight-nex.us";
-                  }
+          // lib.optionalAttrs (entry ? widget) { inherit (entry) widget; };
+        };
+      in
+      {
+        services.homepage-dashboard = {
+          enable = true;
+          environmentFile = config.age.secrets."homepage-dashboard.env".path;
+          allowedHosts = "localhost:${port'},127.0.0.1:${port'},${hosts.homepage.url}";
+          widgets = [
+            {
+              glances = {
+                url = "http://127.0.0.1:${toString config.services.glances.port}";
+                version = 4;
+                cputemp = true;
+                uptime = true;
+                disk = [
+                  "/"
+                  "/metalminds"
                 ];
-              }
-            ];
-          }
-        ];
+                expanded = true;
+              };
+            }
+          ];
+          services = map (group: {
+            ${group} = map entryToService (lib.filter (entry: entry.group == group) homepage-entry);
+          }) groups;
+          bookmarks = [
+            {
+              "Servers" = [
+                {
+                  "Harmony" = [
+                    {
+                      abbr = "HA";
+                      href = urlFor "homepage";
+                    }
+                  ];
+                }
+              ];
+            }
+          ];
+        };
       };
-    };
   };
 }

--- a/modules/aspects/my/nginx.nix
+++ b/modules/aspects/my/nginx.nix
@@ -1,13 +1,8 @@
 {
+  den.quirks.virtual-host.description = "Reverse-proxied virtual hosts served by nginx";
+
   my.nginx = {
-    provides.virtual-host = url: port: {
-      nixos.services.nginx.virtualHosts.${url} = {
-        forceSSL = true;
-        enableACME = true;
-        locations."/".proxyPass = "http://127.0.0.1:${toString port}/";
-      };
-    };
-    nixos = {
+    nixos = { virtual-host, lib, ... }: {
       security.acme = {
         acceptTerms = true;
         defaults.email = "letsencrypt@alias.oscarmarshall.com";
@@ -24,6 +19,17 @@
 
         # Only allow PFS-enabled ciphers with AES256
         sslCiphers = "AES256+EECDH:AES256+EDH:!aNULL";
+
+        virtualHosts = lib.listToAttrs (
+          map (
+            host:
+            lib.nameValuePair host.url {
+              forceSSL = true;
+              enableACME = true;
+              locations."/".proxyPass = "http://127.0.0.1:${toString host.port}/";
+            }
+          ) virtual-host
+        );
 
         appendHttpConfig = ''
           # Add HSTS header with preloading to HTTPS requests.

--- a/modules/aspects/my/plex.nix
+++ b/modules/aspects/my/plex.nix
@@ -1,17 +1,28 @@
-{ den, ... }: {
+{ den, ... }:
+let
+  url = "plex.harmony.silverlight-nex.us";
+in
+{
   my.plex = {
     includes = [ (den._.unfree [ "plexmediaserver" ]) ];
+
+    virtual-host = {
+      name = "plex";
+      inherit url;
+      port = 32400;
+    };
+
+    homepage-entry = {
+      group = "Media";
+      label = "Plex";
+      description = "Media server";
+      href = "https://${url}";
+    };
 
     nixos = {
       services.plex = {
         enable = true;
         openFirewall = true;
-      };
-
-      services.nginx.virtualHosts."plex.harmony.silverlight-nex.us" = {
-        forceSSL = true;
-        enableACME = true;
-        locations."/".proxyPass = "http://127.0.0.1:32400/";
       };
     };
   };

--- a/modules/aspects/my/profilarr.nix
+++ b/modules/aspects/my/profilarr.nix
@@ -1,10 +1,21 @@
-{ my, ... }: {
+{
   my.profilarr =
     let
+      url = "profilarr.harmony.silverlight-nex.us";
       port = 6868;
     in
     {
-      includes = with my; [ (nginx._.virtual-host "profilarr.harmony.silverlight-nex.us" port) ];
+      virtual-host = {
+        name = "profilarr";
+        inherit url port;
+      };
+
+      homepage-entry = {
+        group = "Arr Stack";
+        label = "Profilarr";
+        description = "Radarr/Sonarr custom format manager";
+        href = "https://${url}";
+      };
 
       nixos = { config, ... }: {
         virtualisation.oci-containers.containers.profilarr = {

--- a/modules/aspects/my/prowlarr.nix
+++ b/modules/aspects/my/prowlarr.nix
@@ -1,10 +1,26 @@
-{ my, ... }: {
+{
   my.prowlarr =
     let
+      url = "prowlarr.harmony.silverlight-nex.us";
       port = 9696;
     in
     {
-      includes = with my; [ (nginx._.virtual-host "prowlarr.harmony.silverlight-nex.us" port) ];
+      virtual-host = {
+        name = "prowlarr";
+        inherit url port;
+      };
+
+      homepage-entry = {
+        group = "Arr Stack";
+        label = "Prowlarr";
+        description = "Indexer manager/proxy";
+        href = "https://${url}";
+        widget = {
+          type = "prowlarr";
+          url = "https://${url}";
+          key = "{{HOMEPAGE_VAR_PROWLARR_API_KEY}}";
+        };
+      };
 
       secrets = { secrets, ... }: {
         prowlarr-api-key = {

--- a/modules/aspects/my/qbittorrent.nix
+++ b/modules/aspects/my/qbittorrent.nix
@@ -1,11 +1,15 @@
-{ lib, my, ... }:
+{ lib, ... }:
 let
   port = 8080;
   port' = toString port;
 in
 {
   my.qbittorrent = { administrators }: {
-    includes = with my; [ (nginx._.virtual-host "qbittorrent.harmony.silverlight-nex.us" port) ];
+    virtual-host = {
+      name = "qbittorrent";
+      url = "qbittorrent.harmony.silverlight-nex.us";
+      inherit port;
+    };
 
     secrets = { secrets, ... }: {
       "qbittorrent.env".generator = {

--- a/modules/aspects/my/radarr.nix
+++ b/modules/aspects/my/radarr.nix
@@ -1,10 +1,27 @@
-{ lib, my, ... }:
+{ lib, ... }:
 let
+  url = "radarr.harmony.silverlight-nex.us";
   port = 7878;
 in
 {
   my.radarr = { administrators }: {
-    includes = with my; [ (nginx._.virtual-host "radarr.harmony.silverlight-nex.us" port) ];
+    virtual-host = {
+      name = "radarr";
+      inherit url port;
+    };
+
+    homepage-entry = {
+      group = "Arr Stack";
+      label = "Radarr";
+      description = "Movie organizer/manager";
+      href = "https://${url}";
+      widget = {
+        type = "radarr";
+        url = "https://${url}";
+        key = "{{HOMEPAGE_VAR_RADARR_API_KEY}}";
+        enableQueue = true;
+      };
+    };
 
     secrets = { secrets, ... }: {
       radarr-api-key = {

--- a/modules/aspects/my/sonarr.nix
+++ b/modules/aspects/my/sonarr.nix
@@ -1,10 +1,27 @@
-{ lib, my, ... }: {
+{ lib, ... }: {
   my.sonarr =
     let
+      url = "sonarr.harmony.silverlight-nex.us";
       port = 8989;
     in
     { administrators }: {
-      includes = with my; [ (nginx._.virtual-host "sonarr.harmony.silverlight-nex.us" port) ];
+      virtual-host = {
+        name = "sonarr";
+        inherit url port;
+      };
+
+      homepage-entry = {
+        group = "Arr Stack";
+        label = "Sonarr";
+        description = "Show organizer/manager";
+        href = "https://${url}";
+        widget = {
+          type = "sonarr";
+          url = "https://${url}";
+          key = "{{HOMEPAGE_VAR_SONARR_API_KEY}}";
+          enableQueue = true;
+        };
+      };
 
       secrets = { secrets, ... }: {
         sonarr-api-key = {


### PR DESCRIPTION
## Summary

- Replaces nginx's `provides.virtual-host` sub-aspect (called via `nginx._.virtual-host "url" port` from every reverse-proxied service) with a `virtual-host` [Den quirk](https://den.denful.dev/explanation/quirks-and-pipes/). Services now just emit `virtual-host = { name; url; port; }`, and `nginx.nix` aggregates all of them into `services.nginx.virtualHosts`. This decouples qbittorrent, sonarr, radarr, prowlarr, profilarr, autobrr, and plex from nginx's internals — no more reaching into `my.nginx._` from unrelated aspects.
- Adds a second quirk, `homepage-entry`, so each service declares its own homepage-dashboard entry (group, label, description, href, widget) right next to its `virtual-host` instead of `homepage.nix` hand-authoring the "Media"/"Arr Stack" service list. Adding a new dashboard-worthy service is now just emitting `homepage-entry` — no changes to `homepage.nix` needed.
- Drops a few now-unnecessary `{ ... }:` lambda wrappers on aspect files that don't use any module args (`autobrr.nix`, `prowlarr.nix`, `profilarr.nix`, `homepage.nix`), per the codebase's "bare attrset over unused lambda" style.

## Why

The old sub-aspect pattern tightly coupled every consumer to nginx's internal `provides` function. Den's quirks/pipes system exists specifically to let producers emit structured data without knowing who consumes it, so this brings the config in line with that model and removes the `nginx._.virtual-host`/`my.nginx._.virtual-host` call sites entirely.

## Test plan

- [x] `nix eval` confirms `services.nginx.virtualHosts` and `networking.firewall.allowedTCPPorts` on the `harmony` NixOS config are unchanged from before the rework (verified via `git stash`/`git stash pop` diffing).
- [x] `nix eval` confirms `services.homepage-dashboard.services`, `.bookmarks`, and `.allowedHosts` produce the same hrefs/descriptions/widgets as the old hand-written config (group ordering preserved; within-group ordering now alphabetical by aspect, which is an accepted cosmetic change).
- [x] `nix eval` sanity-checked `melaan` and `Oscars-MacBook-Pro` (hosts that don't use nginx) still evaluate.
- [x] `nix fmt -- --fail-on-change .` is clean.
- [ ] Not run: `nixos-rebuild switch` on `harmony` (x86_64-linux host, can't build/deploy from this aarch64-darwin sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)