### PR TITLE
Add oscar to nix trusted-users

### DIFF
--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -13,6 +13,7 @@ let
         hashedPasswordFile = toString config.age.secrets.oscar-hashed-password.file;
       };
     };
+    os.nix.settings.trusted-users = [ user.userName ];
   };
 in
 {

--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -13,6 +13,10 @@ let
         hashedPasswordFile = toString config.age.secrets.oscar-hashed-password.file;
       };
     };
+    # nixos/modules/config/nix.nix and nix-darwin's equivalent both set
+    # `nix.settings.trusted-users = [ "root" ]` as a real config-level definition
+    # (not just an mkOption default), and trusted-users is a listOf — definitions
+    # concatenate rather than override, so root can't be dropped by adding to this list.
     os.nix.settings.trusted-users = [ user.userName ];
   };
 in


### PR DESCRIPTION
## Summary
- Adds `oscar` to the Nix daemon's `trusted-users` so the flake's `extra-trusted-public-keys`/`extra-substituters` (cachix caches) are actually honored by the daemon instead of being silently ignored with a `restricted setting` warning.
- Set dynamically via `user.userName` in the `oscar` user aspect's existing `userAspect` function (which already derives the OS username the same way for `users.users.${user.userName}`), rather than hardcoding `"oscar"` in the shared `my.nix` aspect — keeps `my.nix` reusable if another user aspect includes it.
- Uses the `os` class so it forwards to both `nixos` and `darwin`.

## Test plan
- [x] `nix eval .#nixosConfigurations.harmony.config.nix.settings.trusted-users` → `["root","oscar"]`
- [x] `nix eval .#darwinConfigurations.OMARSHAL-M-T2QF.config.nix.settings.trusted-users` → `["root","oscar"]`
- [ ] Apply with `darwin-rebuild switch`/`nixos-rebuild switch` and confirm the "Ignoring the client-specified setting" warning is gone