### PR TITLE
Fix Immich login hang: nginx duplicating cookie security flags

### DIFF
--- a/modules/aspects/my/immich.nix
+++ b/modules/aspects/my/immich.nix
@@ -11,6 +11,11 @@ in
       # Immich's frontend opens a WebSocket right after login for real-time updates (job
       # progress, live sync); without this the connection silently fails and the UI hangs.
       websockets = true;
+      # Immich sets its own secure/HttpOnly/SameSite flags on its session cookie. Without this,
+      # nginx's blanket cookie rewrite appends a second, duplicate set of those flags, producing
+      # a malformed Set-Cookie the browser silently refuses to store — login succeeds server-side
+      # but the session never sticks, so the UI hangs forever waiting for one that never arrives.
+      preserveCookieFlags = true;
     };
 
     homepage-entry = {

--- a/modules/aspects/my/nginx.nix
+++ b/modules/aspects/my/nginx.nix
@@ -60,6 +60,15 @@
               lib.nameValuePair host.url {
                 forceSSL = true;
                 enableACME = true;
+                # appendHttpConfig's proxy_cookie_path rewrite appends its own secure/HttpOnly/
+                # SameSite flags to every Set-Cookie header, even ones a backend already set its
+                # own correct flags on. That produces a Set-Cookie with duplicated attributes,
+                # which browsers can silently refuse to store — breaking login for any backend
+                # that manages its own cookie security (e.g. Immich). Opt out per host via
+                # `preserveCookieFlags = true;` on the `virtual-host` record.
+                extraConfig = lib.optionalString (host.preserveCookieFlags or false) ''
+                  proxy_cookie_path / /;
+                '';
                 locations = {
                   "/" = {
                     proxyPass = "http://127.0.0.1:${toString host.port}/";


### PR DESCRIPTION
## Summary

- Even after ruling out websockets, service workers, and stale account state (reproduced on a fully fresh Immich install — wiped DB, brand-new admin account, identical symptoms), Immich's login still hung: `/login` returns `201` with a valid session, no pending requests, no console errors, no websocket activity — but the UI never progresses.
- Matches a known Immich issue: [immich-app/immich#19020](https://github.com/immich-app/immich/discussions/19020). Immich sets its own `secure`/`HttpOnly`/`SameSite` flags on its session cookie. `nginx.nix`'s `appendHttpConfig` has a `proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";` rewrite that appends a *second*, duplicate set of those same flags on top of whatever the backend already set. The resulting malformed `Set-Cookie` header gets silently dropped by the browser — the login request succeeds, but the session cookie never actually sticks, so the frontend waits forever for a session that will never arrive.
- Same root-cause pattern as #477 (Authentik's CSRF cookie), just a different symptom this time — this line has now broken two services that manage their own cookie security correctly.
- Fix: add `preserveCookieFlags` as a per-host opt-out on the `virtual-host` record, mirroring the existing `protected`/`websockets` pattern, and set it for Immich. Scoped rather than global — services that don't set their own cookie flags (most of the *arr stack, qBittorrent, etc.) still benefit from nginx enforcing them by default.

## Test plan

- [x] `nix eval` confirms Immich's vhost gets `extraConfig = "proxy_cookie_path / /;"` while an unrelated host (Radarr) has none — opt-in is correctly scoped.
- [ ] `nixos-rebuild switch --flake .#harmony`, then confirm both OAuth and password login in Immich actually complete and land in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)