### PR TITLE
fix(nix): replace deprecated pkgs.system references

### DIFF
--- a/modules/aspects/my/claude.nix
+++ b/modules/aspects/my/claude.nix
@@ -26,7 +26,7 @@
 
       programs.claude-code = {
         enable = true;
-        package = inputs.claude-code-nix.packages.${pkgs.system}.claude-code;
+        package = inputs.claude-code-nix.packages.${pkgs.stdenv.hostPlatform.system}.claude-code;
 
         settings = {
           agentPushNotifEnabled = true;

--- a/modules/aspects/my/logseq.nix
+++ b/modules/aspects/my/logseq.nix
@@ -18,9 +18,9 @@
     {
       homeManager = { pkgs, lib, ... }: {
         home.packages = [
-          inputs.nix-logseq-git-flake.packages.${pkgs.system}.logseq-cli
+          inputs.nix-logseq-git-flake.packages.${pkgs.stdenv.hostPlatform.system}.logseq-cli
         ]
-        ++ lib.optional (!cli-only) inputs.nix-logseq-git-flake.packages.${pkgs.system}.logseq;
+        ++ lib.optional (!cli-only) inputs.nix-logseq-git-flake.packages.${pkgs.stdenv.hostPlatform.system}.logseq;
       };
     };
 }


### PR DESCRIPTION
## Summary
- Replace `pkgs.system` with `pkgs.stdenv.hostPlatform.system` in `claude.nix` and `logseq.nix`, since nixpkgs deprecated the `pkgs.system` alias and was emitting a build warning: `'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'`.

## Test plan
- [x] `nix build .#darwinConfigurations.Oscars-MacBook-Pro.config.system.build.toplevel --dry-run` — warning no longer appears
- [x] `nix fmt` — no formatting changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)