### PR TITLE
Build Programmer Dvorak with Nix instead of the broken Homebrew cask

### DIFF
--- a/modules/aspects/my/programmer-dvorak.nix
+++ b/modules/aspects/my/programmer-dvorak.nix
@@ -33,14 +33,19 @@
         # macOS caches the list of installed keyboard layouts (com.apple.IntlDataCache.le*) and
         # only rescans it at boot, so a newly (un)installed .bundle won't show up in System
         # Settings -> Keyboard -> Input Sources until the cache is cleared and the machine is
-        # rebooted.
+        # rebooted. Only clear it (and touch the installed bundle at all) when the bundle
+        # actually changed, so unrelated `darwin-rebuild switch` runs are true no-ops. The new
+        # bundle is staged at a sibling path first and swapped in with `mv` so the installed
+        # bundle is never left half-written if the copy is interrupted.
         system.activationScripts.postActivation.text = ''
-          rm -f /System/Library/Caches/com.apple.IntlDataCache.le*
-          rm -f /private/var/folders/*/*/C/com.apple.IntlDataCache.le*
-
           if ! diff -rq "${bundle}/Library/Keyboard Layouts/Programmer Dvorak.bundle" "/Library/Keyboard Layouts/Programmer Dvorak.bundle" >/dev/null 2>&1; then
+            rm -f /System/Library/Caches/com.apple.IntlDataCache.le*
+            rm -f /private/var/folders/*/*/C/com.apple.IntlDataCache.le*
+
+            rm -rf "/Library/Keyboard Layouts/Programmer Dvorak.bundle.new"
+            cp -R "${bundle}/Library/Keyboard Layouts/Programmer Dvorak.bundle" "/Library/Keyboard Layouts/Programmer Dvorak.bundle.new"
             rm -rf "/Library/Keyboard Layouts/Programmer Dvorak.bundle"
-            cp -R "${bundle}/Library/Keyboard Layouts/Programmer Dvorak.bundle" "/Library/Keyboard Layouts/Programmer Dvorak.bundle"
+            mv "/Library/Keyboard Layouts/Programmer Dvorak.bundle.new" "/Library/Keyboard Layouts/Programmer Dvorak.bundle"
           fi
         '';
       };

--- a/modules/aspects/my/programmer-dvorak.nix
+++ b/modules/aspects/my/programmer-dvorak.nix
@@ -1,17 +1,49 @@
 {
   my.programmer-dvorak = {
-    # macOS caches the list of installed keyboard layouts (com.apple.IntlDataCache.le*) and only
-    # rescans it at boot, so a newly (un)installed .bundle won't show up in System Settings ->
-    # Keyboard -> Input Sources until the cache is cleared and the machine is rebooted.
-    darwin.system.activationScripts.postActivation.text = ''
-      rm -f /System/Library/Caches/com.apple.IntlDataCache.le*
-      rm -f /private/var/folders/*/*/C/com.apple.IntlDataCache.le*
-    '';
+    # macOS ships plain Dvorak but not Programmer Dvorak. Upstream publishes it only as a
+    # Homebrew cask (https://formulae.brew.sh/cask/programmer-dvorak), but that cask's
+    # `container nested:` pkg archive isn't extracted correctly by `brew install`/`brew bundle`
+    # as of Homebrew 6.0.10 (https://github.com/Homebrew/brew/issues/23094), which always
+    # leaves the bundle missing. So the same upstream .pkg.zip is unpacked here with Nix instead
+    # and copied into place system-wide (rather than per-user), which is also a commonly cited
+    # workaround for third-party keyboard layout flakiness with sandboxed apps like Safari.
+    darwin =
+      { pkgs, ... }:
+      let
+        bundle =
+          pkgs.runCommand "programmer-dvorak-bundle"
+            {
+              nativeBuildInputs = [
+                pkgs.unzip
+                pkgs.libarchive
+              ];
+            }
+            ''
+              unzip -q ${
+                pkgs.fetchurl {
+                  url = "https://www.kaufmann.no/downloads/macos/ProgrammerDvorak-1_2_13.pkg.zip";
+                  sha256 = "sha256-hC/69xSqrJGwKHxORXbxi+G/wyaTcJWToRhXKnzHgAY=";
+                }
+              } -d extracted
+              mkdir -p $out
+              bsdtar -xf "extracted/Programmer Dvorak v1.2.pkg/Contents/Archive.pax.gz" -C $out
+            '';
+      in
+      {
+        # macOS caches the list of installed keyboard layouts (com.apple.IntlDataCache.le*) and
+        # only rescans it at boot, so a newly (un)installed .bundle won't show up in System
+        # Settings -> Keyboard -> Input Sources until the cache is cleared and the machine is
+        # rebooted.
+        system.activationScripts.postActivation.text = ''
+          rm -f /System/Library/Caches/com.apple.IntlDataCache.le*
+          rm -f /private/var/folders/*/*/C/com.apple.IntlDataCache.le*
 
-    # macOS ships plain Dvorak but not Programmer Dvorak, so it's installed via the Homebrew cask
-    # (https://formulae.brew.sh/cask/programmer-dvorak), which places the bundle in the
-    # system-wide /Library/Keyboard Layouts rather than per-user.
-    darwin.homebrew.casks = [ "programmer-dvorak" ];
+          if ! diff -rq "${bundle}/Library/Keyboard Layouts/Programmer Dvorak.bundle" "/Library/Keyboard Layouts/Programmer Dvorak.bundle" >/dev/null 2>&1; then
+            rm -rf "/Library/Keyboard Layouts/Programmer Dvorak.bundle"
+            cp -R "${bundle}/Library/Keyboard Layouts/Programmer Dvorak.bundle" "/Library/Keyboard Layouts/Programmer Dvorak.bundle"
+          fi
+        '';
+      };
 
     # xkeyboard-config's "us" layout, "dvp" variant is Programmer Dvorak. Listing it as a second
     # GNOME input source (rather than replacing "us") keeps English (US) the default and current


### PR DESCRIPTION
## Summary
- `darwin-rebuild switch` was failing during `brew bundle` because the `programmer-dvorak` Homebrew cask's `container nested:` pkg archive isn't extracted correctly by `brew install`/`brew bundle` as of Homebrew 6.0.10 — filed upstream as [Homebrew/brew#23094](https://github.com/Homebrew/brew/issues/23094).
- Replaces the cask with a Nix derivation that fetches the same upstream `.pkg.zip` and unpacks the nested `Archive.pax.gz` itself (`unzip` + `bsdtar` from `libarchive`), producing a byte-identical `Programmer Dvorak.bundle`.
- The bundle is copied into `/Library/Keyboard Layouts/` (system-wide) by a `postActivation` script, keeping the system-wide placement from #493 that works around sandboxed-app keyboard-layout flakiness (e.g. Safari), without depending on Homebrew's broken extraction.
- The copy is idempotent (`diff -rq` guard) so repeated `darwin-rebuild switch`/`nh darwin switch` runs don't rewrite the bundle — and therefore don't trigger the keyboard-layout cache invalidation — unless the bundle content actually changes.

## Test plan
- [x] `nix build .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel` succeeds and produces the expected `Library/Keyboard Layouts/Programmer Dvorak.bundle` contents in the Nix store.
- [ ] `sudo darwin-rebuild switch --flake .#OMARSHAL-M-T2QF` applies cleanly and installs the layout (requires a reboot afterward for it to appear in System Settings → Keyboard → Input Sources, per the existing cache caveat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)