### PR TITLE
fix(zfs): remove automatic dataset-creation activation script

### DIFF
--- a/modules/aspects/my/zfs.nix
+++ b/modules/aspects/my/zfs.nix
@@ -3,7 +3,7 @@
 
   my.zfs = pools: {
     nixos =
-      { dataset, pkgs, ... }:
+      { pkgs, ... }:
       let
         # Use the default ZFS package for compatibility checking to avoid infinite recursion
         # We can't use config.boot.zfs.package here because it depends on kernelPackages which we're trying to determine
@@ -39,41 +39,6 @@
           autoSnapshot.enable = true;
           trim.enable = true;
         };
-
-        # New child datasets inherit their parent pool's properties, so `options` should only be used to
-        # deviate from those, not to restate them. As of 2026-07-10, metalminds (harmony's data pool) has
-        # compression=on (lz4), atime=off, and recordsize=128K - all sane defaults for most workloads.
-        #
-        # Datasets are only ever created if missing, never renamed or reconfigured - changing a
-        # dataset's name, options, or other properties later leaves the old dataset behind untouched.
-        #
-        # This host also runs full system activation inside the initrd (before switch-root), where no
-        # pool is imported yet - `/etc/initrd-release` only exists there (per systemd's initrd
-        # interface: https://systemd.io/INITRD_INTERFACE/), so skip entirely in that context. Datasets
-        # are only ever created at `nixos-rebuild switch` time, when the pool is already imported.
-        system.activationScripts.zfsDatasets = ''
-          if [ ! -e /etc/initrd-release ]; then
-            ${lib.concatMapStrings (
-              d:
-              let
-                name = "${d.pool}/${d.name}";
-                mountpoint = "/${name}";
-                options = lib.concatStrings (
-                  lib.mapAttrsToList (property: value: " -o ${lib.escapeShellArg "${property}=${value}"}") (d.options or { })
-                );
-              in
-              ''
-                if ! ${pkgs.zfs}/bin/zfs list -H -o name ${lib.escapeShellArg name} >/dev/null 2>&1; then
-                  if [ -d ${lib.escapeShellArg mountpoint} ] && [ -n "$(ls -A ${lib.escapeShellArg mountpoint})" ]; then
-                    echo "zfs dataset ${lib.escapeShellArg name} is missing, but ${lib.escapeShellArg mountpoint} already exists and is non-empty - move its contents aside, then re-run the activation" >&2
-                    exit 1
-                  fi
-                  ${pkgs.zfs}/bin/zfs create -p${options} ${lib.escapeShellArg name}
-                fi
-              ''
-            ) dataset}
-          fi
-        '';
       };
   };
 }


### PR DESCRIPTION
## Summary

Follow-up to #483. That PR guarded the `zfsDatasets` activation script to skip running inside the initrd, on the theory that this host's full system activation runs there (before switch-root, before the ZFS pool is imported) and that the script's `zfs create` was failing against a not-yet-imported pool, aborting activation and surfacing as `Switch root target contains no usable init`.

A generation built from `main` after that fix merged **still fails the same way**, so that guard didn't address the actual cause (whether the "activation in initrd" premise was wrong, or something else is also failing early is still an open question). Per request, this PR removes the automatic dataset-creation activation script entirely rather than continuing to chase narrower guards around it.

## Change

- `modules/aspects/my/zfs.nix`: removes the `system.activationScripts.zfsDatasets` script (and the now-unused `dataset` function argument it required). ZFS pool import/config (`boot.zfs`, `services.zfs`) is untouched.
- The `dataset` quirk itself is untouched and still consumed by other aspects (e.g. `samba.nix` builds Samba shares from it) — only automatic `zfs create` on activation is removed. Datasets declared via the `dataset` quirk now need to be created manually ahead of a switch/reboot instead of relying on Nix activation to create them.

## Test plan

- [ ] `nix build .#nixosConfigurations.harmony.config.system.build.toplevel` (could not run in this sandbox — no `nix` binary available in the execution environment)
- [ ] Confirm harmony boots cleanly on a generation built from this change
- [ ] Manually create any datasets declared via the `dataset` quirk that don't already exist on harmony, since they'll no longer be auto-created

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfAJVq5vW7WQCbzMB3gej4)_