### PR TITLE
Fix SSL_ERROR_NO_CYPHER_OVERLAP by widening nginx cipher list

### DIFF
--- a/modules/aspects/my/nginx.nix
+++ b/modules/aspects/my/nginx.nix
@@ -65,9 +65,6 @@
           recommendedProxySettings = true;
           recommendedTlsSettings = true;
 
-          # Only allow PFS-enabled ciphers with AES256
-          sslCiphers = "AES256+EECDH:AES256+EDH:!aNULL";
-
           virtualHosts = lib.listToAttrs (
             map (
               vh:


### PR DESCRIPTION
## Summary
- `nginx.nix` overrode `services.nginx.sslCiphers` with a custom OpenSSL cipher string (`AES256+EECDH:AES256+EDH:!aNULL`) restricting TLS 1.2 fallback to AES-256-only PFS ciphers, excluding AES-128-GCM and ChaCha20-Poly1305.
- Clients that can't negotiate TLS 1.3 and whose TLS 1.2 support is limited to the excluded suites (common on mobile/embedded clients without AES hardware acceleration) had zero cipher overlap with the server, producing `SSL_ERROR_NO_CYPHER_OVERLAP` when reaching any reverse-proxied webapp.
- Removing the override lets nginx fall back to nixpkgs' vetted default (Mozilla "intermediate" cipher list), which is still ECDHE/PFS-only and excludes anonymous ciphers, just with broader suite coverage (`ECDHE-*-AES128-GCM-SHA256`, `ECDHE-*-AES256-GCM-SHA384`, `ECDHE-*-CHACHA20-POLY1305`).
- Verified via `nix eval .#nixosConfigurations.harmony.config.services.nginx.sslCiphers` that the option now resolves to the expected default list.

## Test plan
- [x] `nix eval .#nixosConfigurations.harmony.config.services.nginx.sslCiphers` confirms fallback to Mozilla intermediate cipher list
- [x] `nix fmt` — no changes needed
- [ ] `sudo nixos-rebuild switch --flake .#harmony` and confirm the previously-blocked webapp now loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)