### PR TITLE
Trust ~/co/personal-assistant for Codex on OMARSHAL-M-T2QF

### DIFF
--- a/modules/aspects/hosts/OMARSHAL-M-T2QF/OMARSHAL-M-T2QF.nix
+++ b/modules/aspects/hosts/OMARSHAL-M-T2QF/OMARSHAL-M-T2QF.nix
@@ -29,6 +29,8 @@
           model_reasoning_effort = "medium";
           approvals_reviewer = "auto_review";
 
+          projects."${config.home.homeDirectory}/co/personal-assistant".trust_level = "trusted";
+
           # Only checked out on this machine.
           mcp_servers.outlook = {
             command = "${pkgs.uv}/bin/uv";


### PR DESCRIPTION
## Summary
- Codex CLI's config.toml is Home Manager-managed (a symlink into `/nix/store`), so its interactive "trust this folder" prompt fails to write the trust decision when it hits an untrusted project.
- Declares trust for `~/co/personal-assistant` declaratively via `programs.codex.settings.projects.<path>.trust_level`, which Codex's own config schema already supports for exactly this case.

## Test plan
- [x] `nix eval .#darwinConfigurations.OMARSHAL-M-T2QF.config.home-manager.users.oscar.programs.codex.settings.projects` resolves to `{"/Users/oscar/co/personal-assistant":{"trust_level":"trusted"}}`
- [ ] `darwin-rebuild switch --flake .#OMARSHAL-M-T2QF` and confirm Codex no longer prompts to trust the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)