### PR TITLE
Move work Codex/ChatGPT config to my.openai, share MCP servers

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -235,6 +235,27 @@
         "type": "github"
       }
     },
+    "codex-cli-nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784011846,
+        "narHash": "sha256-ZwToJMUbcoTxdLV7KKWUQp3b1bL3oCy+/utM4OyaPJ4=",
+        "owner": "sadjow",
+        "repo": "codex-cli-nix",
+        "rev": "be1c5810b72def4f03b92c6717df97480f318796",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sadjow",
+        "repo": "codex-cli-nix",
+        "type": "github"
+      }
+    },
     "crane": {
       "locked": {
         "lastModified": 1760924934,
@@ -683,7 +704,25 @@
     },
     "flake-utils_4": {
       "inputs": {
-        "systems": "systems_5"
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "inputs": {
+        "systems": "systems_6"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -1161,7 +1200,7 @@
     "opam-nix": {
       "inputs": {
         "flake-compat": "flake-compat_6",
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_4",
         "mirage-opam-overlays": "mirage-opam-overlays",
         "nixpkgs": [
           "nix-logseq-git-flake",
@@ -1230,7 +1269,7 @@
           "opam-nix",
           "nixpkgs"
         ],
-        "systems": "systems_4"
+        "systems": "systems_5"
       },
       "locked": {
         "lastModified": 1782276984,
@@ -1323,7 +1362,7 @@
       "inputs": {
         "agenix": "agenix",
         "crane": "crane",
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_5",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -1349,6 +1388,7 @@
         "authentik-nix": "authentik-nix",
         "catppuccin-wallpapers": "catppuccin-wallpapers",
         "claude-code-nix": "claude-code-nix",
+        "codex-cli-nix": "codex-cli-nix",
         "darwin": "darwin",
         "den": "den",
         "flake-compat": "flake-compat_3",
@@ -1366,7 +1406,7 @@
         "nixpkgs": "nixpkgs_2",
         "ragenix": "ragenix",
         "stylix": "stylix",
-        "systems": "systems_7",
+        "systems": "systems_8",
         "terranix": "terranix",
         "treefmt-nix": "treefmt-nix_2",
         "zen-browser": "zen-browser"
@@ -1406,7 +1446,7 @@
           "nixpkgs"
         ],
         "nur": "nur",
-        "systems": "systems_6",
+        "systems": "systems_7",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
@@ -1546,13 +1586,28 @@
         "type": "github"
       }
     },
+    "systems_9": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "terranix": {
       "inputs": {
         "flake-parts": "flake-parts_7",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_8"
+        "systems": "systems_9"
       },
       "locked": {
         "lastModified": 1779965098,

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,10 @@
       url = "github:sadjow/claude-code-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    codex-cli-nix = {
+      url = "github:sadjow/codex-cli-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     darwin = {
       url = "github:nix-darwin/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/aspects/my/claude.nix
+++ b/modules/aspects/my/claude.nix
@@ -1,21 +1,24 @@
-{ den, inputs, ... }: {
+{
+  den,
+  inputs,
+  my,
+  ...
+}:
+{
   flake-file.inputs.claude-code-nix = {
     url = "github:sadjow/claude-code-nix";
     inputs.nixpkgs.follows = "nixpkgs";
   };
 
   my.claude = {
-    includes = [ (den._.unfree [ "claude-code" ]) ];
+    includes = [
+      (den._.unfree [ "claude-code" ])
+      my.mcp-servers
+    ];
 
     darwin.homebrew.casks = [ "claude" ];
 
-    homeManager = { config, pkgs, ... }: {
-      # Declared here (not in a top-level secrets block) so it lands in the
-      # home-manager config's age.secrets, which is what config.age.secrets
-      # refers to inside homeManager modules. The secrets block in user-level
-      # aspects isn't forwarded to age.secrets per defaults.nix.
-      age.secrets.github-mcp-server-github-access-token.rekeyFile = ../../../secrets/github-mcp-server-github-access-token.age;
-
+    homeManager = { pkgs, ... }: {
       home.packages = with pkgs; [
         gh
         nodejs
@@ -27,6 +30,7 @@
       programs.claude-code = {
         enable = true;
         package = inputs.claude-code-nix.packages.${pkgs.stdenv.hostPlatform.system}.claude-code;
+        enableMcpIntegration = true;
 
         settings = {
           agentPushNotifEnabled = true;
@@ -38,29 +42,6 @@
               "Bash(git:*)"
               "Bash(nix:*)"
             ];
-          };
-        };
-
-        mcpServers = {
-          nixos = {
-            type = "stdio";
-            command = "${pkgs.mcp-nixos}/bin/mcp-nixos";
-          };
-
-          github = {
-            type = "stdio";
-            # MCP server configs are static JSON, so the token can't be
-            # referenced directly — a wrapper reads the agenix path at launch.
-            command = "${pkgs.writeShellScript "github-mcp-server-wrapper" ''
-              set -euo pipefail
-              export GITHUB_PERSONAL_ACCESS_TOKEN="$(cat ${config.age.secrets.github-mcp-server-github-access-token.path})"
-              exec ${pkgs.github-mcp-server}/bin/github-mcp-server stdio
-            ''}";
-          };
-
-          context7 = {
-            type = "stdio";
-            command = "${pkgs.context7-mcp}/bin/context7-mcp";
           };
         };
       };

--- a/modules/aspects/my/mcp-servers.nix
+++ b/modules/aspects/my/mcp-servers.nix
@@ -1,0 +1,25 @@
+{ ... }: {
+  my.mcp-servers.homeManager = { config, pkgs, ... }: {
+    # Declared here (not in a top-level secrets block) so it lands in the
+    # home-manager config's age.secrets, which is what config.age.secrets
+    # refers to inside homeManager modules. The secrets block in user-level
+    # aspects isn't forwarded to age.secrets per defaults.nix.
+    age.secrets.github-mcp-server-github-access-token.rekeyFile = ../../../secrets/github-mcp-server-github-access-token.age;
+
+    programs.mcp = {
+      enable = true;
+
+      servers = {
+        nixos.command = "${pkgs.mcp-nixos}/bin/mcp-nixos";
+
+        github = {
+          command = "${pkgs.github-mcp-server}/bin/github-mcp-server";
+          args = [ "stdio" ];
+          env.GITHUB_PERSONAL_ACCESS_TOKEN.file = config.age.secrets.github-mcp-server-github-access-token.path;
+        };
+
+        context7.command = "${pkgs.context7-mcp}/bin/context7-mcp";
+      };
+    };
+  };
+}

--- a/modules/aspects/my/openai.nix
+++ b/modules/aspects/my/openai.nix
@@ -1,0 +1,31 @@
+{
+  den,
+  inputs,
+  lib,
+  my,
+  ...
+}:
+{
+  flake-file.inputs.codex-cli-nix = {
+    url = "github:sadjow/codex-cli-nix";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  my.openai =
+    {
+      chatgpt ? false,
+    }:
+    {
+      includes = [ my.mcp-servers ] ++ lib.optional chatgpt (den._.unfree [ "chatgpt" ]);
+
+      homeManager = { pkgs, ... }: {
+        programs.codex = {
+          enable = true;
+          package = inputs.codex-cli-nix.packages.${pkgs.stdenv.hostPlatform.system}.codex;
+          enableMcpIntegration = true;
+        };
+
+        home.packages = lib.optional chatgpt pkgs.chatgpt;
+      };
+    };
+}

--- a/modules/aspects/users/oscar/work/work.nix
+++ b/modules/aspects/users/oscar/work/work.nix
@@ -5,16 +5,20 @@
   ...
 }:
 let
+  # `home` is checked before `host`: a standalone home named `user@undeclared-host`
+  # (e.g. dev203) gets a synthetic `host = { name = ...; }` from den purely so
+  # host-keyed cross-entity policies can match on `host.name` - it never carries
+  # `work`/`graphical`. The real attributes always live on `home` for those.
   scopeFromArgs =
     {
       host ? null,
       home ? null,
       ...
     }@args:
-    if host != null then
-      host
-    else if home != null then
+    if home != null then
       home
+    else if host != null then
+      host
     else
       args;
 in
@@ -26,18 +30,14 @@ in
     in
     {
       includes = lib.optionals (scope.work or false) (
-        builtins.attrValues den.aspects.oscar.provides.work.provides ++ (lib.optional (scope.graphical or false) my.slack)
+        builtins.attrValues den.aspects.oscar.provides.work.provides
+        ++ (lib.optional (scope.graphical or false) my.slack)
+        ++ [ (my.openai { chatgpt = scope.graphical or false; }) ]
       );
 
-      darwin.homebrew.casks = lib.optionals ((scope.work or false) && (scope.graphical or false)) [ "codex-app" ];
-
-      homeManager = { pkgs, ... }: {
-        home.packages = lib.optional (scope.work or false) pkgs.codex;
-
-        services.proton-pass-agent.extraArgs = lib.optionals (!(scope.work or false)) [
-          "--vault-name"
-          "Personal"
-        ];
-      };
+      homeManager.services.proton-pass-agent.extraArgs = lib.optionals (!(scope.work or false)) [
+        "--vault-name"
+        "Personal"
+      ];
     };
 }


### PR DESCRIPTION
## Summary

- Replace the `codex-app` Homebrew cask + nixpkgs `pkgs.codex` on the work profile with a new `my.openai` aspect (only included by `den.aspects.oscar.provides.work`). It installs the ChatGPT desktop app from nixpkgs (graphical work hosts only) and Codex CLI from [`github:sadjow/codex-cli-nix`](https://github.com/sadjow/codex-cli-nix), configured via home-manager's `programs.codex`.
- Fix a latent bug in `work.nix`'s `scopeFromArgs`: it checked `host != null` before `home != null`, but den synthesizes a bare `host = { name = ...; }` context for standalone homes named `user@undeclared-host` (e.g. `omarshal@dev203.meraki.com`) purely so host-keyed cross-entity policies can match on `host.name`. That synthetic host never carries `work`/`graphical`, so dev203 was silently never getting `work`-gated config (Codex, Slack, etc.) even though `den.homes...work = true` was set. Swapped the priority so `home` wins when present.
- Extract a shared `my.mcp-servers` aspect around home-manager's `programs.mcp` (nixos, github, context7 servers), and wire it into both `my.claude` and `my.openai` via `enableMcpIntegration`, replacing the `mcpServers` block that used to live only in `my.claude`. The GitHub token secret now uses `programs.mcp`'s native `env.<VAR>.file` mechanism instead of a hand-rolled wrapper script — home-manager generates an equivalent wrapper for each consumer automatically.

## Test plan

- [x] `nix fmt` on all changed files
- [x] `nix run .#write-flake` to regenerate `flake.nix`/`flake.lock` for the new `codex-cli-nix` input
- [x] `nix build .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel` succeeds
- [x] `nix eval` against `homeConfigurations."omarshal@dev203.meraki.com"` confirms `scope.work` now resolves true (Codex present, Proton Pass work-vault args applied) and `programs.mcp.servers`/`enableMcpIntegration` wire up correctly
- [x] Confirmed via built derivations that both Claude Code's `.mcp.json` and Codex's `config.toml` list all three MCP servers, sharing the same auto-generated GitHub-token wrapper
- [x] `nix build` for `harmony`/`melaan` reaches the same pre-existing, unrelated cross-arch doom-emacs build limitation as before (no new errors introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)