### PR TITLE
Add work-only Grafana MCP server to Codex

### DIFF
--- a/modules/aspects/my/openai.nix
+++ b/modules/aspects/my/openai.nix
@@ -18,34 +18,11 @@
     {
       includes = [ my.mcp-servers ] ++ lib.optional chatgpt (den._.unfree [ "chatgpt" ]);
 
-      homeManager = { config, pkgs, ... }: {
+      homeManager = { pkgs, ... }: {
         programs.codex = {
           enable = true;
           package = inputs.codex-cli-nix.packages.${pkgs.stdenv.hostPlatform.system}.codex;
           enableMcpIntegration = true;
-
-          settings = {
-            model = "gpt-5.6-sol";
-            model_reasoning_effort = "medium";
-            approvals_reviewer = "auto_review";
-
-            # Only checked out on the Darwin work laptop.
-            mcp_servers = lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
-              outlook = {
-                command = "${pkgs.uv}/bin/uv";
-                args = [
-                  "--directory"
-                  "${config.home.homeDirectory}/co/outlook-mcp-server"
-                  "run"
-                  "outlook-mcp"
-                ];
-                env = {
-                  OUTLOOK_MCP_CONFIG_DIR = "${config.xdg.configHome}/outlook/mcp/sessions";
-                  OUTLOOK_MCP_ENABLE_WRITE_TOOLS = "true";
-                };
-              };
-            };
-          };
         };
 
         home.packages = lib.optional chatgpt pkgs.chatgpt;

--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -28,11 +28,15 @@ in
       ...
     }:
     let
+      # `home` is checked before `host`: a standalone home named `user@undeclared-host`
+      # (e.g. dev203) gets a synthetic `host = { name = ...; }` from den purely so
+      # host-keyed cross-entity policies can match on `host.name` - it never carries
+      # `work`/`graphical`. The real attributes always live on `home` for those.
       scope =
-        if host != null then
-          host
-        else if home != null then
+        if home != null then
           home
+        else if host != null then
+          host
         else
           { };
     in
@@ -126,6 +130,11 @@ in
         # activation time, age decrypts via the Proton Pass SSH agent
         # (SSH_AUTH_SOCK) without needing a private key file on disk.
         age.rekey.hostPubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGt95coA4j19+fPxpOLRfIFb7AvAXdSmf1MyOPibmhe/";
+
+        services.proton-pass-agent.extraArgs = [
+          "--vault-name"
+          "Personal"
+        ];
 
         home.packages =
           with pkgs;

--- a/modules/aspects/users/oscar/work/work.nix
+++ b/modules/aspects/users/oscar/work/work.nix
@@ -35,9 +35,21 @@ in
         ++ [ (my.openai { chatgpt = scope.graphical or false; }) ]
       );
 
-      homeManager.services.proton-pass-agent.extraArgs = lib.optionals (!(scope.work or false)) [
-        "--vault-name"
-        "Personal"
-      ];
+      homeManager = { pkgs, ... }: {
+        programs.codex.settings.mcp_servers = lib.optionalAttrs (scope.work or false) {
+          grafana = {
+            command = "${pkgs.uv}/bin/uvx";
+            args = [
+              "mcp-grafana"
+              "--enabled-tools"
+              "search,datasources,dashboard,elasticsearch,runpanelquery"
+              "--disable-write"
+              "--log-level"
+              "info"
+            ];
+            startup_timeout_sec = 30;
+          };
+        };
+      };
     };
 }


### PR DESCRIPTION
## Summary
- Adds a Grafana MCP server (`uvx mcp-grafana`, read-only tools) to `programs.codex.settings.mcp_servers` on work machines only, wired through `den.aspects.oscar.provides.work` alongside the existing (work-only) `outlook` server.
- Removes the duplicate `outlook` MCP server definition from `my.openai` — it was already declared on the `OMARSHAL-M-T2QF` host aspect, and having it in both places caused `mcp_servers.outlook.args` to render twice in the generated `config.toml`.
- Drops the repo-managed `model`/`model_reasoning_effort`/`approvals_reviewer` Codex settings from `my.openai` (left for hosts/aspects that want to opt in — `OMARSHAL-M-T2QF` still sets them directly).
- Fixes `oscar.nix`'s `scope` to check `home` before `host` (matching `work.nix`'s existing rationale): a standalone home like `omarshal@dev203.meraki.com` gets a synthetic host from den with no `work`/`graphical` fields, so `home` must win for `scope.work`/`scope.graphical` to resolve correctly.
- Moves `proton-pass-agent`'s `--vault-name Personal` flag into `oscar.nix` (now unconditional, applied to every machine) instead of being gated on `scope.work` inside `work.nix`.

## Test plan
- [x] `nix eval` confirms `mcp_servers` contains `grafana` (and `outlook` on Darwin) only on work machines (`OMARSHAL-M-T2QF`, `omarshal@dev203.meraki.com`), and neither on non-work hosts (`melaan`).
- [x] `nix eval` confirms `mcp_servers.outlook.args` is no longer duplicated.
- [x] `nix eval` confirms `services.proton-pass-agent.extraArgs` is `["--vault-name" "Personal"]` on every host.
- [x] `nix build .#checks.aarch64-darwin.check-flake-file` and `.treefmt` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)