### PR TITLE
fix(emacs): follow doomdir input to avoid mutable flake.lock entry

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -261,20 +261,6 @@
         "type": "github"
       }
     },
-    "doomdir": {
-      "flake": false,
-      "locked": {
-        "path": "doomdir",
-        "type": "path"
-      },
-      "original": {
-        "path": "doomdir",
-        "type": "path"
-      },
-      "parent": [
-        "nix-doom-emacs-unstraightened"
-      ]
-    },
     "doomemacs": {
       "flake": false,
       "locked": {
@@ -806,7 +792,9 @@
     },
     "nix-doom-emacs-unstraightened": {
       "inputs": {
-        "doomdir": "doomdir",
+        "doomdir": [
+          "nixpkgs"
+        ],
         "doomemacs": "doomemacs",
         "doomemacs-modules": "doomemacs-modules",
         "emacs-overlay": "emacs-overlay",

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,7 @@
     nix-doom-emacs-unstraightened = {
       url = "github:marienz/nix-doom-emacs-unstraightened";
       inputs = {
+        doomdir.follows = "nixpkgs";
         nixpkgs.follows = "nixpkgs";
         systems.follows = "systems";
       };

--- a/modules/aspects/my/emacs/emacs.nix
+++ b/modules/aspects/my/emacs/emacs.nix
@@ -6,6 +6,11 @@
     inputs = {
       nixpkgs.follows = "nixpkgs";
       systems.follows = "systems";
+      # Unused: we set `doomDir` explicitly below instead of relying on this
+      # input's default. Left unfollowed, it resolves to a mutable relative
+      # `path` input inside nix-doom-emacs-unstraightened, which Lix refuses
+      # to write into our (immutable, git-committed) flake.lock.
+      doomdir.follows = "nixpkgs";
     };
   };
 


### PR DESCRIPTION
## Summary

- `nix-doom-emacs-unstraightened` declares its `doomdir` input as a relative `path` (`url = ./doomdir;`), used only as a fallback default for `doomDir` — which this repo already sets explicitly (`doomDir = ./doom;` in `modules/aspects/my/emacs/emacs.nix`).
- Lix treats that unpinned `path` lock as mutable and refuses to write it into a flake whose tree is a clean git commit, breaking essentially every command that touches the lock file with:
  ```
  error: lock file contains mutable lock '{"path":"doomdir","type":"path"}'
  ```
- Fix: follow the unused `doomdir` input to `nixpkgs` (already pinned) instead of letting it resolve to the mutable path, then regenerated `flake.nix` via `nix run .#write-flake` and re-locked.

## Test plan

- [x] `nix flake lock` completes without error (previously failed on every invocation)
- [x] `nix run .#write-flake` regenerates `flake.nix` identically to the hand-applied change (confirms module source and generated file are in sync)
- [x] `nix build .#darwinConfigurations.Oscars-MacBook-Pro.config.system.build.toplevel --dry-run` evaluates and plans cleanly, including the Doom Emacs derivation
- [x] `nix fmt` reports no changes needed
- [x] `flake.lock` diff is minimal — only the `doomdir` node changes, no other inputs touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)