### PR TITLE
fix(ssh-client): set User to omarshal for meraki hosts

### DIFF
--- a/modules/aspects/users/oscar/work/ssh-client.nix
+++ b/modules/aspects/users/oscar/work/ssh-client.nix
@@ -33,6 +33,7 @@ in
           AddKeysToAgent = "yes";
           ForwardAgent = true;
           ServerAliveInterval = 240;
+          User = "omarshal";
         };
         "dev" = lib.hm.dag.entryBefore [ "meraki.com aliases" ] { HostName = "dev203.meraki.com"; };
         "meraki.com aliases" = lib.hm.dag.entryBefore [ "*.meraki.com" "n*.meraki.com" ] {


### PR DESCRIPTION
## Summary
- SSH to Meraki hosts (`dev`, shard hosts, jump hosts) was using the local macOS username `oscar` instead of the Meraki account `omarshal`, since no `User` was set in the `*.meraki.com` host block.
- The client was correctly offering the Meraki SSH key from the agent (confirmed via `ssh -vvv`), but the server rejected the connection since the wrong username was being used.
- Adds `User = "omarshal";` to the shared `"*.meraki.com ${aliases}"` block in [ssh-client.nix](modules/aspects/users/oscar/work/ssh-client.nix), covering `dev`, `n*` shard hosts, and all jump hosts in one place.

## Test plan
- [ ] `sudo darwin-rebuild switch --flake .#Oscars-MacBook-Pro`
- [ ] `ssh dev` connects successfully as `omarshal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)