### PR TITLE
Scan all Proton Pass vaults for SSH keys on work machines

### DIFF
--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -131,7 +131,10 @@ in
         # (SSH_AUTH_SOCK) without needing a private key file on disk.
         age.rekey.hostPubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGt95coA4j19+fPxpOLRfIFb7AvAXdSmf1MyOPibmhe/";
 
-        services.proton-pass-agent.extraArgs = [
+        # On work machines, the agent needs SSH keys from both the Personal and Meraki
+        # vaults - pass-cli's ssh-agent only accepts a single --vault-name, so the only way
+        # to cover more than one named vault is to omit the flag and let it scan all vaults.
+        services.proton-pass-agent.extraArgs = lib.optionals (!(scope.work or false)) [
           "--vault-name"
           "Personal"
         ];


### PR DESCRIPTION
## Summary
- On work machines (`host.work`/`home.work` true), the Proton Pass SSH agent now omits `--vault-name`, so `pass-cli` scans all vaults instead of just "Personal" — this picks up SSH keys from the Meraki vault too.
- Non-work machines are unaffected and still restrict to the "Personal" vault only.

## Why
`pass-cli ssh-agent start` only accepts a single `--vault-name` flag (confirmed: passing it twice errors with "cannot be used multiple times"), and there's no way to run more than one agent instance without adding per-host `IdentityAgent` SSH config. Since omitting the flag makes it scan all vaults, that's the simplest way to get Meraki vault keys onto the work machine alongside Personal.

## Test plan
- [x] `nix build .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel` succeeds
- [x] `nix eval` confirms `extraArgs = []` for `OMARSHAL-M-T2QF` and the `dev203.meraki.com` standalone home (both `work = true`)
- [x] `nix eval` confirms `extraArgs = ["--vault-name" "Personal"]` is unchanged for `melaan` (non-work)
- [x] `nix fmt` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)