### PR TITLE
feat(netdata): add smartctl and nginx collectors

### DIFF
--- a/modules/aspects/my/netdata.nix
+++ b/modules/aspects/my/netdata.nix
@@ -62,6 +62,9 @@ in
           package = pkgs.netdata.override { withCloudUi = true; };
           # Bind only to loopback; nginx handles external access
           config.web."bind to" = "127.0.0.1";
+          # smartmontools gives the smartctl collector S.M.A.R.T. access to individual disks
+          # (pre-fail indicators), complementing the built-in ZFS pool-level health alerting above.
+          extraNdsudoPackages = [ pkgs.smartmontools ];
           # Discord notifications via health_alarm_notify.conf.
           # The file is a bash script sourced by Netdata's alarm-notify.sh;
           # sourcing the age secret sets DISCORD_WEBHOOK_URL at runtime.

--- a/modules/aspects/my/nginx.nix
+++ b/modules/aspects/my/nginx.nix
@@ -51,6 +51,10 @@
           recommendedProxySettings = true;
           recommendedTlsSettings = true;
 
+          # Exposes /nginx_status on localhost for Netdata's nginx collector (request/connection
+          # metrics).
+          statusPage = true;
+
           # nginx's default bucket size can't fit our longest server_name once enough
           # <service>.<host>.<domain> vhosts pile up (e.g. bookshelf-audiobooks.harmony.…, 47
           # chars) - it then refuses to start at all ("could not build server_names_hash, you


### PR DESCRIPTION
## Summary
- Add `smartmontools` to `services.netdata.extraNdsudoPackages` so the `smartctl` collector gets S.M.A.R.T. access to individual disks — catches pre-fail indicators (reallocated/pending sectors, temperature) that ZFS pool-level health alerting alone won't surface.
- Enable `services.nginx.statusPage` to expose `/nginx_status` on localhost, giving Netdata's `nginx` collector request/connection metrics for the reverse proxy that fronts Plex, Immich, Nextcloud, and the rest of the `*arr` stack.
- No change needed for the `apcupsd` collector — it auto-detects against apcupsd's default localhost NIS port (`127.0.0.1:3551`), which is already the default binding.

Both changes only affect `harmony`, the only host that includes both `netdata` and `nginx`/`apcupsd`.

## Test plan
- [x] `nix eval .#nixosConfigurations.harmony.config.services.nginx.statusPage` → `true`
- [x] `nix eval .#nixosConfigurations.harmony.config.services.netdata.extraNdsudoPackages` → `[ smartmontools ]`
- [x] Confirmed `withNdsudo = true` is already the netdata package default, so `smartctl` works once `smartmontools` is on `PATH`
- [x] `nix fmt` — no formatting changes needed
- [ ] Full `nixos-rebuild switch` on `harmony` not run in this session (cross-arch build not available locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)