### PR TITLE
Add Seerr media request manager on harmony

### DIFF
--- a/modules/aspects/hosts/harmony/harmony.nix
+++ b/modules/aspects/hosts/harmony/harmony.nix
@@ -23,6 +23,7 @@
       (radarr { administrators = [ "oscar" ]; })
       samba
       satisfactory-server
+      seerr
       (sonarr { administrators = [ "oscar" ]; })
       ssh-server
       unpackerr

--- a/modules/aspects/my/seerr.nix
+++ b/modules/aspects/my/seerr.nix
@@ -1,0 +1,24 @@
+let
+  url = "seerr.harmony.silverlight-nex.us";
+  port = 5055;
+in
+{
+  my.seerr = {
+    virtual-host = {
+      name = "seerr";
+      inherit url port;
+    };
+
+    homepage-entry = {
+      group = "Media";
+      label = "Seerr";
+      description = "Media requests";
+      href = "https://${url}";
+    };
+
+    nixos.services.seerr = {
+      enable = true;
+      inherit port;
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a `seerr` aspect (`modules/aspects/my/seerr.nix`) reverse-proxied at `seerr.harmony.silverlight-nex.us` (port 5055) via `services.seerr`
- Includes it on the `harmony` host and adds a "Media" homepage-dashboard entry (no widget, since Seerr issues its own API key via a first-run setup wizard rather than an env var)

## Why Seerr (not Overseerr/Jellyseerr)
Seerr is the new merged Overseerr+Jellyseerr project — one codebase, supports Plex, Jellyfin, and Emby. Harmony only runs Plex today, and Seerr's Plex support matches Overseerr's original scope while keeping the door open for Jellyfin later.

## Notes for reviewer
- Config evaluates cleanly (`nix eval` verified `services.seerr`, the nginx vhost, and the homepage-dashboard entry); a full `nixos-rebuild`/`nix build` of harmony's toplevel wasn't runnable from this aarch64-darwin sandbox because an unrelated home-manager `doom-emacs` derivation requires an x86_64-linux builder — pre-existing, unrelated to this change.
- After merging and rebuilding harmony, the first-run setup wizard at `https://seerr.harmony.silverlight-nex.us` still needs to be completed manually (connect to Plex, point at Radarr/Sonarr).
- If a homepage widget is wanted later, Seerr's API key (from Settings → General post-setup) can be wired in the same way radarr/sonarr's keys are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)