### PR TITLE
Fix Authentik CSRF failure caused by global cookie HttpOnly override

### DIFF
--- a/modules/aspects/my/authentik.nix
+++ b/modules/aspects/my/authentik.nix
@@ -49,6 +49,14 @@ in
           host = url;
         };
       };
+
+      # nginx.nix forces `HttpOnly` onto every proxied cookie, but Authentik's frontend needs to
+      # read its CSRF cookie via JavaScript (it echoes the value back as the X-Authentik-Csrf
+      # header). With HttpOnly forced on, that read fails and Authentik rejects the empty token
+      # with "CSRF token ... incorrect length". Reset the cookie rewrite for this vhost only.
+      services.nginx.virtualHosts.${url}.extraConfig = ''
+        proxy_cookie_path / /;
+      '';
     };
   };
 }


### PR DESCRIPTION
## Summary

- `modules/aspects/my/nginx.nix`'s `proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";` hack forces `HttpOnly` onto every cookie proxied through nginx, applied globally at the `http {}` level.
- Authentik's frontend needs to read its CSRF token from a cookie via JavaScript and echoes it back as the `X-Authentik-Csrf` header. With `HttpOnly` forced on, that read silently fails, so the frontend sends an empty/invalid token — which Authentik/Django reports as `CSRF token from the 'X-Authentik-Csrf' HTTP header has incorrect length`.
- Fix: reset `proxy_cookie_path` back to a no-op specifically on Authentik's nginx vhost (`services.nginx.virtualHosts."auth.harmony.silverlight-nex.us".extraConfig`). Since nginx directive inheritance means a directive redefined in a more specific context (server block) fully replaces the parent context's definition (not merges), this cleanly opts Authentik out of the cookie rewrite without touching the global default other proxied services (which don't need JS cookie access) still rely on.

Found this live while walking through the Plex source setup in Authentik's admin UI on harmony — every form submission failed with the CSRF error above until this fix.

## Test plan

- [x] `nix eval` confirms `services.nginx.virtualHosts."auth.harmony.silverlight-nex.us".extraConfig` now contains the override and nothing else broke.
- [ ] `nixos-rebuild switch --flake .#harmony`, then retry creating the Plex source in Authentik's admin UI and confirm the CSRF error is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)