### PR TITLE
Remove dead cache.xinux.uz substituter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,14 +9,12 @@
       "https://oscarmarshall.cachix.org"
       "https://nix-logseq-git-flake.cachix.org"
       "https://attic.xuyh0120.win/lantian"
-      "https://cache.xinux.uz"
     ];
     extra-trusted-public-keys = [
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       "oscarmarshall.cachix.org-1:Fa13vGeBXoJ7jWpvnalg/PCRTtvCpyuHUFL5jQXt/9w="
       "nix-logseq-git-flake.cachix.org-1:DSBNW07PSRyCvS926tpIWahb53OIydwwZhsP6LhJNZo="
       "lantian:EeAUQ+W+6r7EtwnmYjeVwx5kOGEBpjlBfPlzGlTNvHc="
-      "cache.xinux.uz:BXCrtqejFjWzWEB9YuGB7X2MV4ttBur1N8BkwQRdH+0="
     ];
   };
 

--- a/modules/aspects/my/cachyos-kernel.nix
+++ b/modules/aspects/my/cachyos-kernel.nix
@@ -27,14 +27,8 @@
     inputs.nix-cachyos-kernel.url = "github:xddxdd/nix-cachyos-kernel/release";
 
     nixConfig = {
-      extra-substituters = [
-        "https://attic.xuyh0120.win/lantian"
-        "https://cache.xinux.uz"
-      ];
-      extra-trusted-public-keys = [
-        "lantian:EeAUQ+W+6r7EtwnmYjeVwx5kOGEBpjlBfPlzGlTNvHc="
-        "cache.xinux.uz:BXCrtqejFjWzWEB9YuGB7X2MV4ttBur1N8BkwQRdH+0="
-      ];
+      extra-substituters = [ "https://attic.xuyh0120.win/lantian" ];
+      extra-trusted-public-keys = [ "lantian:EeAUQ+W+6r7EtwnmYjeVwx5kOGEBpjlBfPlzGlTNvHc=" ];
     };
   };
 


### PR DESCRIPTION
## Summary
- `cache.xinux.uz` (added in the CachyOS kernel aspect) started failing DNS resolution (`Could not resolve host`), which Nix treats as a fatal error rather than falling back to the next substituter — so every build was hard-failing while it stayed configured.
- Removed it from `extra-substituters`/`extra-trusted-public-keys` in [modules/aspects/my/cachyos-kernel.nix](modules/aspects/my/cachyos-kernel.nix), leaving `attic.xuyh0120.win/lantian` as the CachyOS-kernel cache.
- Regenerated `flake.nix` via `nix run .#write-flake` to match.

## Test plan
- [x] `nix run .#write-flake` regenerates `flake.nix` identically from the updated module (confirms source of truth is in sync).
- [ ] `sudo darwin-rebuild switch --flake .#OMARSHAL-M-T2QF` (or equivalent) to refresh the machine's global `nix.conf`, which still lists the dead cache until applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)