### PR TITLE
Resolve auth.harmony.silverlight-nex.us to loopback on harmony

### DIFF
--- a/modules/aspects/hosts/harmony/harmony.nix
+++ b/modules/aspects/hosts/harmony/harmony.nix
@@ -53,6 +53,11 @@
       age.rekey.hostPubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMkM5uNY0rMy2QMG6IptlxgVl4sQWoeSSNmUp7/f2z1B";
       networking.hostId = "7dab76c0";
 
+      # The router doesn't support NAT hairpinning, so services on harmony calling other services
+      # on harmony via their public hostname (e.g. Immich's backend fetching Authentik's OIDC
+      # discovery document) hang instead of routing out and back in. Resolve locally instead.
+      networking.hosts."127.0.0.1" = [ "auth.harmony.silverlight-nex.us" ];
+
       services = {
         apcupsd.enable = true;
         glances.enable = true;


### PR DESCRIPTION
## Summary

- Immich's "Login with OAuth" was hanging for roughly a minute before completing.
- Diagnosed with `curl -v https://auth.harmony.silverlight-nex.us/application/o/immich/.well-known/openid-configuration` run from harmony itself: curl's Happy Eyeballs tried the IPv6 address first (`2600:1700:...`), which the router doesn't hairpin back to harmony at all — that attempt has to fully time out before curl falls back to IPv4, which does hairpin, just slowly. Total round trip: ~60s.
- Immich's backend hits this same path (server-to-server, not through the browser) both to fetch Authentik's OIDC discovery document before it can redirect, and again to exchange the auth code for tokens — so every login paid this cost, long enough to look like a hang.
- Both services run on harmony, so there's no reason this traffic should ever leave the machine. Added a `networking.hosts` entry resolving `auth.harmony.silverlight-nex.us` straight to `127.0.0.1` on harmony, bypassing DNS and the router for this hostname entirely.

## Test plan

- [x] `nix eval` confirms `networking.hosts."127.0.0.1"` includes `auth.harmony.silverlight-nex.us` alongside the existing entry.
- [ ] `nixos-rebuild switch --flake .#harmony`, then re-run the `curl` command above and confirm it returns near-instantly, and that "Login with OAuth" in Immich no longer hangs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)