### PR TITLE
Switch system font to Maple Mono, pair with Inter

### DIFF
--- a/modules/aspects/my/emacs/doom/config.el
+++ b/modules/aspects/my/emacs/doom/config.el
@@ -25,8 +25,8 @@
 ;;
 ;; They all accept either a font-spec, font string ("Input Mono-12"), or xlfd
 ;; font string. You generally only need these two:
-(setq doom-font "Fira Code-12" ;(font-spec :family "Fira Code" :size 12)
-      doom-variable-pitch-font (font-spec :family "Helvetica Neue" :size 13))
+(setq doom-font "Maple Mono NF-12" ;(font-spec :family "Maple Mono NF" :size 12)
+      doom-variable-pitch-font (font-spec :family "Inter" :size 13))
 
 ;; There are two ways to load a theme. Both assume the theme is installed and
 ;; available. You can either set `doom-theme' or manually load a theme with the

--- a/modules/aspects/my/fonts.nix
+++ b/modules/aspects/my/fonts.nix
@@ -1,8 +1,7 @@
 {
   my.fonts.os = { pkgs, ... }: {
     fonts.packages = with pkgs; [
-      fira-code
-      nerd-fonts.fira-code
+      maple-mono.NF
       nerd-fonts.symbols-only
     ];
   };

--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -158,12 +158,12 @@ in
 
         stylix.fonts = {
           monospace = {
-            package = pkgs.nerd-fonts.fira-code;
-            name = "FiraCode Nerd Font Mono";
+            package = pkgs.maple-mono.NF;
+            name = "Maple Mono NF";
           };
           sansSerif = {
-            package = pkgs.fira;
-            name = "Fira Sans";
+            package = pkgs.inter;
+            name = "Inter";
           };
         };
       };


### PR DESCRIPTION
## Summary
- Replace FiraCode Nerd Font with [Maple Mono](https://github.com/subframe7536/maple-font) (`maple-mono.NF`) as the system monospace font — used by Stylix (terminals, GTK apps) and the installed `fonts.packages`.
- Switch Doom Emacs's `doom-font` to the same `Maple Mono NF` variant so nerd-icons/doom-modeline glyphs keep rendering.
- Replace Fira Sans with **Inter** as the sans-serif font (Stylix `sansSerif` + Doom's `doom-variable-pitch-font`), chosen as a more neutral/legible UI pairing.

## Test plan
- [x] `nix build .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel` succeeds
- [x] Verified via `nix eval` that Stylix's home-manager module installs the referenced `maple-mono.NF` and `inter` packages into `home.packages` automatically
- [ ] `darwin-rebuild switch` on OMARSHAL-M-T2QF and confirm Ghostty/Emacs render the new fonts as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)