### PR TITLE
Put remaining harmony services behind Authentik SSO

### DIFF
--- a/modules/aspects/my/autobrr.nix
+++ b/modules/aspects/my/autobrr.nix
@@ -7,6 +7,7 @@
       virtual-host = {
         name = "autobrr";
         url = "autobrr.harmony.silverlight-nex.us";
+        protected = true;
         inherit port;
       };
 

--- a/modules/aspects/my/homepage.nix
+++ b/modules/aspects/my/homepage.nix
@@ -9,6 +9,7 @@ in
     virtual-host = {
       name = "homepage";
       url = "harmony.silverlight-nex.us";
+      protected = true;
       inherit port;
     };
 

--- a/modules/aspects/my/nginx.nix
+++ b/modules/aspects/my/nginx.nix
@@ -106,6 +106,18 @@
                       '';
                     };
                   }
+                  // lib.optionalAttrs (host.protected or false) (
+                    lib.listToAttrs (
+                      map (
+                        path:
+                        lib.nameValuePair "~ ${path}" {
+                          # No URI on proxyPass: regex locations can't auto-rewrite the matched path, so this
+                          # forwards the original path+query untouched, without the auth_request config below.
+                          proxyPass = "http://127.0.0.1:${toString host.port}";
+                        }
+                      ) (host.bypassAuthPaths or [ ])
+                    )
+                  )
                   // lib.optionalAttrs (host.protected or false) {
                     "@goauthentik_proxy_signin" = {
                       extraConfig = ''

--- a/modules/aspects/my/profilarr.nix
+++ b/modules/aspects/my/profilarr.nix
@@ -12,6 +12,7 @@
 
       virtual-host = {
         name = "profilarr";
+        protected = true;
         inherit url port;
       };
 

--- a/modules/aspects/my/prowlarr.nix
+++ b/modules/aspects/my/prowlarr.nix
@@ -7,6 +7,15 @@
     {
       virtual-host = {
         name = "prowlarr";
+        protected = true;
+        # Prowlarr serves its own REST API under /api, and proxies per-indexer Torznab requests
+        # under /<indexerId>/api; nginx.nix lets both through the Authentik forward-auth gate
+        # untouched since cross-seed calls them directly with an API key, machine-to-machine, with
+        # no browser session to carry an Authentik cookie.
+        bypassAuthPaths = [
+          "^/api"
+          "^/[0-9]+/api"
+        ];
         inherit url port;
       };
 
@@ -17,7 +26,9 @@
         href = "https://${url}";
         widget = {
           type = "prowlarr";
-          url = "https://${url}";
+          # Hit Prowlarr directly rather than through nginx/Authentik, since Homepage's server-side
+          # widget fetch has no browser session to pass the forward-auth gate.
+          url = "http://127.0.0.1:${toString port}";
           key = "{{HOMEPAGE_VAR_PROWLARR_API_KEY}}";
         };
       };
@@ -46,7 +57,14 @@
         services = {
           prowlarr = {
             enable = true;
-            settings.server = { inherit port; };
+            settings = {
+              server = { inherit port; };
+              # Prowlarr only reaches this vhost via nginx over loopback (its port isn't opened in
+              # the firewall), so every request it sees is "local" — this drops Prowlarr's own
+              # login screen in favor of the Authentik forward-auth gate in front of it, rather
+              # than stacking both.
+              auth.required = "DisabledForLocalAddresses";
+            };
             environmentFiles = [ config.age.secrets."prowlarr.env".path ];
           };
           flaresolverr.enable = true;

--- a/modules/aspects/my/qbittorrent.nix
+++ b/modules/aspects/my/qbittorrent.nix
@@ -8,6 +8,7 @@ in
     virtual-host = {
       name = "qbittorrent";
       url = "qbittorrent.harmony.silverlight-nex.us";
+      protected = true;
       inherit port;
     };
 

--- a/modules/aspects/my/radarr.nix
+++ b/modules/aspects/my/radarr.nix
@@ -7,6 +7,11 @@ in
   my.radarr = { administrators }: {
     virtual-host = {
       name = "radarr";
+      protected = true;
+      # Radarr serves its REST API under /api; nginx.nix lets that through the Authentik
+      # forward-auth gate untouched since cross-seed/unpackerr call it directly with an API key,
+      # machine-to-machine, with no browser session to carry an Authentik cookie.
+      bypassAuthPaths = [ "^/api" ];
       inherit url port;
     };
 
@@ -17,7 +22,9 @@ in
       href = "https://${url}";
       widget = {
         type = "radarr";
-        url = "https://${url}";
+        # Hit Radarr directly rather than through nginx/Authentik, since Homepage's server-side
+        # widget fetch has no browser session to pass the forward-auth gate.
+        url = "http://127.0.0.1:${toString port}";
         key = "{{HOMEPAGE_VAR_RADARR_API_KEY}}";
         enableQueue = true;
       };
@@ -54,6 +61,10 @@ in
       services.radarr = {
         enable = true;
         environmentFiles = [ config.age.secrets."radarr.env".path ];
+        # Radarr only reaches this vhost via nginx over loopback (its port isn't opened in the
+        # firewall), so every request it sees is "local" — this drops Radarr's own login screen in
+        # favor of the Authentik forward-auth gate in front of it, rather than stacking both.
+        settings.auth.required = "DisabledForLocalAddresses";
       };
     };
   };

--- a/modules/aspects/my/sonarr.nix
+++ b/modules/aspects/my/sonarr.nix
@@ -7,6 +7,11 @@
     { administrators }: {
       virtual-host = {
         name = "sonarr";
+        protected = true;
+        # Sonarr serves its REST API under /api; nginx.nix lets that through the Authentik
+        # forward-auth gate untouched since cross-seed/unpackerr call it directly with an API key,
+        # machine-to-machine, with no browser session to carry an Authentik cookie.
+        bypassAuthPaths = [ "^/api" ];
         inherit url port;
       };
 
@@ -17,7 +22,9 @@
         href = "https://${url}";
         widget = {
           type = "sonarr";
-          url = "https://${url}";
+          # Hit Sonarr directly rather than through nginx/Authentik, since Homepage's server-side
+          # widget fetch has no browser session to pass the forward-auth gate.
+          url = "http://127.0.0.1:${toString port}";
           key = "{{HOMEPAGE_VAR_SONARR_API_KEY}}";
           enableQueue = true;
         };
@@ -54,6 +61,10 @@
         services.sonarr = {
           enable = true;
           environmentFiles = [ config.age.secrets."sonarr.env".path ];
+          # Sonarr only reaches this vhost via nginx over loopback (its port isn't opened in the
+          # firewall), so every request it sees is "local" — this drops Sonarr's own login screen
+          # in favor of the Authentik forward-auth gate in front of it, rather than stacking both.
+          settings.auth.required = "DisabledForLocalAddresses";
         };
       };
     };


### PR DESCRIPTION
## Summary

- Adds `protected = true` to qBittorrent, Profilarr, Autobrr, and Homepage's `virtual-host`, gating them behind Authentik forward-auth (same mechanism already used by Netdata).
- Adds a `bypassAuthPaths` escape hatch to `my.nginx`'s protected-vhost handling, and uses it on Sonarr, Radarr, and Prowlarr to exempt their REST API paths (`/api`, and Prowlarr's `/<indexerId>/api`) from the forward-auth gate, since `cross-seed` and `unpackerr` call those over the public HTTPS URL with an API key, machine-to-machine, with no browser session.
- Switches Homepage's Sonarr/Radarr/Prowlarr widget URLs to hit each app's local port directly (`http://127.0.0.1:<port>`), matching the existing Netdata pattern, so the server-side widget fetch doesn't rely on the bypass regex.
- Sets `settings.auth.required = "DisabledForLocalAddresses"` on Sonarr, Radarr, and Prowlarr so their own built-in login screen no longer double-prompts on top of Authentik — these apps only see requests via nginx over loopback (their ports aren't opened in the firewall), so Authentik ends up as the single SSO gate.

Immich is left alone since it already has native Authentik OIDC login, and Plex is left alone since its mobile/TV/cast apps authenticate directly against the server via plex.tv tokens rather than a browser session — forward-auth would break those clients.

qBittorrent, Autobrr, and Profilarr still have their own separate app-level logins that this PR doesn't address; bypassing qBittorrent's in particular depends on how its container networking (it shares gluetun's netns) presents the source IP, which needs testing directly on `harmony`.

## Test plan

- [x] `nix eval` on `nixosConfigurations.harmony` for `services.nginx.virtualHosts.*.locations`, confirming the expected `~ ^/api` (and Prowlarr's `~ ^/[0-9]+/api`) regex locations appear only on the three arr-stack hosts, and are absent from the simple `protected` hosts.
- [x] `nix eval` on `systemd.services.{sonarr,radarr,prowlarr}.environment`, confirming `<APP>__AUTH__REQUIRED=DisabledForLocalAddresses` renders correctly alongside the existing settings.
- [x] `nix fmt` — no changes.
- [ ] Full `nixos-rebuild build`/`switch` for `harmony` (x86_64-linux) isn't possible from this aarch64-darwin sandbox without a matching remote builder — needs to be applied and spot-checked on `harmony` directly: each newly protected service redirects to Authentik login and loads without a second app-level login; `cross-seed`/`unpackerr` logs show no new auth failures; Homepage's arr-stack widgets still populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)