### PR TITLE
fix(mcp): wrap github-mcp-server token read in shell script

### DIFF
--- a/modules/aspects/my/mcp-servers.nix
+++ b/modules/aspects/my/mcp-servers.nix
@@ -12,11 +12,17 @@
       servers = {
         nixos.command = "${pkgs.mcp-nixos}/bin/mcp-nixos";
 
-        github = {
-          command = "${pkgs.github-mcp-server}/bin/github-mcp-server";
-          args = [ "stdio" ];
-          env.GITHUB_PERSONAL_ACCESS_TOKEN.file = config.age.secrets.github-mcp-server-github-access-token.path;
-        };
+        # `programs.mcp`'s env.*.file support single-quotes the path before
+        # `cat`-ing it, but agenix's Darwin secret paths are themselves an
+        # unexpanded `$(getconf DARWIN_USER_TEMP_DIR)/agenix/...` shell
+        # command substitution — single-quoting prevents that expansion, so
+        # the token file is never found. Read it ourselves in a wrapper
+        # script instead, where the substitution is left unquoted for bash
+        # to expand at runtime.
+        github.command = "${pkgs.writeShellScript "github-mcp-server-wrapper" ''
+          export GITHUB_PERSONAL_ACCESS_TOKEN="$(cat ${config.age.secrets.github-mcp-server-github-access-token.path})"
+          exec ${pkgs.github-mcp-server}/bin/github-mcp-server stdio
+        ''}";
 
         context7.command = "${pkgs.context7-mcp}/bin/context7-mcp";
       };


### PR DESCRIPTION
## Summary
- Codex failed to start the `github` MCP server with `authentication required: set GITHUB_PERSONAL_ACCESS_TOKEN`.
- Root cause: `programs.mcp`'s `env.*.file` support single-quotes the secret path before `cat`-ing it, but agenix's Darwin secret paths are themselves an unexpanded `$(getconf DARWIN_USER_TEMP_DIR)/agenix/...` shell command substitution. Single-quoting prevents that expansion, so the token file is never found.
- Fix: read the secret ourselves in a `pkgs.writeShellScript` wrapper (in [modules/aspects/my/mcp-servers.nix](modules/aspects/my/mcp-servers.nix)) where the substitution is left unquoted for bash to expand at runtime, then `exec`s `github-mcp-server stdio`.

## Test plan
- [x] `nix build .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel` succeeds
- [x] Inspected the generated wrapper script — confirms the `$(getconf ...)` substitution now expands correctly instead of being single-quoted
- [ ] Apply with `darwin-rebuild switch --flake .#OMARSHAL-M-T2QF` and confirm Codex can start the `github` MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)