### PR TITLE
Revert "Build Programmer Dvorak with Nix instead of the broken Homebrew cask" (#496)

### DIFF
--- a/modules/aspects/my/programmer-dvorak.nix
+++ b/modules/aspects/my/programmer-dvorak.nix
@@ -1,54 +1,17 @@
 {
   my.programmer-dvorak = {
-    # macOS ships plain Dvorak but not Programmer Dvorak. Upstream publishes it only as a
-    # Homebrew cask (https://formulae.brew.sh/cask/programmer-dvorak), but that cask's
-    # `container nested:` pkg archive isn't extracted correctly by `brew install`/`brew bundle`
-    # as of Homebrew 6.0.10 (https://github.com/Homebrew/brew/issues/23094), which always
-    # leaves the bundle missing. So the same upstream .pkg.zip is unpacked here with Nix instead
-    # and copied into place system-wide (rather than per-user), which is also a commonly cited
-    # workaround for third-party keyboard layout flakiness with sandboxed apps like Safari.
-    darwin =
-      { pkgs, ... }:
-      let
-        bundle =
-          pkgs.runCommand "programmer-dvorak-bundle"
-            {
-              nativeBuildInputs = [
-                pkgs.unzip
-                pkgs.libarchive
-              ];
-            }
-            ''
-              unzip -q ${
-                pkgs.fetchurl {
-                  url = "https://www.kaufmann.no/downloads/macos/ProgrammerDvorak-1_2_13.pkg.zip";
-                  sha256 = "sha256-hC/69xSqrJGwKHxORXbxi+G/wyaTcJWToRhXKnzHgAY=";
-                }
-              } -d extracted
-              mkdir -p $out
-              bsdtar -xf "extracted/Programmer Dvorak v1.2.pkg/Contents/Archive.pax.gz" -C $out
-            '';
-      in
-      {
-        # macOS caches the list of installed keyboard layouts (com.apple.IntlDataCache.le*) and
-        # only rescans it at boot, so a newly (un)installed .bundle won't show up in System
-        # Settings -> Keyboard -> Input Sources until the cache is cleared and the machine is
-        # rebooted. Only clear it (and touch the installed bundle at all) when the bundle
-        # actually changed, so unrelated `darwin-rebuild switch` runs are true no-ops. The new
-        # bundle is staged at a sibling path first and swapped in with `mv` so the installed
-        # bundle is never left half-written if the copy is interrupted.
-        system.activationScripts.postActivation.text = ''
-          if ! diff -rq "${bundle}/Library/Keyboard Layouts/Programmer Dvorak.bundle" "/Library/Keyboard Layouts/Programmer Dvorak.bundle" >/dev/null 2>&1; then
-            rm -f /System/Library/Caches/com.apple.IntlDataCache.le*
-            rm -f /private/var/folders/*/*/C/com.apple.IntlDataCache.le*
+    # macOS caches the list of installed keyboard layouts (com.apple.IntlDataCache.le*) and only
+    # rescans it at boot, so a newly (un)installed .bundle won't show up in System Settings ->
+    # Keyboard -> Input Sources until the cache is cleared and the machine is rebooted.
+    darwin.system.activationScripts.postActivation.text = ''
+      rm -f /System/Library/Caches/com.apple.IntlDataCache.le*
+      rm -f /private/var/folders/*/*/C/com.apple.IntlDataCache.le*
+    '';
 
-            rm -rf "/Library/Keyboard Layouts/Programmer Dvorak.bundle.new"
-            cp -R "${bundle}/Library/Keyboard Layouts/Programmer Dvorak.bundle" "/Library/Keyboard Layouts/Programmer Dvorak.bundle.new"
-            rm -rf "/Library/Keyboard Layouts/Programmer Dvorak.bundle"
-            mv "/Library/Keyboard Layouts/Programmer Dvorak.bundle.new" "/Library/Keyboard Layouts/Programmer Dvorak.bundle"
-          fi
-        '';
-      };
+    # macOS ships plain Dvorak but not Programmer Dvorak, so it's installed via the Homebrew cask
+    # (https://formulae.brew.sh/cask/programmer-dvorak), which places the bundle in the
+    # system-wide /Library/Keyboard Layouts rather than per-user.
+    darwin.homebrew.casks = [ "programmer-dvorak" ];
 
     # xkeyboard-config's "us" layout, "dvp" variant is Programmer Dvorak. Listing it as a second
     # GNOME input source (rather than replacing "us") keeps English (US) the default and current


### PR DESCRIPTION
## Summary

- Reverts #496. That PR worked around Homebrew/brew#23094 (the `programmer-dvorak` cask's nested-container archive not extracting during `brew install`/`brew bundle`) by building the keyboard layout bundle with Nix instead.
- The upstream bug is now fixed: Homebrew/brew#23100 merged and `brew install --cask programmer-dvorak` succeeds again on current Homebrew. Confirmed locally end-to-end.
- This restores `modules/aspects/my/programmer-dvorak.nix` to be byte-identical to its pre-#496 state (the original cask-based install from #493).

## Reviewer notes

- #496 was already merged into `main` (squash commit `9eb5095`) before this revert was prepared, so this is a straight `git revert 9eb5095` on top of current `main` rather than a branch edit.
- Machines that already applied #496 will have a Nix-installed bundle at `/Library/Keyboard Layouts/Programmer Dvorak.bundle`. Homebrew's cask installer refuses to overwrite an existing layout there, so that file needs a one-time manual removal (`sudo rm -rf "/Library/Keyboard Layouts/Programmer Dvorak.bundle"`) before running `darwin-rebuild switch` with this change.

## Test plan

- [x] `nix fmt` on the changed file
- [x] `nix build .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel` succeeds
- [x] Verified `brew install --cask programmer-dvorak` succeeds on current Homebrew (post Homebrew/brew#23100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)