### PR TITLE
fix(netdata): enable dashboard UI files

### DIFF
--- a/modules/aspects/my/netdata.nix
+++ b/modules/aspects/my/netdata.nix
@@ -1,12 +1,15 @@
 let
   port = 19999;
 in
-{
+{ den, ... }: {
   my.netdata =
     {
       global ? false,
     }:
     { host, ... }: {
+      # withCloudUi's dashboard files (below) are under the non-free Netdata Cloud UI License.
+      includes = [ (den._.unfree [ "netdata" ]) ];
+
       virtual-host = {
         name = "netdata";
         host = host.name;
@@ -54,6 +57,9 @@ in
         # Includes built-in ZFS pool health/capacity alerting.
         services.netdata = {
           enable = true;
+          # withCloudUi pulls in the local dashboard's static files; without it the package omits
+          # them entirely and every request 404s with "File does not exist, or is not accessible:".
+          package = pkgs.netdata.override { withCloudUi = true; };
           # Bind only to loopback; nginx handles external access
           config.web."bind to" = "127.0.0.1";
           # Discord notifications via health_alarm_notify.conf.


### PR DESCRIPTION
## Summary

- Netdata's nixpkgs package builds with `withCloudUi = false` by default, which omits the local dashboard's static files entirely — that's why the web UI 404s with `File does not exist, or is not accessible:` for every path. It's not an nginx/proxy issue; requests were reaching Netdata fine, there was just nothing to serve.
- Override the package with `withCloudUi = true` in [`modules/aspects/my/netdata.nix`](modules/aspects/my/netdata.nix) to pull in the dashboard files.
- Allow the resulting non-free Netdata Cloud UI License via the repo's `den._.unfree` battery (same pattern as `plex.nix`, `google-chrome.nix`, etc.), rather than hand-writing `nixpkgs.config.allowUnfreePredicate`.

## Test plan

- [x] `nix eval .#nixosConfigurations.harmony.config.systemd.services.netdata.serviceConfig.ExecStart` resolves cleanly, picking up the overridden package.
- [x] `nix build .#nixosConfigurations.harmony.config.services.netdata.package` succeeds and the resulting store path contains `share/netdata/web/index.html` and the `v3` dashboard assets (confirmed absent before this change).
- [x] `nix fmt` clean.
- [ ] `sudo nixos-rebuild switch --flake .#harmony` and confirm the dashboard loads (needs to be run on the actual host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)