### PR TITLE
fix(nix): resolve nh.clean/nix.gc.automatic conflict warning

### DIFF
--- a/modules/aspects/my/nix.nix
+++ b/modules/aspects/my/nix.nix
@@ -6,10 +6,6 @@ let
       extraOptions = ''
         !include ${config.age.secrets.nix-access-tokens.path}
       '';
-      gc = {
-        automatic = true;
-        options = "--delete-older-than 7d";
-      };
       package = pkgs.lixPackageSets.stable.lix;
       settings = {
         experimental-features = [
@@ -62,7 +58,13 @@ in
       { config, pkgs, ... }:
       lib.mkMerge [
         (mkNixConfig { inherit config pkgs; })
-        { nix.optimise.automatic = true; }
+        {
+          nix.gc = {
+            automatic = true;
+            options = "--delete-older-than 7d";
+          };
+          nix.optimise.automatic = true;
+        }
       ];
   };
 }


### PR DESCRIPTION
## Summary
- Home Manager rebuilds emitted: `programs.nh.clean.enable and nix.gc.automatic (Home-Manager) are both enabled. Please use one or the other to avoid conflict.`
- Root cause: `modules/aspects/my/nix.nix` set `nix.gc.automatic = true` for the shared `homeManager` config, while `modules/aspects/my/nh.nix` also enables `programs.nh.clean.enable = true` for Home Manager — both trying to manage store cleanup.
- Fix: moved `nix.gc` (automatic + `--delete-older-than 7d`) out of the shared `mkNixConfig` helper and into the `os` class only (system-level NixOS/Darwin nix daemon). Home Manager cleanup is now handled solely by `programs.nh.clean` (`nh clean --keep-since 7d`).

## Test plan
- [x] `nix fmt` — no changes needed, already conforms
- [x] `nix build .#darwinConfigurations.Oscars-MacBook-Pro.config.system.build.toplevel` — builds successfully with no `nh.clean`/`nix.gc.automatic` conflict warning (only expected dirty-tree/trusted-settings warnings remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)