### PR TITLE
fix(boot,zfs): prevent unbounded ESP growth and fix boot failure from early ZFS dataset creation

### DIFF
--- a/modules/aspects/my/boot.nix
+++ b/modules/aspects/my/boot.nix
@@ -9,7 +9,7 @@
           # Without a limit, every generation's kernel+initrd accumulates on the EFI System
           # Partition until it fills up, at which point a new generation's files can be written
           # incompletely and fail to boot with "Switch root target contains no usable init".
-          configurationLimit = 10;
+          configurationLimit = lib.mkDefault 10;
         };
         efi.canTouchEfiVariables = true;
       };

--- a/modules/aspects/my/boot.nix
+++ b/modules/aspects/my/boot.nix
@@ -4,7 +4,13 @@
       # Use latest kernel for all systems (lowest priority, can be overridden)
       kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
       loader = {
-        systemd-boot.enable = true;
+        systemd-boot = {
+          enable = true;
+          # Without a limit, every generation's kernel+initrd accumulates on the EFI System
+          # Partition until it fills up, at which point a new generation's files can be written
+          # incompletely and fail to boot with "Switch root target contains no usable init".
+          configurationLimit = 10;
+        };
         efi.canTouchEfiVariables = true;
       };
     };

--- a/modules/aspects/my/zfs.nix
+++ b/modules/aspects/my/zfs.nix
@@ -59,9 +59,7 @@
                 name = "${d.pool}/${d.name}";
                 mountpoint = "/${name}";
                 options = lib.concatStrings (
-                  lib.mapAttrsToList (
-                    property: value: " -o ${lib.escapeShellArg "${property}=${value}"}"
-                  ) (d.options or { })
+                  lib.mapAttrsToList (property: value: " -o ${lib.escapeShellArg "${property}=${value}"}") (d.options or { })
                 );
               in
               ''

--- a/modules/aspects/my/zfs.nix
+++ b/modules/aspects/my/zfs.nix
@@ -50,7 +50,7 @@
         # This host also runs full system activation inside the initrd (before switch-root), where no
         # pool is imported yet - `/etc/initrd-release` only exists there (per systemd's initrd
         # interface: https://systemd.io/INITRD_INTERFACE/), so skip entirely in that context. Datasets
-        # are only ever needed at `nixos-rebuild switch` time, when the pool is already imported.
+        # are only ever created at `nixos-rebuild switch` time, when the pool is already imported.
         system.activationScripts.zfsDatasets = ''
           if [ ! -e /etc/initrd-release ]; then
             ${lib.concatMapStrings (

--- a/modules/aspects/my/zfs.nix
+++ b/modules/aspects/my/zfs.nix
@@ -46,25 +46,36 @@
         #
         # Datasets are only ever created if missing, never renamed or reconfigured - changing a
         # dataset's name, options, or other properties later leaves the old dataset behind untouched.
-        system.activationScripts.zfsDatasets = lib.concatMapStrings (
-          d:
-          let
-            name = "${d.pool}/${d.name}";
-            mountpoint = "/${name}";
-            options = lib.concatStrings (
-              lib.mapAttrsToList (property: value: " -o ${lib.escapeShellArg "${property}=${value}"}") (d.options or { })
-            );
-          in
-          ''
-            if ! ${pkgs.zfs}/bin/zfs list -H -o name ${lib.escapeShellArg name} >/dev/null 2>&1; then
-              if [ -d ${lib.escapeShellArg mountpoint} ] && [ -n "$(ls -A ${lib.escapeShellArg mountpoint})" ]; then
-                echo "zfs dataset ${lib.escapeShellArg name} is missing, but ${lib.escapeShellArg mountpoint} already exists and is non-empty - move its contents aside, then re-run the activation" >&2
-                exit 1
-              fi
-              ${pkgs.zfs}/bin/zfs create -p${options} ${lib.escapeShellArg name}
-            fi
-          ''
-        ) dataset;
+        #
+        # This host also runs full system activation inside the initrd (before switch-root), where no
+        # pool is imported yet - `/etc/initrd-release` only exists there (per systemd's initrd
+        # interface: https://systemd.io/INITRD_INTERFACE/), so skip entirely in that context. Datasets
+        # are only ever needed at `nixos-rebuild switch` time, when the pool is already imported.
+        system.activationScripts.zfsDatasets = ''
+          if [ ! -e /etc/initrd-release ]; then
+            ${lib.concatMapStrings (
+              d:
+              let
+                name = "${d.pool}/${d.name}";
+                mountpoint = "/${name}";
+                options = lib.concatStrings (
+                  lib.mapAttrsToList (
+                    property: value: " -o ${lib.escapeShellArg "${property}=${value}"}"
+                  ) (d.options or { })
+                );
+              in
+              ''
+                if ! ${pkgs.zfs}/bin/zfs list -H -o name ${lib.escapeShellArg name} >/dev/null 2>&1; then
+                  if [ -d ${lib.escapeShellArg mountpoint} ] && [ -n "$(ls -A ${lib.escapeShellArg mountpoint})" ]; then
+                    echo "zfs dataset ${lib.escapeShellArg name} is missing, but ${lib.escapeShellArg mountpoint} already exists and is non-empty - move its contents aside, then re-run the activation" >&2
+                    exit 1
+                  fi
+                  ${pkgs.zfs}/bin/zfs create -p${options} ${lib.escapeShellArg name}
+                fi
+              ''
+            ) dataset}
+          fi
+        '';
       };
   };
 }


### PR DESCRIPTION
## Summary

Harmony was failing to boot on its latest few generations with `Switch root target contains no usable init`, recoverable only by selecting an older generation from the systemd-boot menu.

**Root cause (confirmed via direct investigation on harmony):** this host runs full NixOS system activation inside the initrd, before switch-root (confirmed in boot logs) — no ZFS pool is imported at that point, that only happens later as a regular systemd service after switch-root. The `dataset` quirk's `zfsDatasets` activation script (`modules/aspects/my/zfs.nix`) runs unconditionally as part of activation, so the first boot of any generation that introduces a *new* declared dataset (e.g. `a7b25bc`, which added `metalminds/satisfactory-server`) tries `zfs create` against a pool that doesn't exist yet in the initrd, fails, and aborts activation before handing off to switch-root — which is exactly what surfaces as "no usable init". Older generations that predate a new dataset never hit this, which is why only "the latest few generations" were affected while older ones still boot fine.

My original ESP-exhaustion theory (unbounded `systemd-boot` generationsfilling `/boot`) was disproven by checking harmony directly (`df -h /boot` → 15% used, plenty of room). Keeping `configurationLimit` anyway since unbounded retention is still worth avoiding as hygiene, but it isn't what was causing this.

## Changes

- `boot.loader.systemd-boot.configurationLimit = lib.mkDefault 10` in `modules/aspects/my/boot.nix` — caps generation retention on the EFI System Partition (hygiene, not the fix for the actual bug).
- `modules/aspects/my/zfs.nix`: guard `zfsDatasets` activation script to no-op when running inside the initrd (detected via `/etc/initrd-release`, part of systemd's initrd interface). Dataset creation only needs to happen at `nixos-rebuild switch` time, when the pool is already imported on a running system — not at boot.

## Test plan

- [ ] `nix build .#nixosConfigurations.harmony.config.system.build.toplevel` (could not run in this sandbox — no `nix` binary available in the execution environment; validated separately on harmony itself)
- [ ] Reboot harmony into the fixed generation and confirm it boots cleanly
- [ ] Confirm a future new dataset addition + reboot no longer breaks boot

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfAJVq5vW7WQCbzMB3gej4)_