### PR TITLE
Fix nginx unreachable: DNS/firewall proxy mismatch and crash-looping

### DIFF
--- a/modules/aspects/my/dns.nix
+++ b/modules/aspects/my/dns.nix
@@ -103,15 +103,14 @@
                 name = "${vh.name}.${domain}";
                 inherit (host.dns-record) type content;
                 ttl = 1800;
-                # Proxied through Cloudflare's edge (hides the origin IP, adds DDoS protection) -
-                # every one of these is served by nginx on 80/443, which is restricted to only
-                # accept connections from Cloudflare's IP ranges (see
-                # modules/aspects/my/meraki.nix's `restrict-to-cloudflare`), so real clients MUST
-                # come through the proxy. Requires the zone's SSL/TLS mode set to Full (strict) in
-                # the Cloudflare dashboard - nginx already terminates with a real ACME cert, so
-                # Cloudflare can validate the origin; Flexible mode would break it (HTTP to
-                # origin, which nginx's `forceSSL` rejects).
-                proxied = true;
+                # DNS-only (not proxied through Cloudflare's edge). Every service is namespaced
+                # two levels deep (`<service>.<host>.${domain}`), which Cloudflare's free
+                # Universal SSL certificate doesn't cover (it only spans the apex and one level of
+                # wildcard) - proxying these without Cloudflare's paid Advanced Certificate
+                # Manager add-on breaks TLS at the edge before nginx is ever reached. Clients
+                # connect straight through to nginx, which terminates with its own per-host ACME
+                # cert, so this doesn't need the zone's SSL/TLS mode set to anything in particular.
+                proxied = false;
               };
             }) globalHosts
           )
@@ -121,7 +120,7 @@
               name = "*.${host.name}.${domain}";
               inherit (host.dns-record) type content;
               ttl = 1800;
-              proxied = true;
+              proxied = false;
             };
           };
       };

--- a/modules/aspects/my/dns.nix
+++ b/modules/aspects/my/dns.nix
@@ -103,13 +103,15 @@
                 name = "${vh.name}.${domain}";
                 inherit (host.dns-record) type content;
                 ttl = 1800;
-                # DNS-only (not proxied through Cloudflare's edge). Every service is namespaced
-                # two levels deep (`<service>.<host>.${domain}`), which Cloudflare's free
-                # Universal SSL certificate doesn't cover (it only spans the apex and one level of
-                # wildcard) - proxying these without Cloudflare's paid Advanced Certificate
-                # Manager add-on breaks TLS at the edge before nginx is ever reached. Clients
-                # connect straight through to nginx, which terminates with its own per-host ACME
-                # cert, so this doesn't need the zone's SSL/TLS mode set to anything in particular.
+                # DNS-only (not proxied through Cloudflare's edge). This one-level name is
+                # actually covered by Cloudflare's free Universal SSL cert, but the per-host
+                # wildcard below (`*.${host.name}.${domain}`) is namespaced two levels deep,
+                # which that cert doesn't cover (it only spans the apex and one level of
+                # wildcard) - proxying it without Cloudflare's paid Advanced Certificate Manager
+                # add-on breaks TLS at the edge before nginx is ever reached. Kept DNS-only here
+                # too for consistency, since real client traffic now arrives directly (nginx.nix's
+                # port-forward rules no longer restrict to Cloudflare's IPs) and nginx already
+                # terminates with its own per-host ACME cert.
                 proxied = false;
               };
             }) globalHosts

--- a/modules/aspects/my/nginx.nix
+++ b/modules/aspects/my/nginx.nix
@@ -4,12 +4,10 @@
       {
         name = "http";
         port = 80;
-        restrict-to-cloudflare = true;
       }
       {
         name = "https";
         port = 443;
-        restrict-to-cloudflare = true;
       }
     ];
 

--- a/modules/aspects/my/nginx.nix
+++ b/modules/aspects/my/nginx.nix
@@ -63,6 +63,13 @@
           recommendedProxySettings = true;
           recommendedTlsSettings = true;
 
+          # nginx's default bucket size can't fit our longest server_name once enough
+          # <service>.<host>.<domain> vhosts pile up (e.g. bookshelf-audiobooks.harmony.…, 47
+          # chars) - it then refuses to start at all ("could not build server_names_hash, you
+          # should increase server_names_hash_bucket_size"). 128 leaves headroom for future
+          # services without revisiting this.
+          serverNamesHashBucketSize = 128;
+
           virtualHosts = lib.listToAttrs (
             map (
               vh:

--- a/modules/aspects/my/nginx.nix
+++ b/modules/aspects/my/nginx.nix
@@ -65,9 +65,6 @@
           recommendedProxySettings = true;
           recommendedTlsSettings = true;
 
-          # Only allow PFS-enabled ciphers with AES256
-          sslCiphers = "AES256+EECDH:AES256+EDH:!aNULL";
-
           virtualHosts = lib.listToAttrs (
             map (
               vh:


### PR DESCRIPTION
## Summary
Follow-up to #506. After that cipher fix merged, the user still couldn't reach any reverse-proxied webapp. Root-caused in two parts:

- **DNS/firewall mismatch**: `dns.nix` proxied all records through Cloudflare's edge, but every service here is namespaced two levels deep (`<service>.<host>.silverlight-nex.us`), which Cloudflare's free Universal SSL certificate doesn't cover (only the apex + one level of wildcard). Proxying broke the TLS handshake at Cloudflare's edge before nginx was ever reached, surfacing as `SSL_ERROR_NO_CYPHER_OVERLAP`. Covering nested subdomains needs Cloudflare's paid Advanced Certificate Manager add-on ($10/mo), which the user opted not to buy. Switched the records to DNS-only instead and dropped the matching `restrict-to-cloudflare` port-forward restriction on 80/443, since real client traffic no longer arrives via Cloudflare's edge IPs.
- **nginx crash loop**: independently, nginx had been failing to start since ~Jun 30 (`start-limit-hit` in systemd, config test failing with "could not build server_names_hash, you should increase server_names_hash_bucket_size: 64") once vhosts like `bookshelf-audiobooks.harmony.silverlight-nex.us` (47 chars) stopped fitting the default hash bucket size. This alone made every connection attempt fail regardless of the DNS/Cloudflare state, and was the actual proximate cause of "Unable to connect" once DNS was fixed. Set `serverNamesHashBucketSize = 128;` for headroom.

## Test plan
- [x] `nix eval`/`nix build .#harmony-tf.config` confirm `proxied = false` on all Cloudflare DNS records and `allowed_ips = ["any"]` on the Meraki port-forward rules
- [x] `nix eval .#nixosConfigurations.harmony.config.services.nginx.serverNamesHashBucketSize` confirms `128`
- [x] `nix fmt` — no changes needed
- [ ] `sudo nixos-rebuild switch --flake .#harmony`, confirm `systemctl status nginx` comes up clean
- [ ] `nix run .#harmony-tf` to apply the DNS/firewall changes, then confirm the previously-blocked webapp loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)