### PR TITLE
Add Satisfactory dedicated server to harmony

### DIFF
--- a/modules/aspects/hosts/harmony/harmony.nix
+++ b/modules/aspects/hosts/harmony/harmony.nix
@@ -21,6 +21,7 @@
       (qbittorrent { administrators = [ "oscar" ]; })
       (radarr { administrators = [ "oscar" ]; })
       samba
+      satisfactory-server
       (sonarr { administrators = [ "oscar" ]; })
       ssh-server
       unpackerr

--- a/modules/aspects/my/satisfactory-server.nix
+++ b/modules/aspects/my/satisfactory-server.nix
@@ -1,0 +1,46 @@
+let
+  gamePort = 7777;
+  messagingPort = 8888;
+in
+{
+  my.satisfactory-server = {
+    dataset = {
+      pool = "metalminds";
+      name = "satisfactory-server";
+    };
+
+    nixos = { config, ... }: {
+      users = {
+        users.satisfactory-server = {
+          uid = 984;
+          isSystemUser = true;
+          group = "satisfactory-server";
+        };
+        groups.satisfactory-server.gid = 984;
+      };
+
+      virtualisation.oci-containers.containers.satisfactory-server = {
+        image = "wolveix/satisfactory-server:latest@sha256:e103700ae6ae4c50f19dac80eadb2a805c5b885e179ae2a40850e967bf189efd";
+        ports = [
+          "${toString gamePort}:${toString gamePort}/tcp"
+          "${toString gamePort}:${toString gamePort}/udp"
+          "${toString messagingPort}:${toString messagingPort}/tcp"
+        ];
+        volumes = [ "/metalminds/satisfactory-server:/config" ];
+        environment = {
+          PUID = toString config.users.users.satisfactory-server.uid;
+          PGID = toString config.users.groups.satisfactory-server.gid;
+          MAXPLAYERS = "4";
+        };
+      };
+
+      networking.firewall = {
+        allowedTCPPorts = [
+          gamePort
+          messagingPort
+        ];
+        allowedUDPPorts = [ gamePort ];
+      };
+    };
+  };
+}

--- a/modules/aspects/my/zfs.nix
+++ b/modules/aspects/my/zfs.nix
@@ -40,6 +40,10 @@
           trim.enable = true;
         };
 
+        # New child datasets inherit their parent pool's properties, so `options` should only be used to
+        # deviate from those, not to restate them. As of 2026-07-10, metalminds (harmony's data pool) has
+        # compression=on (lz4), atime=off, and recordsize=128K - all sane defaults for most workloads.
+        #
         # Datasets are only ever created if missing, never renamed or reconfigured - changing a
         # dataset's name, options, or other properties later leaves the old dataset behind untouched.
         system.activationScripts.zfsDatasets = lib.concatMapStrings (


### PR DESCRIPTION
## Summary
- Adds a `my.satisfactory-server` aspect running [wolveix/satisfactory-server](https://github.com/wolveix/satisfactory-server) as an OCI container on `harmony`, exposing the game port (7777 TCP/UDP) and reliable messaging port (8888 TCP) directly on the host firewall — not proxied through nginx, since it's a raw game protocol/self-signed-HTTPS management API rather than a plain HTTP backend.
- Runs as a dedicated system user (uid/gid 984) instead of root.
- Save data lives on its own private ZFS dataset (`metalminds/satisfactory-server`), created declaratively via the `dataset` quirk added in #468. No explicit `options` are set — it just inherits the pool's existing `compression=on` (lz4) / `atime=off`, which is now documented in a comment in `zfs.nix` for future dataset declarations.

## Test plan
- [x] `nix fmt` on all changed files
- [x] Cross-evaluated `nixosConfigurations.harmony.config` for `x86_64-linux` (native `nix build`/`nix eval` for the full toplevel isn't possible from this aarch64-darwin machine due to an unrelated Doom Emacs IFD cross-build limitation): confirmed firewall ports, container definition (image, ports, volumes, `PUID`/`PGID`), and the ZFS dataset activation script all evaluate as expected.
- [ ] `sudo nixos-rebuild switch --flake .#harmony` on the actual host
- [ ] Forward UDP/TCP 7777 and TCP 8888 on the router to harmony
- [ ] Connect from the Satisfactory client and confirm the server comes up

🤖 Generated with [Claude Code](https://claude.com/claude-code)