### PR TITLE
Enable WebSocket proxying for all reverse-proxied virtual hosts

### DIFF
--- a/modules/aspects/my/immich.nix
+++ b/modules/aspects/my/immich.nix
@@ -8,6 +8,9 @@ in
     virtual-host = {
       name = "immich";
       inherit url port;
+      # Immich's frontend opens a WebSocket right after login for real-time updates (job
+      # progress, live sync); without this the connection silently fails and the UI hangs.
+      websockets = true;
     };
 
     homepage-entry = {

--- a/modules/aspects/my/nginx.nix
+++ b/modules/aspects/my/nginx.nix
@@ -64,10 +64,10 @@
                   "/" = {
                     proxyPass = "http://127.0.0.1:${toString host.port}/";
                     # recommendedProxySettings clears the Connection header (`proxy_set_header
-                    # Connection "";`), which breaks WebSocket upgrades for any backend that uses
-                    # them (e.g. Immich's real-time updates). This re-enables upgrade support for
-                    # every proxied service; a no-op for backends that never send Upgrade requests.
-                    proxyWebsockets = true;
+                    # Connection "";`), which breaks WebSocket upgrades. Backends that use them
+                    # (e.g. Immich's real-time updates) opt in via `websockets = true;` on their
+                    # `virtual-host` record.
+                    proxyWebsockets = host.websockets or false;
                     extraConfig = lib.optionalString (host.protected or false) ''
                       auth_request /outpost.goauthentik.io/auth/nginx;
                       error_page 401 = @goauthentik_proxy_signin;

--- a/modules/aspects/my/nginx.nix
+++ b/modules/aspects/my/nginx.nix
@@ -66,7 +66,11 @@
                     # recommendedProxySettings clears the Connection header (`proxy_set_header
                     # Connection "";`), which breaks WebSocket upgrades. Backends that use them
                     # (e.g. Immich's real-time updates) opt in via `websockets = true;` on their
-                    # `virtual-host` record.
+                    # `virtual-host` record — nginx's standard websocket idiom (see
+                    # https://nginx.org/en/docs/http/websocket.html), which sends `Connection:
+                    # close` instead of keep-alive for non-Upgrade requests on that host. Fine
+                    # here: upstream is always 127.0.0.1, so the lost keep-alive just costs an
+                    # extra loopback handshake, not a real round trip.
                     proxyWebsockets = host.websockets or false;
                     extraConfig = lib.optionalString (host.protected or false) ''
                       auth_request /outpost.goauthentik.io/auth/nginx;

--- a/modules/aspects/my/nginx.nix
+++ b/modules/aspects/my/nginx.nix
@@ -63,6 +63,11 @@
                 locations = {
                   "/" = {
                     proxyPass = "http://127.0.0.1:${toString host.port}/";
+                    # recommendedProxySettings clears the Connection header (`proxy_set_header
+                    # Connection "";`), which breaks WebSocket upgrades for any backend that uses
+                    # them (e.g. Immich's real-time updates). This re-enables upgrade support for
+                    # every proxied service; a no-op for backends that never send Upgrade requests.
+                    proxyWebsockets = true;
                     extraConfig = lib.optionalString (host.protected or false) ''
                       auth_request /outpost.goauthentik.io/auth/nginx;
                       error_page 401 = @goauthentik_proxy_signin;


### PR DESCRIPTION
## Summary

- Immich's login (both OAuth and plain email/password) appeared to hang after a successful response. Network tab confirmed `/login` returned `201` with a valid session (`accessToken`, `userId`, etc.) — the request succeeded, but the UI never progressed. Same result for both auth methods, which ruled out anything OAuth/Authentik-specific (see #479, which was based on a since-disproven theory).
- Root cause: `services.nginx.recommendedProxySettings` explicitly sets `proxy_set_header Connection "";`, clearing the header needed for WebSocket upgrades. Immich's frontend opens a WebSocket right after login for real-time updates (job progress, live sync) and apparently blocks its post-login init on that connection — with the handshake silently broken, the app just sits there regardless of which login method got you the session.
- Fix: add `proxyWebsockets = host.websockets or false;` to the generic `virtual-host` quirk's `/` location — an explicit per-service opt-in, matching the shape `protected` already uses on the same record, rather than turning it on unconditionally for every proxied service. `immich.nix` sets `websockets = true;` on its own `virtual-host` entry.
- This makes NixOS emit `proxy_http_version 1.1; proxy_set_header Upgrade $http_upgrade; proxy_set_header Connection $connection_upgrade;` for opted-in hosts, which — because it's declared at the location level — overrides the cleared `Connection` header from the server-level `recommendedProxySettings`. Same override pattern `authentik-nix`'s own module already uses for its `/ws/` location.
- Converges with the same fix independently written in the still-open Nextcloud/Collabora PR (#469), which needs it for Collabora's real-time collaborative editing — landing on the same `host.websockets or false` shape there too.

## Test plan

- [x] `nix eval` confirms `proxyWebsockets = true` on `immich.harmony.silverlight-nex.us`'s `/` location, and stays `false` for hosts that don't opt in (e.g. Radarr).
- [ ] `nixos-rebuild switch --flake .#harmony`, then confirm both OAuth and password login in Immich complete and land in the app instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
