### PR TITLE
Remove IdentityFile from ssh-client meraki wildcard block

### DIFF
--- a/modules/aspects/users/oscar/work/ssh-client.nix
+++ b/modules/aspects/users/oscar/work/ssh-client.nix
@@ -32,7 +32,6 @@ in
         "*.meraki.com ${aliases}" = {
           AddKeysToAgent = "yes";
           ForwardAgent = true;
-          IdentityFile = "~/.ssh/id_ed25519_meraki";
           ServerAliveInterval = 240;
         };
         "dev" = lib.hm.dag.entryBefore [ "meraki.com aliases" ] { HostName = "dev203.meraki.com"; };


### PR DESCRIPTION
## Summary
- Removes the `IdentityFile = "~/.ssh/id_ed25519_meraki";` line from the `*.meraki.com` wildcard SSH host block in `modules/aspects/users/oscar/work/ssh-client.nix`.

## Test plan
- [ ] `nix build .#homeManagerConfigurations."omarshal@dev203.meraki.com".activationPackage` (or relevant host) to confirm it still evaluates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)