### PR TITLE
Fix Immich 502 by pinning its API server to IPv4 loopback

### DIFF
--- a/modules/aspects/my/immich.nix
+++ b/modules/aspects/my/immich.nix
@@ -28,6 +28,7 @@ in
 
       services.immich = {
         enable = true;
+        host = "127.0.0.1";
         inherit port;
         mediaLocation = "/metalminds/pictures";
         settings.oauth = {


### PR DESCRIPTION
## Summary

- `services.immich.host` defaults to `"localhost"`. Node's DNS resolution for that hostname bound Immich's API server to `[::1]:2283` (IPv6) only — confirmed on harmony via `ss -tlnp | grep 2283` → `LISTEN 0 511 [::1]:2283 [::]:*`, nothing on IPv4.
- nginx's `virtual-host` quirk proxies to `http://127.0.0.1:2283/` (IPv4 loopback), so every request 502'd — even though `immich-server.service` was completely healthy (clean startup, no errors, `oauth: true` feature flag correctly set).
- Fix: pin `services.immich.host = "127.0.0.1";` explicitly so it matches what nginx actually targets.

## Test plan

- [x] `nix eval` confirms `IMMICH_HOST=127.0.0.1` in the generated systemd unit environment.
- [ ] `nixos-rebuild switch --flake .#harmony`, then confirm `ss -tlnp | grep 2283` shows `127.0.0.1:2283` and `https://immich.harmony.silverlight-nex.us` no longer 502s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)