### PR TITLE
Have minecraft-servers, storyteller, and bookshelf self-declare their ZFS datasets

### DIFF
--- a/modules/aspects/hosts/harmony/harmony.nix
+++ b/modules/aspects/hosts/harmony/harmony.nix
@@ -46,7 +46,6 @@
         [
           "backups"
           "documents"
-          "minecraft-worlds"
           "movies"
           "music"
           "pictures"

--- a/modules/aspects/my/bookshelf.nix
+++ b/modules/aspects/my/bookshelf.nix
@@ -17,6 +17,11 @@ let
       url = "${name}.harmony.silverlight-nex.us";
     in
     {
+      dataset = {
+        pool = "metalminds";
+        inherit name;
+      };
+
       virtual-host = {
         inherit name url port;
         protected = true;

--- a/modules/aspects/my/minecraft-servers.nix
+++ b/modules/aspects/my/minecraft-servers.nix
@@ -22,6 +22,13 @@
       ])
     ];
 
+    dataset = {
+      pool = "metalminds";
+      name = "minecraft-worlds";
+      samba = true;
+      guestAccess = true;
+    };
+
     secrets = { secrets, ... }: {
       "minecraft-servers.env".generator = {
         dependencies = { inherit (secrets) oscar-password; };

--- a/modules/aspects/my/storyteller.nix
+++ b/modules/aspects/my/storyteller.nix
@@ -5,6 +5,11 @@
       port = 8001;
     in
     {
+      dataset = {
+        pool = "metalminds";
+        name = "storyteller";
+      };
+
       virtual-host = {
         name = "storyteller";
         inherit url port;


### PR DESCRIPTION
## Summary
- `minecraft-servers` used `/metalminds/minecraft-worlds` but relied on `harmony.nix` manually listing `"minecraft-worlds"` in its host-level `dataset` array, instead of declaring the dataset itself the way `nextcloud`/`profilarr`/`satisfactory-server` do. It now self-declares `dataset = { pool = "metalminds"; name = "minecraft-worlds"; samba = true; guestAccess = true; }`, and the now-redundant entry was removed from `harmony.nix`.
- While auditing every `/metalminds/*` consumer against the `dataset` quirk, found two more aspects with no dataset declared anywhere: `storyteller` and both `bookshelf` instances (`bookshelf-audiobooks`, `bookshelf-ebooks`). Their data would have lived as plain directories under the `metalminds` pool root rather than getting their own ZFS dataset. Both now self-declare `dataset = { pool = "metalminds"; name = "..."; }`.
- Confirmed the remaining `/metalminds/*` paths (movies, music, shows, pictures, torrents, backups, documents, yarg-charts) are genuinely shared/ownerless Samba folders correctly left in `harmony.nix`'s host-level list — not gaps.

## Test plan
- [x] `nix eval .#nixosConfigurations.harmony.config.system.activationScripts.zfsDatasets` includes `metalminds/minecraft-worlds`, `metalminds/storyteller`, `metalminds/bookshelf-audiobooks`, `metalminds/bookshelf-ebooks`
- [x] `nix eval .#nixosConfigurations.harmony.config.services.samba.settings` still exposes an unchanged `minecraft-worlds` share (path, guest access, write list)
- [x] `nix fmt` reports no changes needed
- [ ] Full `nixos-rebuild switch` on harmony not run from this session (cross-build from aarch64-darwin hits an unrelated pre-existing IFD limitation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)