### PR TITLE
feat(codex): pass Grafana credentials as env vars to MCP server

### DIFF
--- a/modules/aspects/users/oscar/work/work.nix
+++ b/modules/aspects/users/oscar/work/work.nix
@@ -48,6 +48,11 @@ in
               "info"
             ];
             startup_timeout_sec = 30;
+            env_vars = [
+              "GRAFANA_URL"
+              "GRAFANA_USERNAME"
+              "GRAFANA_PASSWORD"
+            ];
           };
         };
       };


### PR DESCRIPTION
## Summary
- Add `env_vars = [ "GRAFANA_URL" "GRAFANA_USERNAME" "GRAFANA_PASSWORD" ]` to the existing `grafana` entry in `programs.codex.settings.mcp_servers` ([work.nix](modules/aspects/users/oscar/work/work.nix)), so the `mcp-grafana` subprocess receives these credentials forwarded from the shell environment rather than storing them in the Nix store.

## Test plan
- [x] `nix fmt` — no changes needed, already formatted
- [x] `nix build .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel --dry-run` succeeds, including the `codex-config.drv` derivation that embeds this config

🤖 Generated with [Claude Code](https://claude.com/claude-code)