### PR TITLE
fix(homepage): migrate to environmentFiles option

### DIFF
--- a/modules/aspects/my/homepage.nix
+++ b/modules/aspects/my/homepage.nix
@@ -59,7 +59,7 @@ in
       {
         services.homepage-dashboard = {
           enable = true;
-          environmentFile = config.age.secrets."homepage-dashboard.env".path;
+          environmentFiles = [ config.age.secrets."homepage-dashboard.env".path ];
           allowedHosts = "localhost:${port'},127.0.0.1:${port'},${hosts.homepage.url}";
           widgets = [
             {


### PR DESCRIPTION
## Summary
- `services.homepage-dashboard.environmentFile` was renamed upstream to `environmentFiles` (a list), which triggered a deprecation warning on rebuild:
  ```
  warning: The option `services.homepage-dashboard.environmentFile' defined in `nixos@my/homepage' has been changed to `services.homepage-dashboard.environmentFiles' that has a different type.
  ```
- Updated [modules/aspects/my/homepage.nix](modules/aspects/my/homepage.nix) to use the new list-based option, matching the pattern already used for qbittorrent, sonarr, gluetun, radarr, and prowlarr.

## Test plan
- [ ] `nix build .#nixosConfigurations.harmony.config.system.build.toplevel` builds without the deprecation warning