### PR TITLE
Create ZFS datasets declaratively via a shared dataset quirk

### DIFF
--- a/modules/aspects/hosts/harmony/harmony.nix
+++ b/modules/aspects/hosts/harmony/harmony.nix
@@ -7,6 +7,27 @@
       boot
       (cachyos-kernel { variant = "server"; })
       cross-seed
+      {
+        dataset =
+          map
+            (name: {
+              pool = "metalminds";
+              inherit name;
+              samba = true;
+              guestAccess = true;
+            })
+            [
+              "backups"
+              "documents"
+              "minecraft-worlds"
+              "movies"
+              "music"
+              "pictures"
+              "shows"
+              "torrents"
+              "yarg-charts"
+            ];
+      }
       gluetun
       homepage
       (immich { administrators = [ "oscar" ]; })
@@ -20,17 +41,7 @@
       prowlarr
       (qbittorrent { administrators = [ "oscar" ]; })
       (radarr { administrators = [ "oscar" ]; })
-      (samba "/metalminds" [
-        "backups"
-        "documents"
-        "minecraft-worlds"
-        "movies"
-        "music"
-        "pictures"
-        "shows"
-        "torrents"
-        "yarg-charts"
-      ])
+      samba
       (sonarr { administrators = [ "oscar" ]; })
       ssh-server
       unpackerr

--- a/modules/aspects/hosts/harmony/harmony.nix
+++ b/modules/aspects/hosts/harmony/harmony.nix
@@ -7,27 +7,6 @@
       boot
       (cachyos-kernel { variant = "server"; })
       cross-seed
-      {
-        dataset =
-          map
-            (name: {
-              pool = "metalminds";
-              inherit name;
-              samba = true;
-              guestAccess = true;
-            })
-            [
-              "backups"
-              "documents"
-              "minecraft-worlds"
-              "movies"
-              "music"
-              "pictures"
-              "shows"
-              "torrents"
-              "yarg-charts"
-            ];
-      }
       gluetun
       homepage
       (immich { administrators = [ "oscar" ]; })
@@ -47,6 +26,26 @@
       unpackerr
       (zfs [ "metalminds" ])
     ];
+
+    dataset =
+      map
+        (name: {
+          pool = "metalminds";
+          inherit name;
+          samba = true;
+          guestAccess = true;
+        })
+        [
+          "backups"
+          "documents"
+          "minecraft-worlds"
+          "movies"
+          "music"
+          "pictures"
+          "shows"
+          "torrents"
+          "yarg-charts"
+        ];
 
     nixos = {
       age.rekey.hostPubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMkM5uNY0rMy2QMG6IptlxgVl4sQWoeSSNmUp7/f2z1B";

--- a/modules/aspects/my/immich.nix
+++ b/modules/aspects/my/immich.nix
@@ -29,7 +29,7 @@ in
       services.immich = {
         enable = true;
         inherit port;
-        mediaLocation = "/metalminds/immich";
+        mediaLocation = "/metalminds/pictures";
         settings.oauth = {
           enabled = true;
           issuerUrl = "https://auth.harmony.silverlight-nex.us/application/o/immich/";

--- a/modules/aspects/my/profilarr.nix
+++ b/modules/aspects/my/profilarr.nix
@@ -5,6 +5,11 @@
       port = 6868;
     in
     {
+      dataset = {
+        pool = "metalminds";
+        name = "profilarr";
+      };
+
       virtual-host = {
         name = "profilarr";
         inherit url port;

--- a/modules/aspects/my/samba.nix
+++ b/modules/aspects/my/samba.nix
@@ -1,26 +1,36 @@
-{ lib, ... }: {
-  my.samba = pool: shares: {
-    nixos = {
-      services = {
-        samba = {
-          enable = true;
-          openFirewall = true;
-          settings = {
-            global."map to guest" = "Bad User";
-          }
-          // (lib.genAttrs shares (share: {
-            path = "${pool}/${share}";
-            "guest ok" = "yes";
-            "read only" = "yes";
-            "write list" = "@users";
-            browsable = "yes";
-          }));
-        };
-        samba-wsdd = {
-          enable = true;
-          openFirewall = true;
+{
+  my.samba = {
+    nixos =
+      { dataset, lib, ... }:
+      let
+        shares = builtins.filter (d: d.samba or false) dataset;
+      in
+      {
+        services = {
+          samba = {
+            enable = true;
+            openFirewall = true;
+            settings = {
+              global."map to guest" = "Bad User";
+            }
+            // (lib.listToAttrs (
+              map (
+                d:
+                lib.nameValuePair d.name {
+                  path = "/${d.pool}/${d.name}";
+                  "guest ok" = if d.guestAccess or false then "yes" else "no";
+                  "read only" = "yes";
+                  "write list" = "@users";
+                  browsable = "yes";
+                }
+              ) shares
+            ));
+          };
+          samba-wsdd = {
+            enable = true;
+            openFirewall = true;
+          };
         };
       };
-    };
   };
 }

--- a/modules/aspects/my/zfs.nix
+++ b/modules/aspects/my/zfs.nix
@@ -1,7 +1,9 @@
 { lib, ... }: {
+  den.quirks.dataset.description = "ZFS datasets required by aspects, optionally shared via Samba";
+
   my.zfs = pools: {
     nixos =
-      { pkgs, ... }:
+      { dataset, pkgs, ... }:
       let
         # Use the default ZFS package for compatibility checking to avoid infinite recursion
         # We can't use config.boot.zfs.package here because it depends on kernelPackages which we're trying to determine
@@ -37,6 +39,19 @@
           autoSnapshot.enable = true;
           trim.enable = true;
         };
+
+        # Datasets are only ever created if missing, never renamed or reconfigured - changing a
+        # dataset's name or properties later leaves the old dataset behind untouched.
+        system.activationScripts.zfsDatasets = lib.concatMapStrings (
+          d:
+          let
+            name = "${d.pool}/${d.name}";
+          in
+          ''
+            ${pkgs.zfs}/bin/zfs list -H -o name ${lib.escapeShellArg name} >/dev/null 2>&1 \
+              || ${pkgs.zfs}/bin/zfs create -p ${lib.escapeShellArg name}
+          ''
+        ) dataset;
       };
   };
 }

--- a/modules/aspects/my/zfs.nix
+++ b/modules/aspects/my/zfs.nix
@@ -41,12 +41,15 @@
         };
 
         # Datasets are only ever created if missing, never renamed or reconfigured - changing a
-        # dataset's name or properties later leaves the old dataset behind untouched.
+        # dataset's name, options, or other properties later leaves the old dataset behind untouched.
         system.activationScripts.zfsDatasets = lib.concatMapStrings (
           d:
           let
             name = "${d.pool}/${d.name}";
             mountpoint = "/${name}";
+            options = lib.concatStrings (
+              lib.mapAttrsToList (property: value: " -o ${lib.escapeShellArg "${property}=${value}"}") (d.options or { })
+            );
           in
           ''
             if ! ${pkgs.zfs}/bin/zfs list -H -o name ${lib.escapeShellArg name} >/dev/null 2>&1; then
@@ -54,7 +57,7 @@
                 echo "zfs dataset ${lib.escapeShellArg name} is missing, but ${lib.escapeShellArg mountpoint} already exists and is non-empty - move its contents aside, then re-run the activation" >&2
                 exit 1
               fi
-              ${pkgs.zfs}/bin/zfs create -p ${lib.escapeShellArg name}
+              ${pkgs.zfs}/bin/zfs create -p${options} ${lib.escapeShellArg name}
             fi
           ''
         ) dataset;

--- a/modules/aspects/my/zfs.nix
+++ b/modules/aspects/my/zfs.nix
@@ -46,10 +46,16 @@
           d:
           let
             name = "${d.pool}/${d.name}";
+            mountpoint = "/${name}";
           in
           ''
-            ${pkgs.zfs}/bin/zfs list -H -o name ${lib.escapeShellArg name} >/dev/null 2>&1 \
-              || ${pkgs.zfs}/bin/zfs create -p ${lib.escapeShellArg name}
+            if ! ${pkgs.zfs}/bin/zfs list -H -o name ${lib.escapeShellArg name} >/dev/null 2>&1; then
+              if [ -d ${lib.escapeShellArg mountpoint} ] && [ -n "$(ls -A ${lib.escapeShellArg mountpoint})" ]; then
+                echo "zfs dataset ${lib.escapeShellArg name} is missing, but ${lib.escapeShellArg mountpoint} already exists and is non-empty - move its contents aside, then re-run the activation" >&2
+                exit 1
+              fi
+              ${pkgs.zfs}/bin/zfs create -p ${lib.escapeShellArg name}
+            fi
           ''
         ) dataset;
       };


### PR DESCRIPTION
## Summary

- Adds a `dataset` Den quirk (declared in `my.zfs`) that any aspect can produce to request a directory backed by a real ZFS dataset under a given pool.
- `my.zfs` consumes it to idempotently `zfs create -p <pool>/<name>` on every activation (self-healing, never renames/reconfigures an existing dataset), and preflights each mountpoint so a missing dataset whose directory already exists and is non-empty fails activation with an actionable message instead of a generic `zfs create` error.
- `my.samba` consumes it to build Samba share settings for entries that opt in with `samba = true`; each such entry also controls `guestAccess` (defaults to `false` — the harmony shares set `guestAccess = true` explicitly to preserve current behavior).
- `harmony`'s 9 existing shares now flow through this quirk, declared directly on `den.aspects.harmony` (alongside `includes`/`nixos`/`provides`) instead of being passed as explicit params to `my.samba`.
- `profilarr` requests its own private (non-Samba) `metalminds/profilarr` dataset — a directory that was previously a plain, unmanaged path under the pool.
- `dataset` entries can also carry an `options` attrset (ZFS property name/value pairs, e.g. `{ compression = "lz4"; quota = "10G"; }`) passed as `-o property=value` flags to `zfs create` — applied only at creation time, consistent with the create-only semantics of the rest of the quirk.
- Immich's media location moved from its own `metalminds/immich` dataset into the existing `metalminds/pictures` dataset/share (no longer has a private dataset of its own).

## Why

Several aspects reference `/metalminds/<name>` paths that were never declared anywhere — they existed only as directories auto-created by container bind mounts, with no real ZFS dataset backing them (no per-dataset snapshots/quotas) and no self-healing if deleted. This introduces a single, reusable mechanism so any aspect can declare "I need this ZFS dataset to exist" without duplicating activation-script boilerplate, and optionally expose it as a Samba share.

## Notes for reviewer

- On `harmony`'s next `nixos-rebuild switch`, several of these paths (`backups`, `documents`, `minecraft-worlds`, `movies`, `music`, `pictures`, `shows`, `torrents`, `yarg-charts`, `profilarr`) are currently plain directories with existing data, not ZFS datasets. The activation script will now refuse to run (with a clear error) rather than silently fail, but existing data still needs to be moved into place as part of (or before) that rebuild.
- Immich's media now lives inside the same dataset as the `pictures` Samba share (deliberately, per repo owner direction), so its managed library (thumbnails, encoded video, etc.) sits alongside anything already in `pictures` and is network-browsable there. A separate subdirectory (e.g. `metalminds/pictures/immich`) remains an option if that turns out to be undesirable.
- Only verified via `nix eval` against `nixosConfigurations.harmony` (kernel/arch mismatch on this dev machine prevents a full `nix build` here) — no live `nixos-rebuild switch` was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

