### PR TITLE
Move personal Codex settings from my.openai to the OMARSHAL-M-T2QF host aspect

### DIFF
--- a/modules/aspects/hosts/OMARSHAL-M-T2QF/OMARSHAL-M-T2QF.nix
+++ b/modules/aspects/hosts/OMARSHAL-M-T2QF/OMARSHAL-M-T2QF.nix
@@ -12,17 +12,38 @@
     };
 
     provides.oscar = {
-      homeManager = {
-        # This value determines the Home Manager release that your configuration is compatible with. This helps avoid
-        # breakage when a new Home Manager release introduces backwards incompatible changes.
+      homeManager = { config, pkgs, ... }: {
+        # This value determines the Home Manager release that your configuration is compatible with. This helps
+        # avoid breakage when a new Home Manager release introduces backwards incompatible changes.
         #
-        # You can update Home Manager without changing this value. See the Home Manager release notes for a list of
-        # state version changes in each release.
+        # You can update Home Manager without changing this value. See the Home Manager release notes for a list
+        # of state version changes in each release.
         home.stateVersion = "26.11";
 
         # fish defaults this to true for apropos completion, but it has no effect since
         # programs.man.package is null on Darwin (macOS's own man is used instead).
         programs.man.generateCaches = false;
+
+        programs.codex.settings = {
+          model = "gpt-5.6-sol";
+          model_reasoning_effort = "medium";
+          approvals_reviewer = "auto_review";
+
+          # Only checked out on this machine.
+          mcp_servers.outlook = {
+            command = "${pkgs.uv}/bin/uv";
+            args = [
+              "--directory"
+              "${config.home.homeDirectory}/co/outlook-mcp-server"
+              "run"
+              "outlook-mcp"
+            ];
+            env = {
+              OUTLOOK_MCP_CONFIG_DIR = "${config.xdg.configHome}/outlook/mcp/sessions";
+              OUTLOOK_MCP_ENABLE_WRITE_TOOLS = "true";
+            };
+          };
+        };
       };
 
       # Den's allHomeNodes spawn re-walks the host aspect without the user's own includes, so none of the

--- a/modules/aspects/my/openai.nix
+++ b/modules/aspects/my/openai.nix
@@ -18,7 +18,7 @@
     {
       includes = [ my.mcp-servers ] ++ lib.optional chatgpt (den._.unfree [ "chatgpt" ]);
 
-      homeManager = { pkgs, ... }: {
+      homeManager = { config, pkgs, ... }: {
         programs.codex = {
           enable = true;
           package = inputs.codex-cli-nix.packages.${pkgs.stdenv.hostPlatform.system}.codex;
@@ -29,17 +29,20 @@
             model_reasoning_effort = "medium";
             approvals_reviewer = "auto_review";
 
-            mcp_servers.outlook = {
-              command = "uv";
-              args = [
-                "--directory"
-                "/Users/oscar/co/outlook-mcp-server"
-                "run"
-                "outlook-mcp"
-              ];
-              env = {
-                OUTLOOK_MCP_CONFIG_DIR = "/Users/oscar/.config/outlook/mcp/sessions";
-                OUTLOOK_MCP_ENABLE_WRITE_TOOLS = "true";
+            # Only checked out on the Darwin work laptop.
+            mcp_servers = lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+              outlook = {
+                command = "${pkgs.uv}/bin/uv";
+                args = [
+                  "--directory"
+                  "${config.home.homeDirectory}/co/outlook-mcp-server"
+                  "run"
+                  "outlook-mcp"
+                ];
+                env = {
+                  OUTLOOK_MCP_CONFIG_DIR = "${config.xdg.configHome}/outlook/mcp/sessions";
+                  OUTLOOK_MCP_ENABLE_WRITE_TOOLS = "true";
+                };
               };
             };
           };

--- a/modules/aspects/my/openai.nix
+++ b/modules/aspects/my/openai.nix
@@ -18,34 +18,11 @@
     {
       includes = [ my.mcp-servers ] ++ lib.optional chatgpt (den._.unfree [ "chatgpt" ]);
 
-      homeManager = { config, pkgs, ... }: {
+      homeManager = { pkgs, ... }: {
         programs.codex = {
           enable = true;
           package = inputs.codex-cli-nix.packages.${pkgs.stdenv.hostPlatform.system}.codex;
           enableMcpIntegration = true;
-
-          settings = {
-            model = "gpt-5.6-sol";
-            model_reasoning_effort = "medium";
-            approvals_reviewer = "auto_review";
-
-            # Only checked out on the Darwin work laptop.
-            mcp_servers = lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
-              outlook = {
-                command = "${pkgs.uv}/bin/uv";
-                args = [
-                  "--directory"
-                  "${config.home.homeDirectory}/co/outlook-mcp-server"
-                  "run"
-                  "outlook-mcp"
-                ];
-                env = {
-                  OUTLOOK_MCP_CONFIG_DIR = "${config.xdg.configHome}/outlook/mcp/sessions";
-                  OUTLOOK_MCP_ENABLE_WRITE_TOOLS = "true";
-                };
-              };
-            };
-          };
         };
 
         home.packages = lib.optional chatgpt pkgs.chatgpt;

--- a/modules/aspects/my/openai.nix
+++ b/modules/aspects/my/openai.nix
@@ -23,6 +23,26 @@
           enable = true;
           package = inputs.codex-cli-nix.packages.${pkgs.stdenv.hostPlatform.system}.codex;
           enableMcpIntegration = true;
+
+          settings = {
+            model = "gpt-5.6-sol";
+            model_reasoning_effort = "medium";
+            approvals_reviewer = "auto_review";
+
+            mcp_servers.outlook = {
+              command = "uv";
+              args = [
+                "--directory"
+                "/Users/oscar/co/outlook-mcp-server"
+                "run"
+                "outlook-mcp"
+              ];
+              env = {
+                OUTLOOK_MCP_CONFIG_DIR = "/Users/oscar/.config/outlook/mcp/sessions";
+                OUTLOOK_MCP_ENABLE_WRITE_TOOLS = "true";
+              };
+            };
+          };
         };
 
         home.packages = lib.optional chatgpt pkgs.chatgpt;


### PR DESCRIPTION
## Summary

- `model`, `model_reasoning_effort`, `approvals_reviewer`, and the `outlook` MCP server were living in `my.openai`, which is included by every `scope.work` home (e.g. `dev203`, an x86_64-linux standalone Home Manager box) — not just the Darwin work laptop these preferences actually belong to.
- Moved the whole `programs.codex.settings` block into `OMARSHAL-M-T2QF`'s own host aspect (`den.aspects.OMARSHAL-M-T2QF.provides.oscar.homeManager`), following the same pattern already used there for host-specific home-manager config (`home.stateVersion`, `programs.man.generateCaches`).
- `my.openai` is back to being purely generic: `enable`, `package` (from `codex-cli-nix`), and `enableMcpIntegration` — no personal preferences or machine-local paths baked into the shared aspect.

## Test plan

- [x] `nix fmt` on both changed files
- [x] Built the `.codex/config.toml` derivation for `OMARSHAL-M-T2QF` — byte-identical output to before the move (same Nix store hash)
- [x] `nix eval` confirms `dev203`'s `programs.codex.settings` is now `{}` before MCP integration merges in (previously it silently inherited these machine-specific values)
- [x] `nix build .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)