### PR TITLE
feat(treefmt): add pedantix formatter and statix linter

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -493,6 +493,22 @@
         "type": "github"
       }
     },
+    "flake-compat_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-file": {
       "locked": {
         "lastModified": 1781217157,
@@ -606,6 +622,27 @@
     "flake-parts_6": {
       "inputs": {
         "nixpkgs-lib": [
+          "pedantix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_7": {
+      "inputs": {
+        "nixpkgs-lib": [
           "stylix",
           "nixpkgs"
         ]
@@ -624,7 +661,7 @@
         "type": "github"
       }
     },
-    "flake-parts_7": {
+    "flake-parts_8": {
       "inputs": {
         "nixpkgs-lib": [
           "terranix",
@@ -760,6 +797,28 @@
           "flake-compat"
         ],
         "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat_7",
+        "nixpkgs": [
+          "pedantix",
           "nixpkgs"
         ]
       },
@@ -1285,6 +1344,29 @@
         "type": "github"
       }
     },
+    "pedantix": {
+      "inputs": {
+        "flake-parts": "flake-parts_6",
+        "git-hooks-nix": "git-hooks-nix",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1784453140,
+        "narHash": "sha256-XRjOSAUqpWRu/P1gQ6YQjqUnCLihSzQ1h/CvpmBfuMU=",
+        "owner": "Swarsel",
+        "repo": "pedantix",
+        "rev": "c8d75b1b0933c088cc7e66454c1523f6c98d5546",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Swarsel",
+        "repo": "pedantix",
+        "type": "github"
+      }
+    },
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -1404,11 +1486,12 @@
         "nix-minecraft": "nix-minecraft",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_2",
+        "pedantix": "pedantix",
         "ragenix": "ragenix",
         "stylix": "stylix",
         "systems": "systems_8",
         "terranix": "terranix",
-        "treefmt-nix": "treefmt-nix_2",
+        "treefmt-nix": "treefmt-nix_3",
         "zen-browser": "zen-browser"
       }
     },
@@ -1440,7 +1523,7 @@
         "base16-helix": "base16-helix",
         "base16-vim": "base16-vim",
         "firefox-gnome-theme": "firefox-gnome-theme",
-        "flake-parts": "flake-parts_6",
+        "flake-parts": "flake-parts_7",
         "gnome-shell": "gnome-shell",
         "nixpkgs": [
           "nixpkgs"
@@ -1603,7 +1686,7 @@
     },
     "terranix": {
       "inputs": {
-        "flake-parts": "flake-parts_7",
+        "flake-parts": "flake-parts_8",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -1709,6 +1792,27 @@
       }
     },
     "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "pedantix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_3": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,117 @@
 # DO-NOT-EDIT. This file was auto-generated using github:vic/flake-file.
 # Use `nix run .#write-flake` to regenerate it.
 {
-  outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } (inputs.import-tree ./modules);
-
+  inputs = {
+    agenix-rekey = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:oddlama/agenix-rekey";
+    };
+    authentik-nix = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:nix-community/authentik-nix";
+    };
+    catppuccin-wallpapers = {
+      flake = false;
+      url = "github:zhichaoh/catppuccin-wallpapers";
+    };
+    claude-code-nix = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:sadjow/claude-code-nix";
+    };
+    codex-cli-nix = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:sadjow/codex-cli-nix";
+    };
+    darwin = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:nix-darwin/nix-darwin";
+    };
+    den.url = "github:denful/den";
+    flake-compat.url = "github:NixOS/flake-compat";
+    flake-file.url = "github:vic/flake-file";
+    flake-parts = {
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+      url = "github:hercules-ci/flake-parts";
+    };
+    git-hooks = {
+      inputs = {
+        flake-compat.follows = "flake-compat";
+        nixpkgs.follows = "nixpkgs";
+      };
+      url = "github:cachix/git-hooks.nix";
+    };
+    home-manager = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:nix-community/home-manager";
+    };
+    import-tree.url = "github:vic/import-tree";
+    nix-cachyos-kernel.url = "github:xddxdd/nix-cachyos-kernel/release";
+    nix-doom-emacs-unstraightened = {
+      inputs = {
+        doomdir.follows = "nixpkgs";
+        nixpkgs.follows = "nixpkgs";
+        systems.follows = "systems";
+      };
+      url = "github:marienz/nix-doom-emacs-unstraightened";
+    };
+    nix-index-database = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:nix-community/nix-index-database";
+    };
+    nix-logseq-git-flake = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:Bad3r/nix-logseq-git-flake";
+    };
+    nix-minecraft = {
+      inputs = {
+        flake-compat.follows = "flake-compat";
+        nixpkgs.follows = "nixpkgs";
+        systems.follows = "systems";
+      };
+      url = "github:Infinidoge/nix-minecraft";
+    };
+    nixos-hardware = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:NixOS/nixos-hardware";
+    };
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    pedantix = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:Swarsel/pedantix";
+    };
+    ragenix = {
+      inputs = {
+        agenix.inputs = {
+          darwin.follows = "darwin";
+          home-manager.follows = "home-manager";
+          nixpkgs.follows = "nixpkgs";
+          systems.follows = "systems";
+        };
+        nixpkgs.follows = "nixpkgs";
+      };
+      url = "github:yaxitech/ragenix";
+    };
+    stylix = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:nix-community/stylix";
+    };
+    systems.url = "github:nix-systems/default";
+    terranix = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:terranix/terranix";
+    };
+    treefmt-nix = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:numtide/treefmt-nix";
+    };
+    zen-browser = {
+      inputs = {
+        home-manager.follows = "home-manager";
+        nixpkgs.follows = "nixpkgs";
+      };
+      url = "github:0xc000022070/zen-browser-flake";
+    };
+  };
   nixConfig = {
     extra-substituters = [
       "https://nix-community.cachix.org"
@@ -19,112 +128,5 @@
       "cache.xinux.uz:BXCrtqejFjWzWEB9YuGB7X2MV4ttBur1N8BkwQRdH+0="
     ];
   };
-
-  inputs = {
-    agenix-rekey = {
-      url = "github:oddlama/agenix-rekey";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    authentik-nix = {
-      url = "github:nix-community/authentik-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    catppuccin-wallpapers = {
-      url = "github:zhichaoh/catppuccin-wallpapers";
-      flake = false;
-    };
-    claude-code-nix = {
-      url = "github:sadjow/claude-code-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    codex-cli-nix = {
-      url = "github:sadjow/codex-cli-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    darwin = {
-      url = "github:nix-darwin/nix-darwin";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    den.url = "github:denful/den";
-    flake-compat.url = "github:NixOS/flake-compat";
-    flake-file.url = "github:vic/flake-file";
-    flake-parts = {
-      url = "github:hercules-ci/flake-parts";
-      inputs.nixpkgs-lib.follows = "nixpkgs";
-    };
-    git-hooks = {
-      url = "github:cachix/git-hooks.nix";
-      inputs = {
-        flake-compat.follows = "flake-compat";
-        nixpkgs.follows = "nixpkgs";
-      };
-    };
-    home-manager = {
-      url = "github:nix-community/home-manager";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    import-tree.url = "github:vic/import-tree";
-    nix-cachyos-kernel.url = "github:xddxdd/nix-cachyos-kernel/release";
-    nix-doom-emacs-unstraightened = {
-      url = "github:marienz/nix-doom-emacs-unstraightened";
-      inputs = {
-        doomdir.follows = "nixpkgs";
-        nixpkgs.follows = "nixpkgs";
-        systems.follows = "systems";
-      };
-    };
-    nix-index-database = {
-      url = "github:nix-community/nix-index-database";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    nix-logseq-git-flake = {
-      url = "github:Bad3r/nix-logseq-git-flake";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    nix-minecraft = {
-      url = "github:Infinidoge/nix-minecraft";
-      inputs = {
-        flake-compat.follows = "flake-compat";
-        nixpkgs.follows = "nixpkgs";
-        systems.follows = "systems";
-      };
-    };
-    nixos-hardware = {
-      url = "github:NixOS/nixos-hardware";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    ragenix = {
-      url = "github:yaxitech/ragenix";
-      inputs = {
-        agenix.inputs = {
-          darwin.follows = "darwin";
-          home-manager.follows = "home-manager";
-          nixpkgs.follows = "nixpkgs";
-          systems.follows = "systems";
-        };
-        nixpkgs.follows = "nixpkgs";
-      };
-    };
-    stylix = {
-      url = "github:nix-community/stylix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    systems.url = "github:nix-systems/default";
-    terranix = {
-      url = "github:terranix/terranix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    treefmt-nix = {
-      url = "github:numtide/treefmt-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    zen-browser = {
-      url = "github:0xc000022070/zen-browser-flake";
-      inputs = {
-        home-manager.follows = "home-manager";
-        nixpkgs.follows = "nixpkgs";
-      };
-    };
-  };
+  outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } (inputs.import-tree ./modules);
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,117 +1,8 @@
 # DO-NOT-EDIT. This file was auto-generated using github:vic/flake-file.
 # Use `nix run .#write-flake` to regenerate it.
 {
-  inputs = {
-    agenix-rekey = {
-      inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:oddlama/agenix-rekey";
-    };
-    authentik-nix = {
-      inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:nix-community/authentik-nix";
-    };
-    catppuccin-wallpapers = {
-      flake = false;
-      url = "github:zhichaoh/catppuccin-wallpapers";
-    };
-    claude-code-nix = {
-      inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:sadjow/claude-code-nix";
-    };
-    codex-cli-nix = {
-      inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:sadjow/codex-cli-nix";
-    };
-    darwin = {
-      inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:nix-darwin/nix-darwin";
-    };
-    den.url = "github:denful/den";
-    flake-compat.url = "github:NixOS/flake-compat";
-    flake-file.url = "github:vic/flake-file";
-    flake-parts = {
-      inputs.nixpkgs-lib.follows = "nixpkgs";
-      url = "github:hercules-ci/flake-parts";
-    };
-    git-hooks = {
-      inputs = {
-        flake-compat.follows = "flake-compat";
-        nixpkgs.follows = "nixpkgs";
-      };
-      url = "github:cachix/git-hooks.nix";
-    };
-    home-manager = {
-      inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:nix-community/home-manager";
-    };
-    import-tree.url = "github:vic/import-tree";
-    nix-cachyos-kernel.url = "github:xddxdd/nix-cachyos-kernel/release";
-    nix-doom-emacs-unstraightened = {
-      inputs = {
-        doomdir.follows = "nixpkgs";
-        nixpkgs.follows = "nixpkgs";
-        systems.follows = "systems";
-      };
-      url = "github:marienz/nix-doom-emacs-unstraightened";
-    };
-    nix-index-database = {
-      inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:nix-community/nix-index-database";
-    };
-    nix-logseq-git-flake = {
-      inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:Bad3r/nix-logseq-git-flake";
-    };
-    nix-minecraft = {
-      inputs = {
-        flake-compat.follows = "flake-compat";
-        nixpkgs.follows = "nixpkgs";
-        systems.follows = "systems";
-      };
-      url = "github:Infinidoge/nix-minecraft";
-    };
-    nixos-hardware = {
-      inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:NixOS/nixos-hardware";
-    };
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    pedantix = {
-      inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:Swarsel/pedantix";
-    };
-    ragenix = {
-      inputs = {
-        agenix.inputs = {
-          darwin.follows = "darwin";
-          home-manager.follows = "home-manager";
-          nixpkgs.follows = "nixpkgs";
-          systems.follows = "systems";
-        };
-        nixpkgs.follows = "nixpkgs";
-      };
-      url = "github:yaxitech/ragenix";
-    };
-    stylix = {
-      inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:nix-community/stylix";
-    };
-    systems.url = "github:nix-systems/default";
-    terranix = {
-      inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:terranix/terranix";
-    };
-    treefmt-nix = {
-      inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:numtide/treefmt-nix";
-    };
-    zen-browser = {
-      inputs = {
-        home-manager.follows = "home-manager";
-        nixpkgs.follows = "nixpkgs";
-      };
-      url = "github:0xc000022070/zen-browser-flake";
-    };
-  };
+  outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } (inputs.import-tree ./modules);
+
   nixConfig = {
     extra-substituters = [
       "https://nix-community.cachix.org"
@@ -128,5 +19,116 @@
       "cache.xinux.uz:BXCrtqejFjWzWEB9YuGB7X2MV4ttBur1N8BkwQRdH+0="
     ];
   };
-  outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } (inputs.import-tree ./modules);
+
+  inputs = {
+    agenix-rekey = {
+      url = "github:oddlama/agenix-rekey";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    authentik-nix = {
+      url = "github:nix-community/authentik-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    catppuccin-wallpapers = {
+      url = "github:zhichaoh/catppuccin-wallpapers";
+      flake = false;
+    };
+    claude-code-nix = {
+      url = "github:sadjow/claude-code-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    codex-cli-nix = {
+      url = "github:sadjow/codex-cli-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    darwin = {
+      url = "github:nix-darwin/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    den.url = "github:denful/den";
+    flake-compat.url = "github:NixOS/flake-compat";
+    flake-file.url = "github:vic/flake-file";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+    git-hooks = {
+      url = "github:cachix/git-hooks.nix";
+      inputs = {
+        flake-compat.follows = "flake-compat";
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    import-tree.url = "github:vic/import-tree";
+    nix-cachyos-kernel.url = "github:xddxdd/nix-cachyos-kernel/release";
+    nix-doom-emacs-unstraightened = {
+      url = "github:marienz/nix-doom-emacs-unstraightened";
+      inputs = {
+        doomdir.follows = "nixpkgs";
+        nixpkgs.follows = "nixpkgs";
+        systems.follows = "systems";
+      };
+    };
+    nix-index-database = {
+      url = "github:nix-community/nix-index-database";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nix-logseq-git-flake = {
+      url = "github:Bad3r/nix-logseq-git-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nix-minecraft = {
+      url = "github:Infinidoge/nix-minecraft";
+      inputs = {
+        flake-compat.follows = "flake-compat";
+        nixpkgs.follows = "nixpkgs";
+        systems.follows = "systems";
+      };
+    };
+    nixos-hardware = {
+      url = "github:NixOS/nixos-hardware";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    pedantix = {
+      url = "github:Swarsel/pedantix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    ragenix = {
+      url = "github:yaxitech/ragenix";
+      inputs = {
+        agenix.inputs = {
+          darwin.follows = "darwin";
+          home-manager.follows = "home-manager";
+          nixpkgs.follows = "nixpkgs";
+          systems.follows = "systems";
+        };
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+    stylix = {
+      url = "github:nix-community/stylix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    systems.url = "github:nix-systems/default";
+    terranix = {
+      url = "github:terranix/terranix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    zen-browser = {
+      url = "github:0xc000022070/zen-browser-flake";
+      inputs = {
+        home-manager.follows = "home-manager";
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+  };
 }

--- a/modules/aspects/defaults.nix
+++ b/modules/aspects/defaults.nix
@@ -9,18 +9,18 @@ let
   hmPlatforms =
     { aspect-chain, ... }:
     den._.forward {
+      adaptArgs = { config, ... }: { osConfig = config; };
       each = [
         "Linux"
         "Darwin"
         "Aarch64"
         "64bit"
       ];
+      fromAspect = _: lib.head aspect-chain;
       fromClass = platform: "hm${platform}";
+      guard = { pkgs, ... }: platform: lib.mkIf pkgs.stdenv."is${platform}";
       intoClass = _: "homeManager";
       intoPath = _: [ ];
-      fromAspect = _: lib.head aspect-chain;
-      guard = { pkgs, ... }: platform: lib.mkIf pkgs.stdenv."is${platform}";
-      adaptArgs = { config, ... }: { osConfig = config; };
     };
   secrets =
     {
@@ -29,39 +29,39 @@ let
       ...
     }:
     den._.forward {
+      adaptArgs = { config, ... }: {
+        inherit config;
+        inherit (config.age) secrets;
+      };
       each = [
         "nixos"
         "darwin"
         "homeManager"
       ];
+      fromAspect = _: lib.head aspect-chain;
       fromClass = _: "secrets";
+      fromCtx = _: lib.optionalAttrs (home != null) { inherit home; };
       intoClass = lib.id;
       intoPath = _: [
         "age"
         "secrets"
       ];
-      fromAspect = _: lib.head aspect-chain;
-      fromCtx = _: lib.optionalAttrs (home != null) { inherit home; };
-      adaptArgs = { config, ... }: {
-        inherit config;
-        inherit (config.age) secrets;
-      };
     };
   nixosSecrets =
     { aspect-chain, ... }:
     den._.forward {
+      adaptArgs = { config, ... }: {
+        inherit config;
+        inherit (config.age) secrets;
+      };
       each = [ "nixos" ];
+      fromAspect = _: lib.head aspect-chain;
       fromClass = _: "nixosSecrets";
       intoClass = lib.id;
       intoPath = _: [
         "age"
         "secrets"
       ];
-      fromAspect = _: lib.head aspect-chain;
-      adaptArgs = { config, ... }: {
-        inherit config;
-        inherit (config.age) secrets;
-      };
     };
 in
 {
@@ -93,9 +93,8 @@ in
         os.system.configurationRevision = self.rev or self.dirtyRev or null;
       };
       user = {
-        includes = [ my.starship ];
-
         classes = lib.mkDefault [ "homeManager" ];
+        includes = [ my.starship ];
       };
     };
   };

--- a/modules/aspects/defaults.nix
+++ b/modules/aspects/defaults.nix
@@ -1,6 +1,6 @@
 {
-  den,
   lib,
+  den,
   my,
   self,
   ...
@@ -10,17 +10,37 @@ let
     { aspect-chain, ... }:
     den._.forward {
       adaptArgs = { config, ... }: { osConfig = config; };
+
       each = [
         "Linux"
         "Darwin"
         "Aarch64"
         "64bit"
       ];
+
       fromAspect = _: lib.head aspect-chain;
       fromClass = platform: "hm${platform}";
       guard = { pkgs, ... }: platform: lib.mkIf pkgs.stdenv."is${platform}";
       intoClass = _: "homeManager";
       intoPath = _: [ ];
+    };
+  nixosSecrets =
+    { aspect-chain, ... }:
+    den._.forward {
+      adaptArgs = { config, ... }: {
+        inherit config;
+        inherit (config.age) secrets;
+      };
+
+      each = [ "nixos" ];
+      fromAspect = _: lib.head aspect-chain;
+      fromClass = _: "nixosSecrets";
+      intoClass = lib.id;
+
+      intoPath = _: [
+        "age"
+        "secrets"
+      ];
     };
   secrets =
     {
@@ -33,31 +53,18 @@ let
         inherit config;
         inherit (config.age) secrets;
       };
+
       each = [
         "nixos"
         "darwin"
         "homeManager"
       ];
+
       fromAspect = _: lib.head aspect-chain;
       fromClass = _: "secrets";
       fromCtx = _: lib.optionalAttrs (home != null) { inherit home; };
       intoClass = lib.id;
-      intoPath = _: [
-        "age"
-        "secrets"
-      ];
-    };
-  nixosSecrets =
-    { aspect-chain, ... }:
-    den._.forward {
-      adaptArgs = { config, ... }: {
-        inherit config;
-        inherit (config.age) secrets;
-      };
-      each = [ "nixos" ];
-      fromAspect = _: lib.head aspect-chain;
-      fromClass = _: "nixosSecrets";
-      intoClass = lib.id;
+
       intoPath = _: [
         "age"
         "secrets"
@@ -67,34 +74,34 @@ in
 {
   den = {
     default.includes = [
-      hmPlatforms
-
       den.batteries.define-user
       den.batteries.hostname
-
+      hmPlatforms
       my.secrets
       my.stylix
     ];
 
     schema = {
       home.includes = [
-        secrets
         my.nix
         my.starship
+        secrets
       ];
+
       host = {
         includes = [
-          nixosSecrets
-          secrets
           my.fonts
           my.nix
+          nixosSecrets
+          secrets
         ];
 
         os.system.configurationRevision = self.rev or self.dirtyRev or null;
       };
+
       user = {
-        classes = lib.mkDefault [ "homeManager" ];
         includes = [ my.starship ];
+        classes = lib.mkDefault [ "homeManager" ];
       };
     };
   };

--- a/modules/aspects/hosts/OMARSHAL-M-T2QF/OMARSHAL-M-T2QF.nix
+++ b/modules/aspects/hosts/OMARSHAL-M-T2QF/OMARSHAL-M-T2QF.nix
@@ -1,7 +1,5 @@
 { my, ... }: {
   den.aspects.OMARSHAL-M-T2QF = {
-    includes = with my; [ homebrew ];
-
     darwin = {
       age.rekey.hostPubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJYml5zuvVCI6yKyiCz9Jx5wv9S4OrzZRltqzEH1NQdC";
 
@@ -10,8 +8,17 @@
       # $ darwin-rebuild changelog
       system.stateVersion = 7;
     };
-
+    includes = with my; [ homebrew ];
     provides.oscar = {
+      hm64bit = { };
+      hmAarch64 = { };
+      hmDarwin = { };
+      # Den's allHomeNodes spawn re-walks the host aspect without the user's own includes, so none of the
+      # hmXxx keys are present at compile time. Without them, the hmXxx→homeManager forwards compiled by
+      # hmPlatforms become Tier 2 (complex) routes that call resolveSourceFallback, which creates a
+      # self-parent inner spawn and throws. Sentinel empty modules here make each key present so the
+      # forwards compile as Tier 1 (simple) routes instead.
+      hmLinux = { };
       homeManager = { config, pkgs, ... }: {
         # This value determines the Home Manager release that your configuration is compatible with. This helps
         # avoid breakage when a new Home Manager release introduces backwards incompatible changes.
@@ -19,44 +26,30 @@
         # You can update Home Manager without changing this value. See the Home Manager release notes for a list
         # of state version changes in each release.
         home.stateVersion = "26.11";
-
-        # fish defaults this to true for apropos completion, but it has no effect since
-        # programs.man.package is null on Darwin (macOS's own man is used instead).
-        programs.man.generateCaches = false;
-
         programs.codex.settings = {
-          model = "gpt-5.6-sol";
-          model_reasoning_effort = "medium";
           approvals_reviewer = "auto_review";
-
-          projects."${config.home.homeDirectory}/co/personal-assistant".trust_level = "trusted";
-
           # Only checked out on this machine.
           mcp_servers.outlook = {
-            command = "${pkgs.uv}/bin/uv";
             args = [
               "--directory"
               "${config.home.homeDirectory}/co/outlook-mcp-server"
               "run"
               "outlook-mcp"
             ];
+            command = "${pkgs.uv}/bin/uv";
             env = {
               OUTLOOK_MCP_CONFIG_DIR = "${config.xdg.configHome}/outlook/mcp/sessions";
               OUTLOOK_MCP_ENABLE_WRITE_TOOLS = "true";
             };
           };
+          model = "gpt-5.6-sol";
+          model_reasoning_effort = "medium";
+          projects."${config.home.homeDirectory}/co/personal-assistant".trust_level = "trusted";
         };
+        # fish defaults this to true for apropos completion, but it has no effect since
+        # programs.man.package is null on Darwin (macOS's own man is used instead).
+        programs.man.generateCaches = false;
       };
-
-      # Den's allHomeNodes spawn re-walks the host aspect without the user's own includes, so none of the
-      # hmXxx keys are present at compile time. Without them, the hmXxx→homeManager forwards compiled by
-      # hmPlatforms become Tier 2 (complex) routes that call resolveSourceFallback, which creates a
-      # self-parent inner spawn and throws. Sentinel empty modules here make each key present so the
-      # forwards compile as Tier 1 (simple) routes instead.
-      hmLinux = { };
-      hmDarwin = { };
-      hmAarch64 = { };
-      hm64bit = { };
     };
   };
 }

--- a/modules/aspects/hosts/OMARSHAL-M-T2QF/OMARSHAL-M-T2QF.nix
+++ b/modules/aspects/hosts/OMARSHAL-M-T2QF/OMARSHAL-M-T2QF.nix
@@ -1,14 +1,15 @@
 { my, ... }: {
   den.aspects.OMARSHAL-M-T2QF = {
+    includes = with my; [ homebrew ];
+
     darwin = {
       age.rekey.hostPubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJYml5zuvVCI6yKyiCz9Jx5wv9S4OrzZRltqzEH1NQdC";
-
       # Used for backwards compatibility, please read the changelog before changing.
       #
       # $ darwin-rebuild changelog
       system.stateVersion = 7;
     };
-    includes = with my; [ homebrew ];
+
     provides.oscar = {
       hm64bit = { };
       hmAarch64 = { };
@@ -19,6 +20,7 @@
       # self-parent inner spawn and throws. Sentinel empty modules here make each key present so the
       # forwards compile as Tier 1 (simple) routes instead.
       hmLinux = { };
+
       homeManager = { config, pkgs, ... }: {
         # This value determines the Home Manager release that your configuration is compatible with. This helps
         # avoid breakage when a new Home Manager release introduces backwards incompatible changes.
@@ -26,29 +28,37 @@
         # You can update Home Manager without changing this value. See the Home Manager release notes for a list
         # of state version changes in each release.
         home.stateVersion = "26.11";
-        programs.codex.settings = {
-          approvals_reviewer = "auto_review";
-          # Only checked out on this machine.
-          mcp_servers.outlook = {
-            args = [
-              "--directory"
-              "${config.home.homeDirectory}/co/outlook-mcp-server"
-              "run"
-              "outlook-mcp"
-            ];
-            command = "${pkgs.uv}/bin/uv";
-            env = {
-              OUTLOOK_MCP_CONFIG_DIR = "${config.xdg.configHome}/outlook/mcp/sessions";
-              OUTLOOK_MCP_ENABLE_WRITE_TOOLS = "true";
+
+        programs = {
+          codex.settings = {
+            approvals_reviewer = "auto_review";
+
+            # Only checked out on this machine.
+            mcp_servers.outlook = {
+              args = [
+                "--directory"
+                "${config.home.homeDirectory}/co/outlook-mcp-server"
+                "run"
+                "outlook-mcp"
+              ];
+
+              command = "${pkgs.uv}/bin/uv";
+
+              env = {
+                OUTLOOK_MCP_CONFIG_DIR = "${config.xdg.configHome}/outlook/mcp/sessions";
+                OUTLOOK_MCP_ENABLE_WRITE_TOOLS = "true";
+              };
             };
+
+            model = "gpt-5.6-sol";
+            model_reasoning_effort = "medium";
+            projects."${config.home.homeDirectory}/co/personal-assistant".trust_level = "trusted";
           };
-          model = "gpt-5.6-sol";
-          model_reasoning_effort = "medium";
-          projects."${config.home.homeDirectory}/co/personal-assistant".trust_level = "trusted";
+
+          # fish defaults this to true for apropos completion, but it has no effect since
+          # programs.man.package is null on Darwin (macOS's own man is used instead).
+          man.generateCaches = false;
         };
-        # fish defaults this to true for apropos completion, but it has no effect since
-        # programs.man.package is null on Darwin (macOS's own man is used instead).
-        programs.man.generateCaches = false;
       };
     };
   };

--- a/modules/aspects/hosts/harmony/hardware-configuration.nix
+++ b/modules/aspects/hosts/harmony/hardware-configuration.nix
@@ -10,32 +10,44 @@
       ...
     }:
     {
+      imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
+
       boot = {
         extraModulePackages = [ ];
-        initrd.availableKernelModules = [
-          "xhci_pci"
-          "ahci"
-          "nvme"
-          "usbhid"
-          "sd_mod"
-        ];
-        initrd.kernelModules = [ ];
+
+        initrd = {
+          availableKernelModules = [
+            "xhci_pci"
+            "ahci"
+            "nvme"
+            "usbhid"
+            "sd_mod"
+          ];
+
+          kernelModules = [ ];
+        };
+
         kernelModules = [ "kvm-intel" ];
       };
-      fileSystems."/" = {
-        device = "/dev/disk/by-uuid/d4c201a1-20a4-4b67-ac13-eeb7ed133a50";
-        fsType = "ext4";
+
+      fileSystems = {
+        "/" = {
+          device = "/dev/disk/by-uuid/d4c201a1-20a4-4b67-ac13-eeb7ed133a50";
+          fsType = "ext4";
+        };
+
+        "/boot" = {
+          options = [
+            "fmask=0077"
+            "dmask=0077"
+          ];
+
+          device = "/dev/disk/by-uuid/23DE-E9DA";
+          fsType = "vfat";
+        };
       };
-      fileSystems."/boot" = {
-        device = "/dev/disk/by-uuid/23DE-E9DA";
-        fsType = "vfat";
-        options = [
-          "fmask=0077"
-          "dmask=0077"
-        ];
-      };
+
       hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
-      imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
       nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
       swapDevices = [ ];
     };

--- a/modules/aspects/hosts/harmony/hardware-configuration.nix
+++ b/modules/aspects/hosts/harmony/hardware-configuration.nix
@@ -10,9 +10,8 @@
       ...
     }:
     {
-      imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
-
       boot = {
+        extraModulePackages = [ ];
         initrd.availableKernelModules = [
           "xhci_pci"
           "ahci"
@@ -22,14 +21,11 @@
         ];
         initrd.kernelModules = [ ];
         kernelModules = [ "kvm-intel" ];
-        extraModulePackages = [ ];
       };
-
       fileSystems."/" = {
         device = "/dev/disk/by-uuid/d4c201a1-20a4-4b67-ac13-eeb7ed133a50";
         fsType = "ext4";
       };
-
       fileSystems."/boot" = {
         device = "/dev/disk/by-uuid/23DE-E9DA";
         fsType = "vfat";
@@ -38,10 +34,9 @@
           "dmask=0077"
         ];
       };
-
-      swapDevices = [ ];
-
-      nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
       hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+      imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
+      nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+      swapDevices = [ ];
     };
 }

--- a/modules/aspects/hosts/harmony/harmony.nix
+++ b/modules/aspects/hosts/harmony/harmony.nix
@@ -1,5 +1,23 @@
 { den, my, ... }: {
   den.aspects.harmony = {
+    dataset =
+      map
+        (name: {
+          inherit name;
+          guestAccess = true;
+          pool = "metalminds";
+          samba = true;
+        })
+        [
+          "backups"
+          "documents"
+          "movies"
+          "music"
+          "pictures"
+          "shows"
+          "torrents"
+          "yarg-charts"
+        ];
     includes = with my; [
       (auto-upgrade { allowReboot = true; })
       (authentik { global = true; })
@@ -40,26 +58,6 @@
       unpackerr
       (zfs [ "metalminds" ])
     ];
-
-    dataset =
-      map
-        (name: {
-          pool = "metalminds";
-          inherit name;
-          samba = true;
-          guestAccess = true;
-        })
-        [
-          "backups"
-          "documents"
-          "movies"
-          "music"
-          "pictures"
-          "shows"
-          "torrents"
-          "yarg-charts"
-        ];
-
     nixos = {
       age.rekey.hostPubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMkM5uNY0rMy2QMG6IptlxgVl4sQWoeSSNmUp7/f2z1B";
       networking.hostId = "7dab76c0";
@@ -88,19 +86,18 @@
       # https://nixos.org/manual/nixos/stable/options#opt-system.stateVersion .
       system.stateVersion = "25.05"; # Did you read the comment?
     };
-
     # This value determines the Home Manager release that your configuration is compatible with. This helps avoid
     # breakage when a new Home Manager release introduces backwards incompatible changes.
     #
     # You can update Home Manager without changing this value. See the Home Manager release notes for a list of state
     # version changes in each release.
     provides.oscar = {
-      homeManager.home.stateVersion = "25.05";
+      hm64bit = { };
+      hmAarch64 = { };
+      hmDarwin = { };
       # See the comment in OMARSHAL-M-T2QF.nix for why these sentinels are needed.
       hmLinux = { };
-      hmDarwin = { };
-      hmAarch64 = { };
-      hm64bit = { };
+      homeManager.home.stateVersion = "25.05";
     };
   };
 }

--- a/modules/aspects/hosts/harmony/harmony.nix
+++ b/modules/aspects/hosts/harmony/harmony.nix
@@ -1,5 +1,46 @@
 { den, my, ... }: {
   den.aspects.harmony = {
+    includes = with my; [
+      (authentik { global = true; })
+      (auto-upgrade { allowReboot = true; })
+      (autobrr { })
+      (bookshelf-audiobooks { })
+      (bookshelf-ebooks { })
+      (cachyos-kernel { variant = "server"; })
+      (collabora-online { })
+      (immich {
+        administrators = [ "oscar" ];
+        global = true;
+      })
+      (netdata { })
+      (nextcloud { global = true; })
+      (plex { global = true; })
+      (profilarr { })
+      (prowlarr { })
+      (qbittorrent { administrators = [ "oscar" ]; })
+      (radarr { administrators = [ "oscar" ]; })
+      (seerr { global = true; })
+      (sonarr { administrators = [ "oscar" ]; })
+      (storyteller { global = true; })
+      (tautulli { })
+      (zfs [ "metalminds" ])
+      boot
+      cross-seed
+      den.aspects.oscar.provides.minecraft-servers
+      dns
+      gluetun
+      homepage
+      lm-sensors
+      locale
+      meraki
+      networkmanager
+      nginx
+      samba
+      satisfactory-server
+      ssh-server
+      unpackerr
+    ];
+
     dataset =
       map
         (name: {
@@ -18,46 +59,7 @@
           "torrents"
           "yarg-charts"
         ];
-    includes = with my; [
-      (auto-upgrade { allowReboot = true; })
-      (authentik { global = true; })
-      (autobrr { })
-      (bookshelf-audiobooks { })
-      (bookshelf-ebooks { })
-      boot
-      (cachyos-kernel { variant = "server"; })
-      (collabora-online { })
-      cross-seed
-      dns
-      gluetun
-      homepage
-      (immich {
-        administrators = [ "oscar" ];
-        global = true;
-      })
-      lm-sensors
-      locale
-      meraki
-      (netdata { })
-      networkmanager
-      (nextcloud { global = true; })
-      nginx
-      den.aspects.oscar.provides.minecraft-servers
-      (plex { global = true; })
-      (profilarr { })
-      (prowlarr { })
-      (qbittorrent { administrators = [ "oscar" ]; })
-      (radarr { administrators = [ "oscar" ]; })
-      samba
-      satisfactory-server
-      (seerr { global = true; })
-      (sonarr { administrators = [ "oscar" ]; })
-      ssh-server
-      (storyteller { global = true; })
-      (tautulli { })
-      unpackerr
-      (zfs [ "metalminds" ])
-    ];
+
     nixos = {
       age.rekey.hostPubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMkM5uNY0rMy2QMG6IptlxgVl4sQWoeSSNmUp7/f2z1B";
       networking.hostId = "7dab76c0";
@@ -86,6 +88,7 @@
       # https://nixos.org/manual/nixos/stable/options#opt-system.stateVersion .
       system.stateVersion = "25.05"; # Did you read the comment?
     };
+
     # This value determines the Home Manager release that your configuration is compatible with. This helps avoid
     # breakage when a new Home Manager release introduces backwards incompatible changes.
     #

--- a/modules/aspects/hosts/melaan/hardware-configuration.nix
+++ b/modules/aspects/hosts/melaan/hardware-configuration.nix
@@ -10,9 +10,8 @@
       ...
     }:
     {
-      imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
-
       boot = {
+        extraModulePackages = [ ];
         initrd = {
           availableKernelModules = [
             "xhci_pci"
@@ -23,9 +22,7 @@
           kernelModules = [ ];
         };
         kernelModules = [ "kvm-intel" ];
-        extraModulePackages = [ ];
       };
-
       fileSystems = {
         "/" = {
           device = "/dev/disk/by-uuid/97fa9e33-f044-41f2-ba6b-d493d82a144b";
@@ -40,10 +37,9 @@
           ];
         };
       };
-
-      swapDevices = [ { device = "/dev/disk/by-uuid/58f51069-e018-4f9c-bb1b-71c4bcc9ce81"; } ];
-
-      nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
       hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+      imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
+      nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+      swapDevices = [ { device = "/dev/disk/by-uuid/58f51069-e018-4f9c-bb1b-71c4bcc9ce81"; } ];
     };
 }

--- a/modules/aspects/hosts/melaan/hardware-configuration.nix
+++ b/modules/aspects/hosts/melaan/hardware-configuration.nix
@@ -10,8 +10,11 @@
       ...
     }:
     {
+      imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
+
       boot = {
         extraModulePackages = [ ];
+
         initrd = {
           availableKernelModules = [
             "xhci_pci"
@@ -19,26 +22,31 @@
             "usb_storage"
             "sd_mod"
           ];
+
           kernelModules = [ ];
         };
+
         kernelModules = [ "kvm-intel" ];
       };
+
       fileSystems = {
         "/" = {
           device = "/dev/disk/by-uuid/97fa9e33-f044-41f2-ba6b-d493d82a144b";
           fsType = "ext4";
         };
+
         "/boot" = {
-          device = "/dev/disk/by-uuid/1698-87D0";
-          fsType = "vfat";
           options = [
             "fmask=0077"
             "dmask=0077"
           ];
+
+          device = "/dev/disk/by-uuid/1698-87D0";
+          fsType = "vfat";
         };
       };
+
       hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
-      imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
       nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
       swapDevices = [ { device = "/dev/disk/by-uuid/58f51069-e018-4f9c-bb1b-71c4bcc9ce81"; } ];
     };

--- a/modules/aspects/hosts/melaan/melaan.nix
+++ b/modules/aspects/hosts/melaan/melaan.nix
@@ -1,9 +1,4 @@
 { inputs, my, ... }: {
-  flake-file.inputs.nixos-hardware = {
-    url = "github:NixOS/nixos-hardware";
-    inputs.nixpkgs.follows = "nixpkgs";
-  };
-
   den.aspects.melaan = {
     includes = with my; [
       (auto-upgrade { allowReboot = false; })
@@ -17,16 +12,13 @@
     ];
 
     nixos = {
-      imports = [ (inputs.nixos-hardware.nixosModules.framework-12-13th-gen-intel or { }) ];
-
       age.rekey.hostPubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILqFHtkApjVtbJj4hR4sEyHJhwrZ74+gR3OviJk9VxYb";
-
+      imports = [ (inputs.nixos-hardware.nixosModules.framework-12-13th-gen-intel or { }) ];
       services = {
         flatpak.enable = true;
         openssh.enable = true;
         printing.enable = true;
       };
-
       # This option defines the first version of NixOS you have installed on this particular machine, and is used to
       # maintain compatibility with application data (e.g. databases) created on older NixOS versions.
       #
@@ -56,10 +48,10 @@
       let
         # See the comment in OMARSHAL-M-T2QF.nix for why these sentinels are needed.
         hmSentinels = {
-          hmLinux = { };
-          hmDarwin = { };
-          hmAarch64 = { };
           hm64bit = { };
+          hmAarch64 = { };
+          hmDarwin = { };
+          hmLinux = { };
         };
       in
       {
@@ -70,5 +62,9 @@
           homeManager.home.stateVersion = "25.05";
         };
       };
+  };
+  flake-file.inputs.nixos-hardware = {
+    inputs.nixpkgs.follows = "nixpkgs";
+    url = "github:NixOS/nixos-hardware";
   };
 }

--- a/modules/aspects/hosts/melaan/melaan.nix
+++ b/modules/aspects/hosts/melaan/melaan.nix
@@ -1,9 +1,14 @@
 { inputs, my, ... }: {
+  flake-file.inputs.nixos-hardware = {
+    url = "github:NixOS/nixos-hardware";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+
   den.aspects.melaan = {
     includes = with my; [
       (auto-upgrade { allowReboot = false; })
-      boot
       (cachyos-kernel { })
+      boot
       gnome
       locale
       networkmanager
@@ -12,13 +17,15 @@
     ];
 
     nixos = {
-      age.rekey.hostPubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILqFHtkApjVtbJj4hR4sEyHJhwrZ74+gR3OviJk9VxYb";
       imports = [ (inputs.nixos-hardware.nixosModules.framework-12-13th-gen-intel or { }) ];
+      age.rekey.hostPubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILqFHtkApjVtbJj4hR4sEyHJhwrZ74+gR3OviJk9VxYb";
+
       services = {
         flatpak.enable = true;
         openssh.enable = true;
         printing.enable = true;
       };
+
       # This option defines the first version of NixOS you have installed on this particular machine, and is used to
       # maintain compatibility with application data (e.g. databases) created on older NixOS versions.
       #
@@ -58,13 +65,10 @@
         adelline = hmSentinels // {
           homeManager.home.stateVersion = "25.05";
         };
+
         oscar = hmSentinels // {
           homeManager.home.stateVersion = "25.05";
         };
       };
-  };
-  flake-file.inputs.nixos-hardware = {
-    inputs.nixpkgs.follows = "nixpkgs";
-    url = "github:NixOS/nixos-hardware";
   };
 }

--- a/modules/aspects/my/authentik.nix
+++ b/modules/aspects/my/authentik.nix
@@ -4,8 +4,8 @@ let
 in
 {
   flake-file.inputs.authentik-nix = {
-    url = "github:nix-community/authentik-nix";
     inputs.nixpkgs.follows = "nixpkgs";
+    url = "github:nix-community/authentik-nix";
   };
 
   my.authentik =
@@ -25,6 +25,76 @@ in
       url = if global then "auth.${domain}" else "auth.${host.name}.${domain}";
     in
     {
+      nixos = { config, ... }: {
+        imports = [ (inputs.authentik-nix.nixosModules.default or { }) ];
+
+        services.authentik = {
+          enable = true;
+          environmentFile = config.age.secrets."authentik.env".path;
+          nginx = {
+            enable = true;
+            enableACME = true;
+            host = url;
+          };
+          settings.disable_startup_analytics = true;
+        };
+
+        # nginx.nix forces `HttpOnly` onto every proxied cookie, but Authentik's frontend needs to
+        # read its CSRF cookie via JavaScript (it echoes the value back as the X-Authentik-Csrf
+        # header). With HttpOnly forced on, that read fails and Authentik rejects the empty token
+        # with "CSRF token ... incorrect length". Reset the cookie rewrite for this vhost only.
+        services.nginx.virtualHosts.${url}.extraConfig = ''
+          proxy_cookie_path / /;
+        '';
+      };
+      secrets = { secrets, ... }: {
+        authentik-secret-key = {
+          generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -base64 60";
+          intermediary = true;
+        };
+        # Consumed both by `authentik.env` below (so Authentik mints it as `akadmin`'s API token
+        # on first boot, under the DIFFERENT env var name that bootstrap mechanism expects) and,
+        # via `settings.terraform = true;`, by harmony's shared Terraform env (as `AUTHENTIK_TOKEN`)
+        # - see the `terranix` field's comment for why a bootstrap token rather than a UI-created
+        # one.
+        authentik-token = {
+          generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -hex 32";
+          intermediary = true;
+          settings.terraform = true;
+        };
+        "authentik.env".generator = {
+          dependencies = { inherit (secrets) authentik-secret-key authentik-token; };
+          script =
+            {
+              decrypt,
+              deps,
+              lib,
+              ...
+            }:
+            ''
+              printf 'AUTHENTIK_SECRET_KEY=%s\n' "$(${decrypt} ${lib.escapeShellArg deps.authentik-secret-key.file})"
+              printf 'AUTHENTIK_BOOTSTRAP_TOKEN=%s\n' "$(${decrypt} ${lib.escapeShellArg deps.authentik-token.file})"
+            '';
+        };
+
+        # Both come from an external dashboard (Discord's, Plex's own account), so - unlike the
+        # generated secrets above - these use `rekeyFile` and need a one-time `agenix edit` (see
+        # the `terranix` field's comment for where each value comes from), same as
+        # `cloudflare-api-token`/`meraki-dashboard-api-key`. `settings.terraform = "variable";`
+        # (not `= true;`) because they're only ever consumed as Terraform `variable`s, never by a
+        # NixOS service directly - see modules/terranix.nix's header comment on the two modes.
+        discord-client-secret = {
+          intermediary = true;
+          rekeyFile = ../../../secrets/discord-client-secret.age;
+          settings.terraform = "variable";
+        };
+
+        plex-token = {
+          intermediary = true;
+          rekeyFile = ../../../secrets/plex-token.age;
+          settings.terraform = "variable";
+        };
+      };
       # SSO-as-code, managed via terranix (Nix -> Terraform config, see modules/terranix.nix) and
       # the authentik Terraform provider - see dns.nix/meraki.nix for the general pattern
       # (`nix run .#<host>-tf[.plan|.destroy]`, `nix develop .#<host>-tf`,
@@ -109,7 +179,7 @@ in
       # these out of the plaintext git history; `settings.terraform = "variable";` (below, on each
       # secret) is just how their values reach the `variable`s that encryption config wraps.
       terranix =
-        { virtual-host, lib, ... }:
+        { lib, virtual-host, ... }:
         let
           protected-hosts = lib.filter (vh: vh.protected or false) virtual-host;
           oidc-hosts = lib.filter (vh: vh ? oidc) virtual-host;
@@ -119,7 +189,8 @@ in
           # `oidc` field comment for why both need a redirect URI registered, not just one.
           # `unique` because a `global` host whose `url` override IS already the canonical name
           # (storyteller.nix) would otherwise register every redirect URI twice.
-          hostnames-of = vh: lib.unique ([ (hostname-of vh) ] ++ lib.optional (vh.global or false) "${vh.name}.${domain}");
+          hostnames-of =
+            vh: lib.unique ([ (hostname-of vh) ] ++ lib.optional (vh.global or false) "${vh.name}.${domain}");
 
           # The `group` (virtual-host.nix) whose applications everyone gets, rather than just
           # `admins` - the same string the Homepage dashboard and Authentik's library file these
@@ -141,9 +212,9 @@ in
             lib.imap0 (
               index: group-name:
               lib.nameValuePair "${app-key}-${group-name}" {
-                target = "\${authentik_application.${app-key}.uuid}";
                 group = "\${authentik_group.${group-name}.id}";
                 order = index;
+                target = "\${authentik_application.${app-key}.uuid}";
               }
             ) ([ "admin" ] ++ lib.optional (vh.group or null == open-group) "user");
 
@@ -194,15 +265,6 @@ in
         # branch silently clobber the earlier ones' resources instead of adding to them.
         lib.foldl' lib.recursiveUpdate
           {
-            terraform.required_providers.authentik = {
-              source = "goauthentik/authentik";
-              version = "~> 2026";
-            };
-
-            # `token` isn't set here - the provider reads it from AUTHENTIK_TOKEN (see above); `url`
-            # isn't secret, so it's set directly rather than round-tripped through an env var.
-            provider.authentik.url = "https://${url}";
-
             data.authentik_flow = {
               default-authorization-flow.slug = "default-provider-authorization-implicit-consent";
               default-invalidation-flow.slug = "default-provider-invalidation-flow";
@@ -211,10 +273,9 @@ in
               default-source-authentication.slug = "default-source-authentication";
               default-source-enrollment.slug = "default-source-enrollment";
             };
-
-            variable.DISCORD_CLIENT_SECRET.sensitive = true;
-            variable.PLEX_TOKEN.sensitive = true;
-
+            # `token` isn't set here - the provider reads it from AUTHENTIK_TOKEN (see above); `url`
+            # isn't secret, so it's set directly rather than round-tripped through an env var.
+            provider.authentik.url = "https://${url}";
             # Groups live here rather than on the services that consume them: they're a DIRECTORY
             # concept (authentik.nix owns every `authentik_*` resource, the way dns.nix owns every
             # `cloudflare_*` one), and three unrelated things key off them already - the application
@@ -240,70 +301,86 @@ in
             resource.authentik_group = lib.genAttrs [ "admin" "user" ] (name: {
               inherit name;
             });
-
             resource.authentik_source_oauth.discord = {
-              name = "Discord";
-              slug = "discord";
               authentication_flow = "\${data.authentik_flow.default-source-authentication.id}";
-              enrollment_flow = "\${data.authentik_flow.default-source-enrollment.id}";
-              provider_type = "discord";
               consumer_key = discord-client-id;
               consumer_secret = "\${var.${tf-var-name-of "discord-client-secret"}}";
-            };
-
-            resource.authentik_source_plex.plex = {
-              name = "Plex";
-              slug = "plex";
-              authentication_flow = "\${data.authentik_flow.default-source-authentication.id}";
               enrollment_flow = "\${data.authentik_flow.default-source-enrollment.id}";
-              client_id = plex-client-id;
-              plex_token = "\${var.${tf-var-name-of "plex-token"}}";
-              allowed_servers = plex-allowed-servers;
-              allow_friends = true;
+              name = "Discord";
+              provider_type = "discord";
+              slug = "discord";
             };
+            resource.authentik_source_plex.plex = {
+              allow_friends = true;
+              allowed_servers = plex-allowed-servers;
+              authentication_flow = "\${data.authentik_flow.default-source-authentication.id}";
+              client_id = plex-client-id;
+              enrollment_flow = "\${data.authentik_flow.default-source-enrollment.id}";
+              name = "Plex";
+              plex_token = "\${var.${tf-var-name-of "plex-token"}}";
+              slug = "plex";
+            };
+            terraform.required_providers.authentik = {
+              source = "goauthentik/authentik";
+              version = "~> 2026";
+            };
+            variable.DISCORD_CLIENT_SECRET.sensitive = true;
+            variable.PLEX_TOKEN.sensitive = true;
           }
           [
             (lib.optionalAttrs (protected-hosts != [ ]) {
-              resource.authentik_provider_proxy = lib.listToAttrs (
-                map (vh: {
-                  name = vh.name;
-                  value = {
-                    name = vh.name;
-                    mode = "forward_single";
-                    external_host = "https://${hostname-of vh}";
-                    authorization_flow = "\${data.authentik_flow.default-authorization-flow.id}";
-                    invalidation_flow = "\${data.authentik_flow.default-invalidation-flow.id}";
-                  };
-                }) protected-hosts
-              );
-
               resource.authentik_application = lib.listToAttrs (
                 map (vh: {
                   name = vh.name;
                   value = {
                     name = vh.label or vh.name;
-                    slug = vh.name;
                     protocol_provider = "\${authentik_provider_proxy.${vh.name}.id}";
+                    slug = vh.name;
                   }
                   // lib.optionalAttrs (vh ? icon) { meta_icon = icon-url-of vh.icon; }
                   // lib.optionalAttrs (vh ? group) { inherit (vh) group; };
                 }) protected-hosts
               );
-
-              resource.authentik_policy_binding = lib.listToAttrs (
-                lib.concatMap (vh: binding-entries-for vh.name vh) protected-hosts
-              );
-
               resource.authentik_outpost.embedded = {
                 name = "authentik Embedded Outpost";
                 protocol_providers = map (vh: "\${authentik_provider_proxy.${vh.name}.id}") protected-hosts;
               };
+              resource.authentik_policy_binding = lib.listToAttrs (
+                lib.concatMap (vh: binding-entries-for vh.name vh) protected-hosts
+              );
+              resource.authentik_provider_proxy = lib.listToAttrs (
+                map (vh: {
+                  name = vh.name;
+                  value = {
+                    authorization_flow = "\${data.authentik_flow.default-authorization-flow.id}";
+                    external_host = "https://${hostname-of vh}";
+                    invalidation_flow = "\${data.authentik_flow.default-invalidation-flow.id}";
+                    mode = "forward_single";
+                    name = vh.name;
+                  };
+                }) protected-hosts
+              );
             })
             (lib.optionalAttrs (oidc-hosts != [ ]) {
-              variable = lib.genAttrs (map (vh: tf-var-name-of vh.oidc.client-secret) oidc-hosts) (_: {
-                sensitive = true;
-              });
-
+              # `signing_key`: with none attached, authentik doesn't fall back to a default keypair -
+              # it signs id_tokens with the CLIENT SECRET under HS256 ("No Certificate at all,
+              # assume HS256", `OAuth2Provider.jwt_key`). Clients that actually verify the id_token
+              # expect an asymmetric alg and reject that; Immich, whose default `signingAlgorithm` is
+              # RS256, fails the login with "unexpected JWT alg received" and even names this exact
+              # cause in its own warning ("...or that you have specified a signing key in your OAuth
+              # provider"). This is the keypair authentik generates for itself on first start, and
+              # it's RSA (`CertificateBuilder.alg` is `PrivateKeyAlg.RSA`), so `jwt_key` reports
+              # RS256 - matching what these clients expect without further configuration.
+              #
+              # `fetch_certificate`/`fetch_key` OFF because both default ON, and `key_data` would
+              # pull authentik's PRIVATE KEY into the state file - which, for harmony, is committed
+              # to this public repo (see the header comment on encryption). Only `.id` is needed to
+              # reference the keypair, and that's returned regardless.
+              data.authentik_certificate_key_pair.signing = {
+                fetch_certificate = false;
+                fetch_key = false;
+                name = "authentik Self-signed Certificate";
+              };
               # `grant_types`, `property_mappings` and `signing_key` below ALL have to be spelled
               # out, for the same underlying reason: authentik's API defaults them to empty and only
               # its own admin UI pre-fills them, so a provider built through the API (like these)
@@ -335,40 +412,25 @@ in
                 "goauthentik.io/providers/oauth2/scope-email"
                 "goauthentik.io/providers/oauth2/scope-profile"
               ];
-
-              # `signing_key`: with none attached, authentik doesn't fall back to a default keypair -
-              # it signs id_tokens with the CLIENT SECRET under HS256 ("No Certificate at all,
-              # assume HS256", `OAuth2Provider.jwt_key`). Clients that actually verify the id_token
-              # expect an asymmetric alg and reject that; Immich, whose default `signingAlgorithm` is
-              # RS256, fails the login with "unexpected JWT alg received" and even names this exact
-              # cause in its own warning ("...or that you have specified a signing key in your OAuth
-              # provider"). This is the keypair authentik generates for itself on first start, and
-              # it's RSA (`CertificateBuilder.alg` is `PrivateKeyAlg.RSA`), so `jwt_key` reports
-              # RS256 - matching what these clients expect without further configuration.
-              #
-              # `fetch_certificate`/`fetch_key` OFF because both default ON, and `key_data` would
-              # pull authentik's PRIVATE KEY into the state file - which, for harmony, is committed
-              # to this public repo (see the header comment on encryption). Only `.id` is needed to
-              # reference the keypair, and that's returned regardless.
-              data.authentik_certificate_key_pair.signing = {
-                name = "authentik Self-signed Certificate";
-                fetch_certificate = false;
-                fetch_key = false;
-              };
-
+              resource.authentik_application = lib.listToAttrs (
+                map (vh: {
+                  name = "${vh.name}-oidc";
+                  value = {
+                    name = vh.label or vh.name;
+                    protocol_provider = "\${authentik_provider_oauth2.${vh.name}-oidc.id}";
+                    slug = vh.name;
+                  }
+                  // lib.optionalAttrs (vh ? icon) { meta_icon = icon-url-of vh.icon; }
+                  // lib.optionalAttrs (vh ? group) { inherit (vh) group; };
+                }) oidc-hosts
+              );
+              resource.authentik_policy_binding = lib.listToAttrs (
+                lib.concatMap (vh: binding-entries-for "${vh.name}-oidc" vh) oidc-hosts
+              );
               resource.authentik_provider_oauth2 = lib.listToAttrs (
                 map (vh: {
                   name = "${vh.name}-oidc";
                   value = {
-                    name = vh.name;
-                    client_id = vh.name;
-                    client_secret = "\${var.${tf-var-name-of vh.oidc.client-secret}}";
-                    grant_types = [
-                      "authorization_code"
-                      "refresh_token"
-                    ];
-                    property_mappings = "\${data.authentik_property_mapping_provider_scope.oidc-defaults.ids}";
-                    signing_key = "\${data.authentik_certificate_key_pair.signing.id}";
                     allowed_redirect_uris = lib.concatMap (
                       hostname:
                       map (path: {
@@ -378,30 +440,24 @@ in
                       }) vh.oidc.redirect-paths
                     ) (hostnames-of vh);
                     authorization_flow = "\${data.authentik_flow.default-authorization-flow.id}";
+                    client_id = vh.name;
+                    client_secret = "\${var.${tf-var-name-of vh.oidc.client-secret}}";
+                    grant_types = [
+                      "authorization_code"
+                      "refresh_token"
+                    ];
                     invalidation_flow = "\${data.authentik_flow.default-invalidation-flow.id}";
+                    name = vh.name;
+                    property_mappings = "\${data.authentik_property_mapping_provider_scope.oidc-defaults.ids}";
+                    signing_key = "\${data.authentik_certificate_key_pair.signing.id}";
                   };
                 }) oidc-hosts
               );
-
-              resource.authentik_application = lib.listToAttrs (
-                map (vh: {
-                  name = "${vh.name}-oidc";
-                  value = {
-                    name = vh.label or vh.name;
-                    slug = vh.name;
-                    protocol_provider = "\${authentik_provider_oauth2.${vh.name}-oidc.id}";
-                  }
-                  // lib.optionalAttrs (vh ? icon) { meta_icon = icon-url-of vh.icon; }
-                  // lib.optionalAttrs (vh ? group) { inherit (vh) group; };
-                }) oidc-hosts
-              );
-
-              resource.authentik_policy_binding = lib.listToAttrs (
-                lib.concatMap (vh: binding-entries-for "${vh.name}-oidc" vh) oidc-hosts
-              );
+              variable = lib.genAttrs (map (vh: tf-var-name-of vh.oidc.client-secret) oidc-hosts) (_: {
+                sensitive = true;
+              });
             })
           ];
-
       # No `port`: authentik-nix's own module wires `services.nginx.virtualHosts.${url}.locations`
       # directly (see `services.authentik.nginx` below), same pattern as Nextcloud's PHP-FPM vhost.
       # This entry only exists so nginx.nix's `serverAliases`/global-toggle and homepage.nix's
@@ -413,87 +469,15 @@ in
       # binding's comment above for why Authentik's `global` means something stronger than every
       # other service's (replace, not merely alias).
       virtual-host = {
-        name = "auth";
-        host = host.name;
         inherit global url;
-        label = "Authentik";
-        icon = "authentik.svg";
         group = "Infra";
         homepage = {
           description = "Single sign-on";
         };
-      };
-
-      secrets = { secrets, ... }: {
-        authentik-secret-key = {
-          generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -base64 60";
-          intermediary = true;
-        };
-        # Consumed both by `authentik.env` below (so Authentik mints it as `akadmin`'s API token
-        # on first boot, under the DIFFERENT env var name that bootstrap mechanism expects) and,
-        # via `settings.terraform = true;`, by harmony's shared Terraform env (as `AUTHENTIK_TOKEN`)
-        # - see the `terranix` field's comment for why a bootstrap token rather than a UI-created
-        # one.
-        authentik-token = {
-          generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -hex 32";
-          intermediary = true;
-          settings.terraform = true;
-        };
-        "authentik.env".generator = {
-          dependencies = { inherit (secrets) authentik-secret-key authentik-token; };
-          script =
-            {
-              lib,
-              decrypt,
-              deps,
-              ...
-            }:
-            ''
-              printf 'AUTHENTIK_SECRET_KEY=%s\n' "$(${decrypt} ${lib.escapeShellArg deps.authentik-secret-key.file})"
-              printf 'AUTHENTIK_BOOTSTRAP_TOKEN=%s\n' "$(${decrypt} ${lib.escapeShellArg deps.authentik-token.file})"
-            '';
-        };
-
-        # Both come from an external dashboard (Discord's, Plex's own account), so - unlike the
-        # generated secrets above - these use `rekeyFile` and need a one-time `agenix edit` (see
-        # the `terranix` field's comment for where each value comes from), same as
-        # `cloudflare-api-token`/`meraki-dashboard-api-key`. `settings.terraform = "variable";`
-        # (not `= true;`) because they're only ever consumed as Terraform `variable`s, never by a
-        # NixOS service directly - see modules/terranix.nix's header comment on the two modes.
-        discord-client-secret = {
-          rekeyFile = ../../../secrets/discord-client-secret.age;
-          intermediary = true;
-          settings.terraform = "variable";
-        };
-
-        plex-token = {
-          rekeyFile = ../../../secrets/plex-token.age;
-          intermediary = true;
-          settings.terraform = "variable";
-        };
-      };
-
-      nixos = { config, ... }: {
-        imports = [ (inputs.authentik-nix.nixosModules.default or { }) ];
-
-        services.authentik = {
-          enable = true;
-          environmentFile = config.age.secrets."authentik.env".path;
-          settings.disable_startup_analytics = true;
-          nginx = {
-            enable = true;
-            enableACME = true;
-            host = url;
-          };
-        };
-
-        # nginx.nix forces `HttpOnly` onto every proxied cookie, but Authentik's frontend needs to
-        # read its CSRF cookie via JavaScript (it echoes the value back as the X-Authentik-Csrf
-        # header). With HttpOnly forced on, that read fails and Authentik rejects the empty token
-        # with "CSRF token ... incorrect length". Reset the cookie rewrite for this vhost only.
-        services.nginx.virtualHosts.${url}.extraConfig = ''
-          proxy_cookie_path / /;
-        '';
+        host = host.name;
+        icon = "authentik.svg";
+        label = "Authentik";
+        name = "auth";
       };
     };
 }

--- a/modules/aspects/my/authentik.nix
+++ b/modules/aspects/my/authentik.nix
@@ -4,8 +4,8 @@ let
 in
 {
   flake-file.inputs.authentik-nix = {
-    inputs.nixpkgs.follows = "nixpkgs";
     url = "github:nix-community/authentik-nix";
+    inputs.nixpkgs.follows = "nixpkgs";
   };
 
   my.authentik =
@@ -28,30 +28,36 @@ in
       nixos = { config, ... }: {
         imports = [ (inputs.authentik-nix.nixosModules.default or { }) ];
 
-        services.authentik = {
-          enable = true;
-          environmentFile = config.age.secrets."authentik.env".path;
-          nginx = {
+        services = {
+          authentik = {
             enable = true;
-            enableACME = true;
-            host = url;
-          };
-          settings.disable_startup_analytics = true;
-        };
+            environmentFile = config.age.secrets."authentik.env".path;
 
-        # nginx.nix forces `HttpOnly` onto every proxied cookie, but Authentik's frontend needs to
-        # read its CSRF cookie via JavaScript (it echoes the value back as the X-Authentik-Csrf
-        # header). With HttpOnly forced on, that read fails and Authentik rejects the empty token
-        # with "CSRF token ... incorrect length". Reset the cookie rewrite for this vhost only.
-        services.nginx.virtualHosts.${url}.extraConfig = ''
-          proxy_cookie_path / /;
-        '';
+            nginx = {
+              enable = true;
+              enableACME = true;
+              host = url;
+            };
+
+            settings.disable_startup_analytics = true;
+          };
+
+          # nginx.nix forces `HttpOnly` onto every proxied cookie, but Authentik's frontend needs to
+          # read its CSRF cookie via JavaScript (it echoes the value back as the X-Authentik-Csrf
+          # header). With HttpOnly forced on, that read fails and Authentik rejects the empty token
+          # with "CSRF token ... incorrect length". Reset the cookie rewrite for this vhost only.
+          nginx.virtualHosts.${url}.extraConfig = ''
+            proxy_cookie_path / /;
+          '';
+        };
       };
+
       secrets = { secrets, ... }: {
         authentik-secret-key = {
           generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -base64 60";
           intermediary = true;
         };
+
         # Consumed both by `authentik.env` below (so Authentik mints it as `akadmin`'s API token
         # on first boot, under the DIFFERENT env var name that bootstrap mechanism expects) and,
         # via `settings.terraform = true;`, by harmony's shared Terraform env (as `AUTHENTIK_TOKEN`)
@@ -62,13 +68,15 @@ in
           intermediary = true;
           settings.terraform = true;
         };
+
         "authentik.env".generator = {
           dependencies = { inherit (secrets) authentik-secret-key authentik-token; };
+
           script =
             {
+              lib,
               decrypt,
               deps,
-              lib,
               ...
             }:
             ''
@@ -95,6 +103,7 @@ in
           settings.terraform = "variable";
         };
       };
+
       # SSO-as-code, managed via terranix (Nix -> Terraform config, see modules/terranix.nix) and
       # the authentik Terraform provider - see dns.nix/meraki.nix for the general pattern
       # (`nix run .#<host>-tf[.plan|.destroy]`, `nix develop .#<host>-tf`,
@@ -181,22 +190,6 @@ in
       terranix =
         { lib, virtual-host, ... }:
         let
-          protected-hosts = lib.filter (vh: vh.protected or false) virtual-host;
-          oidc-hosts = lib.filter (vh: vh ? oidc) virtual-host;
-          hostname-of = vh: vh.url or "${vh.name}.${host.name}.${domain}";
-          # Every hostname a `global` virtual-host actually answers on: its own (derived or
-          # overridden) name, plus the canonical `<name>.<domain>` too - see virtual-host.nix's
-          # `oidc` field comment for why both need a redirect URI registered, not just one.
-          # `unique` because a `global` host whose `url` override IS already the canonical name
-          # (storyteller.nix) would otherwise register every redirect URI twice.
-          hostnames-of =
-            vh: lib.unique ([ (hostname-of vh) ] ++ lib.optional (vh.global or false) "${vh.name}.${domain}");
-
-          # The `group` (virtual-host.nix) whose applications everyone gets, rather than just
-          # `admins` - the same string the Homepage dashboard and Authentik's library file these
-          # services under, so a service moving between sections moves its access with it.
-          open-group = "Media";
-
           # WHO may reach an application. An application with NO bindings is open to every
           # authenticated user, which - combined with the Discord/Plex sources below being able to
           # ENROLL brand-new accounts - would otherwise mean a stranger's Discord account reaching
@@ -217,7 +210,19 @@ in
                 target = "\${authentik_application.${app-key}.uuid}";
               }
             ) ([ "admin" ] ++ lib.optional (vh.group or null == open-group) "user");
-
+          # Discord: create an OAuth2 app at https://discord.com/developers/applications, copy its
+          # Client ID below (not secret - it's public in every OAuth redirect), put the Client
+          # Secret in the `discord-client-secret` age file (one-time `agenix edit
+          # secrets/discord-client-secret.age`, then `agenix rekey -a`), and add
+          # `https://${url}/source/oauth/callback/discord/` as that app's OAuth2 redirect URI.
+          discord-client-id = "1525363641598083102";
+          hostname-of = vh: vh.url or "${vh.name}.${host.name}.${domain}";
+          # Every hostname a `global` virtual-host actually answers on: its own (derived or
+          # overridden) name, plus the canonical `<name>.<domain>` too - see virtual-host.nix's
+          # `oidc` field comment for why both need a redirect URI registered, not just one.
+          # `unique` because a `global` host whose `url` override IS already the canonical name
+          # (storyteller.nix) would otherwise register every redirect URI twice.
+          hostnames-of = vh: lib.unique ([ (hostname-of vh) ] ++ lib.optional (vh.global or false) "${vh.name}.${domain}");
           # Reuses each service's own `virtual-host.icon` (virtual-host.nix) rather than picking
           # Authentik icons separately, translating Homepage's icon shorthands into the plain URL
           # Authentik's `meta_icon` expects. Only the forms actually in use are handled - an
@@ -234,7 +239,20 @@ in
               "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/${icon}"
             else
               throw "my.authentik: don't know how to turn icon \"${icon}\" into a meta_icon URL";
-
+          oidc-hosts = lib.filter (vh: vh ? oidc) virtual-host;
+          # The `group` (virtual-host.nix) whose applications everyone gets, rather than just
+          # `admins` - the same string the Homepage dashboard and Authentik's library file these
+          # services under, so a service moving between sections moves its access with it.
+          open-group = "Media";
+          # harmony's Plex server `machineIdentifier` (`curl http://localhost:32400/identity` on
+          # harmony) - restricts Plex login to people with access to this server; left empty, ANY
+          # Plex.tv account could log into Authentik instead.
+          plex-allowed-servers = [ "8c5824dcf35bfbe5a6f73239e4150ab2f563f624" ];
+          # Plex: unlike Discord, this ID isn't issued BY Plex - it's an arbitrary, stable string
+          # Authentik uses to identify itself to plex.tv (the `X-Plex-Client-Identifier`). Any
+          # value works and never needs to change; no action needed.
+          plex-client-id = "silverlight-nex-us-authentik";
+          protected-hosts = lib.filter (vh: vh.protected or false) virtual-host;
           # Mirrors `env-var-for` (modules/terranix.nix) exactly - the `TF_VAR_` prefix a
           # `settings.terraform = "variable";` secret surfaces under is added programmatically
           # there, not baked into the secret's name, so the Terraform `variable` it populates is
@@ -242,23 +260,6 @@ in
           # host's own `client-secret` below, so all of these stay derived from one place instead
           # of hand-typed twice per secret.
           tf-var-name-of = secret: lib.toUpper (lib.replaceStrings [ "-" ] [ "_" ] secret);
-
-          # Discord: create an OAuth2 app at https://discord.com/developers/applications, copy its
-          # Client ID below (not secret - it's public in every OAuth redirect), put the Client
-          # Secret in the `discord-client-secret` age file (one-time `agenix edit
-          # secrets/discord-client-secret.age`, then `agenix rekey -a`), and add
-          # `https://${url}/source/oauth/callback/discord/` as that app's OAuth2 redirect URI.
-          discord-client-id = "1525363641598083102";
-
-          # Plex: unlike Discord, this ID isn't issued BY Plex - it's an arbitrary, stable string
-          # Authentik uses to identify itself to plex.tv (the `X-Plex-Client-Identifier`). Any
-          # value works and never needs to change; no action needed.
-          plex-client-id = "silverlight-nex-us-authentik";
-
-          # harmony's Plex server `machineIdentifier` (`curl http://localhost:32400/identity` on
-          # harmony) - restricts Plex login to people with access to this server; left empty, ANY
-          # Plex.tv account could log into Authentik instead.
-          plex-allowed-servers = [ "8c5824dcf35bfbe5a6f73239e4150ab2f563f624" ];
         in
         # `lib.foldl' lib.recursiveUpdate`, not `//` - every branch below declares a top-level
         # `resource`/`data` attrset, and `//` only shallow-merges, which would make each later
@@ -273,191 +274,220 @@ in
               default-source-authentication.slug = "default-source-authentication";
               default-source-enrollment.slug = "default-source-enrollment";
             };
+
             # `token` isn't set here - the provider reads it from AUTHENTIK_TOKEN (see above); `url`
             # isn't secret, so it's set directly rather than round-tripped through an env var.
             provider.authentik.url = "https://${url}";
-            # Groups live here rather than on the services that consume them: they're a DIRECTORY
-            # concept (authentik.nix owns every `authentik_*` resource, the way dns.nix owns every
-            # `cloudflare_*` one), and three unrelated things key off them already - the application
-            # bindings below, Storyteller's group-to-permission mapping, and Nextcloud's group
-            # provisioning. All match on the group's NAME (Authentik's default `profile` scope emits
-            # `groups` as a list of names - see the `oidc-defaults` comment below), so renaming one
-            # is a breaking change for whatever maps it.
-            #
-            # "admin" is SINGULAR because it isn't free to rename: Nextcloud grants administrator
-            # rights to exactly the group whose gid is `admin`, and user_oidc's group provisioning
-            # creates each Nextcloud group under the claim value verbatim (see nextcloud.nix), with
-            # no mapping layer in between - "admins" would provision a Nextcloud group named
-            # "admins" that confers nothing. "user" is singular only to match it; nothing external
-            # constrains that one.
-            #
-            # MEMBERSHIP is deliberately not managed here: the `users` FIELD on `authentik_group`
-            # (not to be confused with the group named `user`) is `Optional` AND `Computed` in the
-            # Terraform provider, so omitting it means "leave whatever's there alone" rather than
-            # "empty it" - unlike `authentik_outpost`'s `protocol_providers` above, which really
-            # does replace the whole list. Accounts arrive by Discord/Plex enrollment and don't
-            # exist in this config, so assign people through Authentik's UI (Directory > Groups)
-            # and applies won't fight you over it.
-            resource.authentik_group = lib.genAttrs [ "admin" "user" ] (name: {
-              inherit name;
-            });
-            resource.authentik_source_oauth.discord = {
-              authentication_flow = "\${data.authentik_flow.default-source-authentication.id}";
-              consumer_key = discord-client-id;
-              consumer_secret = "\${var.${tf-var-name-of "discord-client-secret"}}";
-              enrollment_flow = "\${data.authentik_flow.default-source-enrollment.id}";
-              name = "Discord";
-              provider_type = "discord";
-              slug = "discord";
+
+            resource = {
+              # Groups live here rather than on the services that consume them: they're a DIRECTORY
+              # concept (authentik.nix owns every `authentik_*` resource, the way dns.nix owns every
+              # `cloudflare_*` one), and three unrelated things key off them already - the application
+              # bindings below, Storyteller's group-to-permission mapping, and Nextcloud's group
+              # provisioning. All match on the group's NAME (Authentik's default `profile` scope emits
+              # `groups` as a list of names - see the `oidc-defaults` comment below), so renaming one
+              # is a breaking change for whatever maps it.
+              #
+              # "admin" is SINGULAR because it isn't free to rename: Nextcloud grants administrator
+              # rights to exactly the group whose gid is `admin`, and user_oidc's group provisioning
+              # creates each Nextcloud group under the claim value verbatim (see nextcloud.nix), with
+              # no mapping layer in between - "admins" would provision a Nextcloud group named
+              # "admins" that confers nothing. "user" is singular only to match it; nothing external
+              # constrains that one.
+              #
+              # MEMBERSHIP is deliberately not managed here: the `users` FIELD on `authentik_group`
+              # (not to be confused with the group named `user`) is `Optional` AND `Computed` in the
+              # Terraform provider, so omitting it means "leave whatever's there alone" rather than
+              # "empty it" - unlike `authentik_outpost`'s `protocol_providers` above, which really
+              # does replace the whole list. Accounts arrive by Discord/Plex enrollment and don't
+              # exist in this config, so assign people through Authentik's UI (Directory > Groups)
+              # and applies won't fight you over it.
+              authentik_group = lib.genAttrs [ "admin" "user" ] (name: {
+                inherit name;
+              });
+
+              authentik_source_oauth.discord = {
+                authentication_flow = "\${data.authentik_flow.default-source-authentication.id}";
+                consumer_key = discord-client-id;
+                consumer_secret = "\${var.${tf-var-name-of "discord-client-secret"}}";
+                enrollment_flow = "\${data.authentik_flow.default-source-enrollment.id}";
+                name = "Discord";
+                provider_type = "discord";
+                slug = "discord";
+              };
+
+              authentik_source_plex.plex = {
+                allow_friends = true;
+                allowed_servers = plex-allowed-servers;
+                authentication_flow = "\${data.authentik_flow.default-source-authentication.id}";
+                client_id = plex-client-id;
+                enrollment_flow = "\${data.authentik_flow.default-source-enrollment.id}";
+                name = "Plex";
+                plex_token = "\${var.${tf-var-name-of "plex-token"}}";
+                slug = "plex";
+              };
             };
-            resource.authentik_source_plex.plex = {
-              allow_friends = true;
-              allowed_servers = plex-allowed-servers;
-              authentication_flow = "\${data.authentik_flow.default-source-authentication.id}";
-              client_id = plex-client-id;
-              enrollment_flow = "\${data.authentik_flow.default-source-enrollment.id}";
-              name = "Plex";
-              plex_token = "\${var.${tf-var-name-of "plex-token"}}";
-              slug = "plex";
-            };
+
             terraform.required_providers.authentik = {
               source = "goauthentik/authentik";
               version = "~> 2026";
             };
-            variable.DISCORD_CLIENT_SECRET.sensitive = true;
-            variable.PLEX_TOKEN.sensitive = true;
+
+            variable = {
+              DISCORD_CLIENT_SECRET.sensitive = true;
+              PLEX_TOKEN.sensitive = true;
+            };
           }
           [
             (lib.optionalAttrs (protected-hosts != [ ]) {
-              resource.authentik_application = lib.listToAttrs (
-                map (vh: {
-                  name = vh.name;
-                  value = {
-                    name = vh.label or vh.name;
-                    protocol_provider = "\${authentik_provider_proxy.${vh.name}.id}";
-                    slug = vh.name;
-                  }
-                  // lib.optionalAttrs (vh ? icon) { meta_icon = icon-url-of vh.icon; }
-                  // lib.optionalAttrs (vh ? group) { inherit (vh) group; };
-                }) protected-hosts
-              );
-              resource.authentik_outpost.embedded = {
-                name = "authentik Embedded Outpost";
-                protocol_providers = map (vh: "\${authentik_provider_proxy.${vh.name}.id}") protected-hosts;
+              resource = {
+                authentik_application = lib.listToAttrs (
+                  map (vh: {
+                    inherit (vh) name;
+
+                    value = {
+                      name = vh.label or vh.name;
+                      protocol_provider = "\${authentik_provider_proxy.${vh.name}.id}";
+                      slug = vh.name;
+                    }
+                    // lib.optionalAttrs (vh ? icon) { meta_icon = icon-url-of vh.icon; }
+                    // lib.optionalAttrs (vh ? group) { inherit (vh) group; };
+                  }) protected-hosts
+                );
+
+                authentik_outpost.embedded = {
+                  name = "authentik Embedded Outpost";
+                  protocol_providers = map (vh: "\${authentik_provider_proxy.${vh.name}.id}") protected-hosts;
+                };
+
+                authentik_policy_binding = lib.listToAttrs (lib.concatMap (vh: binding-entries-for vh.name vh) protected-hosts);
+
+                authentik_provider_proxy = lib.listToAttrs (
+                  map (vh: {
+                    inherit (vh) name;
+
+                    value = {
+                      inherit (vh) name;
+                      authorization_flow = "\${data.authentik_flow.default-authorization-flow.id}";
+                      external_host = "https://${hostname-of vh}";
+                      invalidation_flow = "\${data.authentik_flow.default-invalidation-flow.id}";
+                      mode = "forward_single";
+                    };
+                  }) protected-hosts
+                );
               };
-              resource.authentik_policy_binding = lib.listToAttrs (
-                lib.concatMap (vh: binding-entries-for vh.name vh) protected-hosts
-              );
-              resource.authentik_provider_proxy = lib.listToAttrs (
-                map (vh: {
-                  name = vh.name;
-                  value = {
-                    authorization_flow = "\${data.authentik_flow.default-authorization-flow.id}";
-                    external_host = "https://${hostname-of vh}";
-                    invalidation_flow = "\${data.authentik_flow.default-invalidation-flow.id}";
-                    mode = "forward_single";
-                    name = vh.name;
-                  };
-                }) protected-hosts
-              );
             })
             (lib.optionalAttrs (oidc-hosts != [ ]) {
-              # `signing_key`: with none attached, authentik doesn't fall back to a default keypair -
-              # it signs id_tokens with the CLIENT SECRET under HS256 ("No Certificate at all,
-              # assume HS256", `OAuth2Provider.jwt_key`). Clients that actually verify the id_token
-              # expect an asymmetric alg and reject that; Immich, whose default `signingAlgorithm` is
-              # RS256, fails the login with "unexpected JWT alg received" and even names this exact
-              # cause in its own warning ("...or that you have specified a signing key in your OAuth
-              # provider"). This is the keypair authentik generates for itself on first start, and
-              # it's RSA (`CertificateBuilder.alg` is `PrivateKeyAlg.RSA`), so `jwt_key` reports
-              # RS256 - matching what these clients expect without further configuration.
-              #
-              # `fetch_certificate`/`fetch_key` OFF because both default ON, and `key_data` would
-              # pull authentik's PRIVATE KEY into the state file - which, for harmony, is committed
-              # to this public repo (see the header comment on encryption). Only `.id` is needed to
-              # reference the keypair, and that's returned regardless.
-              data.authentik_certificate_key_pair.signing = {
-                fetch_certificate = false;
-                fetch_key = false;
-                name = "authentik Self-signed Certificate";
+              data = {
+                # `signing_key`: with none attached, authentik doesn't fall back to a default keypair -
+                # it signs id_tokens with the CLIENT SECRET under HS256 ("No Certificate at all,
+                # assume HS256", `OAuth2Provider.jwt_key`). Clients that actually verify the id_token
+                # expect an asymmetric alg and reject that; Immich, whose default `signingAlgorithm` is
+                # RS256, fails the login with "unexpected JWT alg received" and even names this exact
+                # cause in its own warning ("...or that you have specified a signing key in your OAuth
+                # provider"). This is the keypair authentik generates for itself on first start, and
+                # it's RSA (`CertificateBuilder.alg` is `PrivateKeyAlg.RSA`), so `jwt_key` reports
+                # RS256 - matching what these clients expect without further configuration.
+                #
+                # `fetch_certificate`/`fetch_key` OFF because both default ON, and `key_data` would
+                # pull authentik's PRIVATE KEY into the state file - which, for harmony, is committed
+                # to this public repo (see the header comment on encryption). Only `.id` is needed to
+                # reference the keypair, and that's returned regardless.
+                authentik_certificate_key_pair.signing = {
+                  fetch_certificate = false;
+                  fetch_key = false;
+                  name = "authentik Self-signed Certificate";
+                };
+
+                # `grant_types`, `property_mappings` and `signing_key` below ALL have to be spelled
+                # out, for the same underlying reason: authentik's API defaults them to empty and only
+                # its own admin UI pre-fills them, so a provider built through the API (like these)
+                # comes out inert unless we say so. `authentik_provider_proxy` above is immune and
+                # hides the problem - authentik's `ProxyProvider.set_oauth_defaults()` reassigns its
+                # own `grant_types`, `property_mappings` AND `signing_key` server-side on every save -
+                # which is exactly why forward-auth worked while these OIDC providers didn't.
+                #
+                # `grant_types`: the model is `ArrayField(..., default=list)` - an EMPTY list, not the
+                # obvious `[authorization_code]`. authentik's authorize view rejects any flow whose
+                # grant type isn't listed (`if self.grant_type not in self.provider.grant_types`)
+                # with a bare `invalid_request`/"The request is otherwise malformed" and no further
+                # explanation, which is what a login against these providers actually returned.
+                # `refresh_token` isn't needed by anything here today; it's what lets a client ask for
+                # `offline_access` later without rediscovering this the hard way.
+                #
+                # `property_mappings`: an OAuth2 provider returns ONLY the claims whose scope mapping
+                # is attached to it - `ScopeMapping.objects.filter(provider=provider,
+                # scope_name__in=scopes_from_client)` in authentik's userinfo view - so with none
+                # attached, userinfo comes back with no `email`, no `profile`, no `groups`. These are
+                # the same three the UI's form pre-selects. `profile` is what carries the `groups`
+                # claim - see the default mapping's expression, `[group.name for group in
+                # request.user.groups.all()]` - so group-based permissions in a downstream app
+                # (storyteller.nix) depend on this too, not just on a `groups` scope being requested.
+                # (Requesting a scope authentik doesn't know is harmless, incidentally: it logs and
+                # intersects with what's attached rather than erroring.)
+                authentik_property_mapping_provider_scope.oidc-defaults.managed_list = [
+                  "goauthentik.io/providers/oauth2/scope-openid"
+                  "goauthentik.io/providers/oauth2/scope-email"
+                  "goauthentik.io/providers/oauth2/scope-profile"
+                ];
               };
-              # `grant_types`, `property_mappings` and `signing_key` below ALL have to be spelled
-              # out, for the same underlying reason: authentik's API defaults them to empty and only
-              # its own admin UI pre-fills them, so a provider built through the API (like these)
-              # comes out inert unless we say so. `authentik_provider_proxy` above is immune and
-              # hides the problem - authentik's `ProxyProvider.set_oauth_defaults()` reassigns its
-              # own `grant_types`, `property_mappings` AND `signing_key` server-side on every save -
-              # which is exactly why forward-auth worked while these OIDC providers didn't.
-              #
-              # `grant_types`: the model is `ArrayField(..., default=list)` - an EMPTY list, not the
-              # obvious `[authorization_code]`. authentik's authorize view rejects any flow whose
-              # grant type isn't listed (`if self.grant_type not in self.provider.grant_types`)
-              # with a bare `invalid_request`/"The request is otherwise malformed" and no further
-              # explanation, which is what a login against these providers actually returned.
-              # `refresh_token` isn't needed by anything here today; it's what lets a client ask for
-              # `offline_access` later without rediscovering this the hard way.
-              #
-              # `property_mappings`: an OAuth2 provider returns ONLY the claims whose scope mapping
-              # is attached to it - `ScopeMapping.objects.filter(provider=provider,
-              # scope_name__in=scopes_from_client)` in authentik's userinfo view - so with none
-              # attached, userinfo comes back with no `email`, no `profile`, no `groups`. These are
-              # the same three the UI's form pre-selects. `profile` is what carries the `groups`
-              # claim - see the default mapping's expression, `[group.name for group in
-              # request.user.groups.all()]` - so group-based permissions in a downstream app
-              # (storyteller.nix) depend on this too, not just on a `groups` scope being requested.
-              # (Requesting a scope authentik doesn't know is harmless, incidentally: it logs and
-              # intersects with what's attached rather than erroring.)
-              data.authentik_property_mapping_provider_scope.oidc-defaults.managed_list = [
-                "goauthentik.io/providers/oauth2/scope-openid"
-                "goauthentik.io/providers/oauth2/scope-email"
-                "goauthentik.io/providers/oauth2/scope-profile"
-              ];
-              resource.authentik_application = lib.listToAttrs (
-                map (vh: {
-                  name = "${vh.name}-oidc";
-                  value = {
-                    name = vh.label or vh.name;
-                    protocol_provider = "\${authentik_provider_oauth2.${vh.name}-oidc.id}";
-                    slug = vh.name;
-                  }
-                  // lib.optionalAttrs (vh ? icon) { meta_icon = icon-url-of vh.icon; }
-                  // lib.optionalAttrs (vh ? group) { inherit (vh) group; };
-                }) oidc-hosts
-              );
-              resource.authentik_policy_binding = lib.listToAttrs (
-                lib.concatMap (vh: binding-entries-for "${vh.name}-oidc" vh) oidc-hosts
-              );
-              resource.authentik_provider_oauth2 = lib.listToAttrs (
-                map (vh: {
-                  name = "${vh.name}-oidc";
-                  value = {
-                    allowed_redirect_uris = lib.concatMap (
-                      hostname:
-                      map (path: {
-                        matching_mode = "strict";
-                        redirect_uri_type = "authorization";
-                        url = "https://${hostname}${path}";
-                      }) vh.oidc.redirect-paths
-                    ) (hostnames-of vh);
-                    authorization_flow = "\${data.authentik_flow.default-authorization-flow.id}";
-                    client_id = vh.name;
-                    client_secret = "\${var.${tf-var-name-of vh.oidc.client-secret}}";
-                    grant_types = [
-                      "authorization_code"
-                      "refresh_token"
-                    ];
-                    invalidation_flow = "\${data.authentik_flow.default-invalidation-flow.id}";
-                    name = vh.name;
-                    property_mappings = "\${data.authentik_property_mapping_provider_scope.oidc-defaults.ids}";
-                    signing_key = "\${data.authentik_certificate_key_pair.signing.id}";
-                  };
-                }) oidc-hosts
-              );
+
+              resource = {
+                authentik_application = lib.listToAttrs (
+                  map (vh: {
+                    name = "${vh.name}-oidc";
+
+                    value = {
+                      name = vh.label or vh.name;
+                      protocol_provider = "\${authentik_provider_oauth2.${vh.name}-oidc.id}";
+                      slug = vh.name;
+                    }
+                    // lib.optionalAttrs (vh ? icon) { meta_icon = icon-url-of vh.icon; }
+                    // lib.optionalAttrs (vh ? group) { inherit (vh) group; };
+                  }) oidc-hosts
+                );
+
+                authentik_policy_binding = lib.listToAttrs (lib.concatMap (vh: binding-entries-for "${vh.name}-oidc" vh) oidc-hosts);
+
+                authentik_provider_oauth2 = lib.listToAttrs (
+                  map (vh: {
+                    name = "${vh.name}-oidc";
+
+                    value = {
+                      inherit (vh) name;
+
+                      allowed_redirect_uris = lib.concatMap (
+                        hostname:
+                        map (path: {
+                          matching_mode = "strict";
+                          redirect_uri_type = "authorization";
+                          url = "https://${hostname}${path}";
+                        }) vh.oidc.redirect-paths
+                      ) (hostnames-of vh);
+
+                      authorization_flow = "\${data.authentik_flow.default-authorization-flow.id}";
+                      client_id = vh.name;
+                      client_secret = "\${var.${tf-var-name-of vh.oidc.client-secret}}";
+
+                      grant_types = [
+                        "authorization_code"
+                        "refresh_token"
+                      ];
+
+                      invalidation_flow = "\${data.authentik_flow.default-invalidation-flow.id}";
+                      property_mappings = "\${data.authentik_property_mapping_provider_scope.oidc-defaults.ids}";
+                      signing_key = "\${data.authentik_certificate_key_pair.signing.id}";
+                    };
+                  }) oidc-hosts
+                );
+              };
+
               variable = lib.genAttrs (map (vh: tf-var-name-of vh.oidc.client-secret) oidc-hosts) (_: {
                 sensitive = true;
               });
             })
           ];
+
       # No `port`: authentik-nix's own module wires `services.nginx.virtualHosts.${url}.locations`
       # directly (see `services.authentik.nginx` below), same pattern as Nextcloud's PHP-FPM vhost.
       # This entry only exists so nginx.nix's `serverAliases`/global-toggle and homepage.nix's
@@ -471,9 +501,11 @@ in
       virtual-host = {
         inherit global url;
         group = "Infra";
+
         homepage = {
           description = "Single sign-on";
         };
+
         host = host.name;
         icon = "authentik.svg";
         label = "Authentik";

--- a/modules/aspects/my/auto-login.nix
+++ b/modules/aspects/my/auto-login.nix
@@ -4,8 +4,8 @@
       { config, lib, ... }:
       lib.mkIf config.services.displayManager.enable {
         services.displayManager.autoLogin = {
-          enable = true;
           inherit user;
+          enable = true;
         };
       };
   };

--- a/modules/aspects/my/auto-upgrade.nix
+++ b/modules/aspects/my/auto-upgrade.nix
@@ -2,8 +2,8 @@
   my.auto-upgrade = { allowReboot }: {
     nixos = {
       system.autoUpgrade = {
-        enable = true;
         inherit allowReboot;
+        enable = true;
         flake = "github:OscarMarshall/dotfiles";
       };
     };

--- a/modules/aspects/my/autobrr.nix
+++ b/modules/aspects/my/autobrr.nix
@@ -12,6 +12,7 @@
         services.autobrr = {
           enable = true;
           secretFile = config.age.secrets.autobrr-session-secret.path;
+
           settings = {
             inherit port;
             checkForUpdates = true;
@@ -19,12 +20,14 @@
           };
         };
       };
+
       secrets.autobrr-session-secret.generator.script = "alnum";
+
       # No `homepage` block: deliberately not a dashboard tile, but `icon`/`group` still feed its
       # Authentik application (see virtual-host.nix). No `label` either - "autobrr" IS the brand's
       # own styling.
       virtual-host = {
-        inherit port global;
+        inherit global port;
         group = "Arr Stack";
         host = host.name;
         icon = "https://raw.githubusercontent.com/autobrr/autobrr/develop/web/src/logo.svg";

--- a/modules/aspects/my/autobrr.nix
+++ b/modules/aspects/my/autobrr.nix
@@ -8,20 +8,6 @@
       port = 7474;
     in
     {
-      # No `homepage` block: deliberately not a dashboard tile, but `icon`/`group` still feed its
-      # Authentik application (see virtual-host.nix). No `label` either - "autobrr" IS the brand's
-      # own styling.
-      virtual-host = {
-        name = "autobrr";
-        host = host.name;
-        protected = true;
-        icon = "https://raw.githubusercontent.com/autobrr/autobrr/develop/web/src/logo.svg";
-        group = "Arr Stack";
-        inherit port global;
-      };
-
-      secrets.autobrr-session-secret.generator.script = "alnum";
-
       nixos = { config, ... }: {
         services.autobrr = {
           enable = true;
@@ -32,6 +18,18 @@
             host = "127.0.0.1";
           };
         };
+      };
+      secrets.autobrr-session-secret.generator.script = "alnum";
+      # No `homepage` block: deliberately not a dashboard tile, but `icon`/`group` still feed its
+      # Authentik application (see virtual-host.nix). No `label` either - "autobrr" IS the brand's
+      # own styling.
+      virtual-host = {
+        inherit port global;
+        group = "Arr Stack";
+        host = host.name;
+        icon = "https://raw.githubusercontent.com/autobrr/autobrr/develop/web/src/logo.svg";
+        name = "autobrr";
+        protected = true;
       };
     };
 }

--- a/modules/aspects/my/bat.nix
+++ b/modules/aspects/my/bat.nix
@@ -2,6 +2,7 @@
   my.bat.homeManager = { pkgs, ... }: {
     programs.bat = {
       enable = true;
+
       extraPackages = [
         (pkgs.bat-extras.core.overrideAttrs (_: {
           doCheck = false;

--- a/modules/aspects/my/bookshelf.nix
+++ b/modules/aspects/my/bookshelf.nix
@@ -24,6 +24,7 @@ let
         inherit name;
         pool = "metalminds";
       };
+
       nixos = {
         virtualisation.oci-containers.containers.${name} = {
           # Bookshelf only reaches this vhost via nginx over loopback (its port isn't opened in
@@ -37,16 +38,19 @@ let
           #     -H "Accept: application/vnd.docker.distribution.manifest.v2+json" -D - -o /dev/null \
           #     https://ghcr.io/v2/pennydreadful/bookshelf/manifests/hardcover
           image = "ghcr.io/pennydreadful/bookshelf@sha256:388eecc94362580eae31ee0a454be6af516f8a311f8432a521c202fb475f4359";
+
           ports =
             let
               port' = toString port;
             in
             [ "127.0.0.1:${port'}:${port'}" ];
+
           volumes = [ "/metalminds/${name}:/config" ];
         };
       };
+
       virtual-host = {
-        inherit name port global;
+        inherit global name port;
         group = "Arr Stack";
         homepage = { inherit description; };
         host = host.name;
@@ -60,16 +64,19 @@ let
     };
 in
 {
-  my.bookshelf-audiobooks = mkBookshelfInstance {
-    description = "Audiobook manager";
-    instance = "audiobooks";
-    label = "Audiobooks";
-    port = 8788;
-  };
-  my.bookshelf-ebooks = mkBookshelfInstance {
-    description = "Ebook manager";
-    instance = "ebooks";
-    label = "Ebooks";
-    port = 8787;
+  my = {
+    bookshelf-audiobooks = mkBookshelfInstance {
+      description = "Audiobook manager";
+      instance = "audiobooks";
+      label = "Audiobooks";
+      port = 8788;
+    };
+
+    bookshelf-ebooks = mkBookshelfInstance {
+      description = "Ebook manager";
+      instance = "ebooks";
+      label = "Ebooks";
+      port = 8787;
+    };
   };
 }

--- a/modules/aspects/my/bookshelf.nix
+++ b/modules/aspects/my/bookshelf.nix
@@ -7,9 +7,9 @@ let
   # `my.bookshelf-audiobooks`), sharing this builder.
   mkBookshelfInstance =
     {
+      description,
       instance,
       label,
-      description,
       port,
     }:
     {
@@ -21,25 +21,16 @@ let
     in
     {
       dataset = {
-        pool = "metalminds";
         inherit name;
+        pool = "metalminds";
       };
-
-      virtual-host = {
-        inherit name port global;
-        host = host.name;
-        protected = true;
-        label = "Bookshelf (${label})";
-        # No dashboard-icons entry for pennydreadful/bookshelf specifically (its "audiobookshelf"
-        # entry is a different, unrelated app) - its own upstream logo instead. Named Readarr.svg
-        # upstream since Bookshelf is a Readarr fork.
-        icon = "https://raw.githubusercontent.com/pennydreadful/bookshelf/develop/Logo/Readarr.svg";
-        group = "Arr Stack";
-        homepage = { inherit description; };
-      };
-
       nixos = {
         virtualisation.oci-containers.containers.${name} = {
+          # Bookshelf only reaches this vhost via nginx over loopback (its port isn't opened in
+          # the firewall), so every request it sees is "local" -- this drops Bookshelf's own login
+          # screen (it's a Readarr fork and shares Readarr's `<APPNAME>__AUTH__REQUIRED` setting)
+          # in favor of the Authentik forward-auth gate in front of it, rather than stacking both.
+          environment.READARR__AUTH__REQUIRED = "DisabledForLocalAddresses";
           # Pinned to the current "hardcover" tag's digest (Hardcover-sourced metadata, higher
           # quality than the Goodreads-compatible "softcover" variant) -- re-resolve if bumping:
           #   curl -sH "Authorization: Bearer $(curl -s 'https://ghcr.io/token?scope=repository:pennydreadful/bookshelf:pull' | jq -r .token)" \
@@ -52,26 +43,33 @@ let
             in
             [ "127.0.0.1:${port'}:${port'}" ];
           volumes = [ "/metalminds/${name}:/config" ];
-          # Bookshelf only reaches this vhost via nginx over loopback (its port isn't opened in
-          # the firewall), so every request it sees is "local" -- this drops Bookshelf's own login
-          # screen (it's a Readarr fork and shares Readarr's `<APPNAME>__AUTH__REQUIRED` setting)
-          # in favor of the Authentik forward-auth gate in front of it, rather than stacking both.
-          environment.READARR__AUTH__REQUIRED = "DisabledForLocalAddresses";
         };
+      };
+      virtual-host = {
+        inherit name port global;
+        group = "Arr Stack";
+        homepage = { inherit description; };
+        host = host.name;
+        # No dashboard-icons entry for pennydreadful/bookshelf specifically (its "audiobookshelf"
+        # entry is a different, unrelated app) - its own upstream logo instead. Named Readarr.svg
+        # upstream since Bookshelf is a Readarr fork.
+        icon = "https://raw.githubusercontent.com/pennydreadful/bookshelf/develop/Logo/Readarr.svg";
+        label = "Bookshelf (${label})";
+        protected = true;
       };
     };
 in
 {
   my.bookshelf-audiobooks = mkBookshelfInstance {
+    description = "Audiobook manager";
     instance = "audiobooks";
     label = "Audiobooks";
-    description = "Audiobook manager";
     port = 8788;
   };
   my.bookshelf-ebooks = mkBookshelfInstance {
+    description = "Ebook manager";
     instance = "ebooks";
     label = "Ebooks";
-    description = "Ebook manager";
     port = 8787;
   };
 }

--- a/modules/aspects/my/boot.nix
+++ b/modules/aspects/my/boot.nix
@@ -3,14 +3,16 @@
     boot = {
       # Use latest kernel for all systems (lowest priority, can be overridden)
       kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
+
       loader = {
         efi.canTouchEfiVariables = true;
+
         systemd-boot = {
+          enable = true;
           # Without a limit, every generation's kernel+initrd accumulates on the EFI System
           # Partition until it fills up, at which point a new generation's files can be written
           # incompletely and fail to boot with "Switch root target contains no usable init".
           configurationLimit = lib.mkDefault 10;
-          enable = true;
         };
       };
     };

--- a/modules/aspects/my/boot.nix
+++ b/modules/aspects/my/boot.nix
@@ -4,14 +4,14 @@
       # Use latest kernel for all systems (lowest priority, can be overridden)
       kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
       loader = {
+        efi.canTouchEfiVariables = true;
         systemd-boot = {
-          enable = true;
           # Without a limit, every generation's kernel+initrd accumulates on the EFI System
           # Partition until it fills up, at which point a new generation's files can be written
           # incompletely and fail to boot with "Switch root target contains no usable init".
           configurationLimit = lib.mkDefault 10;
+          enable = true;
         };
-        efi.canTouchEfiVariables = true;
       };
     };
   };

--- a/modules/aspects/my/cachyos-kernel.nix
+++ b/modules/aspects/my/cachyos-kernel.nix
@@ -31,6 +31,7 @@
         "https://attic.xuyh0120.win/lantian"
         "https://cache.xinux.uz"
       ];
+
       extra-trusted-public-keys = [
         "lantian:EeAUQ+W+6r7EtwnmYjeVwx5kOGEBpjlBfPlzGlTNvHc="
         "cache.xinux.uz:BXCrtqejFjWzWEB9YuGB7X2MV4ttBur1N8BkwQRdH+0="
@@ -54,10 +55,10 @@
           boot = {
             # Use mkForce to override the default kernel (including ZFS aspect if present)
             kernelPackages = lib.mkForce pkgs.cachyosKernels."linuxPackages-cachyos-${variant}";
-
             # Configure ZFS to use the CachyOS-patched module (NixOS will only use this if ZFS is enabled)
             zfs.package = config.boot.kernelPackages.zfs_cachyos;
           };
+
           nixpkgs.overlays = [
             # Use the exact kernel versions as defined in nix-cachyos-kernel repo.
             # Guarantees binary cache availability.

--- a/modules/aspects/my/cachyos-kernel.nix
+++ b/modules/aspects/my/cachyos-kernel.nix
@@ -46,17 +46,11 @@
       nixos =
         {
           config,
-          pkgs,
           lib,
+          pkgs,
           ...
         }:
         {
-          nixpkgs.overlays = [
-            # Use the exact kernel versions as defined in nix-cachyos-kernel repo.
-            # Guarantees binary cache availability.
-            inputs.nix-cachyos-kernel.overlays.pinned
-          ];
-
           boot = {
             # Use mkForce to override the default kernel (including ZFS aspect if present)
             kernelPackages = lib.mkForce pkgs.cachyosKernels."linuxPackages-cachyos-${variant}";
@@ -64,6 +58,11 @@
             # Configure ZFS to use the CachyOS-patched module (NixOS will only use this if ZFS is enabled)
             zfs.package = config.boot.kernelPackages.zfs_cachyos;
           };
+          nixpkgs.overlays = [
+            # Use the exact kernel versions as defined in nix-cachyos-kernel repo.
+            # Guarantees binary cache availability.
+            inputs.nix-cachyos-kernel.overlays.pinned
+          ];
         };
     };
 }

--- a/modules/aspects/my/catppuccin.nix
+++ b/modules/aspects/my/catppuccin.nix
@@ -1,7 +1,7 @@
 { inputs, ... }: {
   flake-file.inputs.catppuccin-wallpapers = {
-    flake = false;
     url = "github:zhichaoh/catppuccin-wallpapers";
+    flake = false;
   };
 
   my.catppuccin =
@@ -12,11 +12,13 @@
       homeManager = { pkgs, ... }: {
         stylix = {
           base16Scheme = "${pkgs.base16-schemes}/share/themes/catppuccin-${flavor}.yaml";
+
           cursor = {
-            name = "catppuccin-mocha-dark-cursors";
             package = pkgs.catppuccin-cursors.mochaDark;
+            name = "catppuccin-mocha-dark-cursors";
             size = 24;
           };
+
           image = "${inputs.catppuccin-wallpapers}/os/nix-black-4k.png";
           targets.emacs.colors.enable = false;
         };

--- a/modules/aspects/my/catppuccin.nix
+++ b/modules/aspects/my/catppuccin.nix
@@ -1,7 +1,7 @@
 { inputs, ... }: {
   flake-file.inputs.catppuccin-wallpapers = {
-    url = "github:zhichaoh/catppuccin-wallpapers";
     flake = false;
+    url = "github:zhichaoh/catppuccin-wallpapers";
   };
 
   my.catppuccin =
@@ -12,13 +12,13 @@
       homeManager = { pkgs, ... }: {
         stylix = {
           base16Scheme = "${pkgs.base16-schemes}/share/themes/catppuccin-${flavor}.yaml";
-          image = "${inputs.catppuccin-wallpapers}/os/nix-black-4k.png";
-          targets.emacs.colors.enable = false;
           cursor = {
             name = "catppuccin-mocha-dark-cursors";
             package = pkgs.catppuccin-cursors.mochaDark;
             size = 24;
           };
+          image = "${inputs.catppuccin-wallpapers}/os/nix-black-4k.png";
+          targets.emacs.colors.enable = false;
         };
       };
     };

--- a/modules/aspects/my/ci-no-boot.nix
+++ b/modules/aspects/my/ci-no-boot.nix
@@ -1,6 +1,7 @@
 {
   my.ci-no-boot = {
     description = "Disables booting during CI";
+
     nixos = {
       boot.loader.grub.enable = false;
       fileSystems."/".device = "/dev/null";

--- a/modules/aspects/my/claude.nix
+++ b/modules/aspects/my/claude.nix
@@ -6,30 +6,38 @@
 }:
 {
   flake-file.inputs.claude-code-nix = {
-    inputs.nixpkgs.follows = "nixpkgs";
     url = "github:sadjow/claude-code-nix";
+    inputs.nixpkgs.follows = "nixpkgs";
   };
 
   my.claude = {
+    includes = [
+      (den._.unfree [ "claude-code" ])
+      my.mcp-servers
+    ];
+
     darwin.homebrew.casks = [ "claude" ];
+
     homeManager = { pkgs, ... }: {
       home.packages = with pkgs; [
         gh
+        jq
         nodejs
         python3
         uv
-        jq
       ];
 
       programs.claude-code = {
         enable = true;
-        enableMcpIntegration = true;
         package = inputs.claude-code-nix.packages.${pkgs.stdenv.hostPlatform.system}.claude-code;
+        enableMcpIntegration = true;
+
         settings = {
           agentPushNotifEnabled = true;
           autoUpdaterStatus = "disabled";
           enableWorkflows = true;
           inputNeededNotifEnabled = true;
+
           permissions = {
             allow = [
               "Bash(git:*)"
@@ -39,9 +47,5 @@
         };
       };
     };
-    includes = [
-      (den._.unfree [ "claude-code" ])
-      my.mcp-servers
-    ];
   };
 }

--- a/modules/aspects/my/claude.nix
+++ b/modules/aspects/my/claude.nix
@@ -6,18 +6,12 @@
 }:
 {
   flake-file.inputs.claude-code-nix = {
-    url = "github:sadjow/claude-code-nix";
     inputs.nixpkgs.follows = "nixpkgs";
+    url = "github:sadjow/claude-code-nix";
   };
 
   my.claude = {
-    includes = [
-      (den._.unfree [ "claude-code" ])
-      my.mcp-servers
-    ];
-
     darwin.homebrew.casks = [ "claude" ];
-
     homeManager = { pkgs, ... }: {
       home.packages = with pkgs; [
         gh
@@ -29,9 +23,8 @@
 
       programs.claude-code = {
         enable = true;
-        package = inputs.claude-code-nix.packages.${pkgs.stdenv.hostPlatform.system}.claude-code;
         enableMcpIntegration = true;
-
+        package = inputs.claude-code-nix.packages.${pkgs.stdenv.hostPlatform.system}.claude-code;
         settings = {
           agentPushNotifEnabled = true;
           autoUpdaterStatus = "disabled";
@@ -46,5 +39,9 @@
         };
       };
     };
+    includes = [
+      (den._.unfree [ "claude-code" ])
+      my.mcp-servers
+    ];
   };
 }

--- a/modules/aspects/my/collabora-online.nix
+++ b/modules/aspects/my/collabora-online.nix
@@ -12,19 +12,11 @@ in
       url = "collabora.${host.name}.${domain}";
     in
     {
-      virtual-host = {
-        name = "collabora";
-        host = host.name;
-        inherit port global;
-        websockets = true;
-      };
-
       # Deliberately no homepage-entry: Collabora has no useful standalone landing page,
       # it's only used embedded inside Nextcloud.
-
       nixos.services.collabora-online = {
-        enable = true;
         inherit port;
+        enable = true;
         settings = {
           # These MUST be nested attrsets, not quoted dotted keys: this option's freeform type maps
           # attribute NESTING onto XML nesting, so `"ssl.enable"` is one attribute whose name merely
@@ -43,6 +35,7 @@ in
           # virtual-host - so every browser-facing request 502'd while Nextcloud's own WOPI
           # discovery (which is configured to hit http://[::1]:9980 directly) kept working.
           net.proto = "IPv4";
+          server_name = url;
           ssl.enable = false; # nginx terminates TLS
           # Without this, coolwsd's own listener being plain HTTP makes it advertise http:// URLs
           # in its self-generated discovery.xml (urlsrc entries) - confirmed via
@@ -53,11 +46,16 @@ in
           # is coolwsd's own name for "tell clients this is https even though I only speak http" -
           # exactly this reverse-proxy-terminates-TLS setup.
           ssl.termination = true;
-          server_name = url;
           # No explicit WOPI host allowlist: coolwsd.xml's storage.wopi.alias_groups defaults to
           # mode="first", which trusts whichever host connects first. That's fine since Nextcloud
           # is the only WOPI client here; there's no plain storage.wopi.host key in the real schema.
         };
+      };
+      virtual-host = {
+        inherit port global;
+        host = host.name;
+        name = "collabora";
+        websockets = true;
       };
     };
 }

--- a/modules/aspects/my/collabora-online.nix
+++ b/modules/aspects/my/collabora-online.nix
@@ -17,42 +17,50 @@ in
       nixos.services.collabora-online = {
         inherit port;
         enable = true;
+
         settings = {
-          # These MUST be nested attrsets, not quoted dotted keys: this option's freeform type maps
-          # attribute NESTING onto XML nesting, so `"ssl.enable"` is one attribute whose name merely
-          # contains a dot. It lands beside the real `ssl` set rather than inside it, emitting a
-          # junk `<ssl.enable>` element that coolwsd ignores while `<ssl><enable>` keeps whatever it
-          # would have been - which is on, since the module only ever sets `ssl.{ca,cert,key}` (the
-          # dummy self-signed certs it ships for testing) and never `ssl.enable`. Nothing warns
-          # about the stray key; the failure surfaces at the far end as Nextcloud's plain-HTTP WOPI
-          # probe getting "cURL error 52: Empty reply from server" off a TLS listener.
-          net.listen = "loopback";
-          # coolwsd.xml's own shipped comment on net.listen: "On systems where localhost resolves
-          # to IPv6 [::1] address first, when net.proto is all and net.listen is loopback, coolwsd
-          # unexpectedly listens on [::1] only. You need to change net.proto to IPv4, if you want
-          # to use 127.0.0.1." Confirmed on harmony: journalctl showed "Bind to: IPv6 port: 9980"
-          # and nothing on 127.0.0.1:9980, which nginx.nix's proxyPass targets for every
-          # virtual-host - so every browser-facing request 502'd while Nextcloud's own WOPI
-          # discovery (which is configured to hit http://[::1]:9980 directly) kept working.
-          net.proto = "IPv4";
+          net = {
+            # These MUST be nested attrsets, not quoted dotted keys: this option's freeform type maps
+            # attribute NESTING onto XML nesting, so `"ssl.enable"` is one attribute whose name merely
+            # contains a dot. It lands beside the real `ssl` set rather than inside it, emitting a
+            # junk `<ssl.enable>` element that coolwsd ignores while `<ssl><enable>` keeps whatever it
+            # would have been - which is on, since the module only ever sets `ssl.{ca,cert,key}` (the
+            # dummy self-signed certs it ships for testing) and never `ssl.enable`. Nothing warns
+            # about the stray key; the failure surfaces at the far end as Nextcloud's plain-HTTP WOPI
+            # probe getting "cURL error 52: Empty reply from server" off a TLS listener.
+            listen = "loopback";
+            # coolwsd.xml's own shipped comment on net.listen: "On systems where localhost resolves
+            # to IPv6 [::1] address first, when net.proto is all and net.listen is loopback, coolwsd
+            # unexpectedly listens on [::1] only. You need to change net.proto to IPv4, if you want
+            # to use 127.0.0.1." Confirmed on harmony: journalctl showed "Bind to: IPv6 port: 9980"
+            # and nothing on 127.0.0.1:9980, which nginx.nix's proxyPass targets for every
+            # virtual-host - so every browser-facing request 502'd while Nextcloud's own WOPI
+            # discovery (which is configured to hit http://[::1]:9980 directly) kept working.
+            proto = "IPv4";
+          };
+
           server_name = url;
-          ssl.enable = false; # nginx terminates TLS
-          # Without this, coolwsd's own listener being plain HTTP makes it advertise http:// URLs
-          # in its self-generated discovery.xml (urlsrc entries) - confirmed via
-          # `curl http://127.0.0.1:9980/hosting/discovery`. richdocuments builds the browser-facing
-          # editor iframe straight from that urlsrc, so the iframe embedded in Nextcloud's https
-          # page pointed at http://collabora..., and the browser silently blocked it as mixed
-          # active content (visible only in the console, never as a network request). ssl.termination
-          # is coolwsd's own name for "tell clients this is https even though I only speak http" -
-          # exactly this reverse-proxy-terminates-TLS setup.
-          ssl.termination = true;
+
+          ssl = {
+            enable = false; # nginx terminates TLS
+            # Without this, coolwsd's own listener being plain HTTP makes it advertise http:// URLs
+            # in its self-generated discovery.xml (urlsrc entries) - confirmed via
+            # `curl http://127.0.0.1:9980/hosting/discovery`. richdocuments builds the browser-facing
+            # editor iframe straight from that urlsrc, so the iframe embedded in Nextcloud's https
+            # page pointed at http://collabora..., and the browser silently blocked it as mixed
+            # active content (visible only in the console, never as a network request). ssl.termination
+            # is coolwsd's own name for "tell clients this is https even though I only speak http" -
+            # exactly this reverse-proxy-terminates-TLS setup.
+            termination = true;
+          };
           # No explicit WOPI host allowlist: coolwsd.xml's storage.wopi.alias_groups defaults to
           # mode="first", which trusts whichever host connects first. That's fine since Nextcloud
           # is the only WOPI client here; there's no plain storage.wopi.host key in the real schema.
         };
       };
+
       virtual-host = {
-        inherit port global;
+        inherit global port;
         host = host.name;
         name = "collabora";
         websockets = true;

--- a/modules/aspects/my/cross-seed.nix
+++ b/modules/aspects/my/cross-seed.nix
@@ -1,5 +1,19 @@
 {
   my.cross-seed = {
+    nixos = { config, ... }: {
+      services.cross-seed = {
+        enable = true;
+        group = "qbittorrent";
+        settings = {
+          linkDirs = [ "/metalminds/torrents/link-dir" ];
+          matchMode = "partial";
+          port = 2468;
+        };
+        settingsFile = config.age.secrets."cross-seed.json".path;
+        useGenConfigDefaults = true;
+        user = "qbittorrent";
+      };
+    };
     secrets = { secrets, ... }: {
       cross-seed-api-key = {
         generator.script = "alnum";
@@ -24,10 +38,10 @@
         };
         script =
           {
-            lib,
-            pkgs,
             decrypt,
             deps,
+            lib,
+            pkgs,
             ...
           }:
           ''
@@ -67,21 +81,6 @@
                 ]
               }'
           '';
-      };
-    };
-
-    nixos = { config, ... }: {
-      services.cross-seed = {
-        enable = true;
-        user = "qbittorrent";
-        group = "qbittorrent";
-        useGenConfigDefaults = true;
-        settingsFile = config.age.secrets."cross-seed.json".path;
-        settings = {
-          port = 2468;
-          linkDirs = [ "/metalminds/torrents/link-dir" ];
-          matchMode = "partial";
-        };
       };
     };
   };

--- a/modules/aspects/my/cross-seed.nix
+++ b/modules/aspects/my/cross-seed.nix
@@ -4,21 +4,25 @@
       services.cross-seed = {
         enable = true;
         group = "qbittorrent";
+
         settings = {
           linkDirs = [ "/metalminds/torrents/link-dir" ];
           matchMode = "partial";
           port = 2468;
         };
+
         settingsFile = config.age.secrets."cross-seed.json".path;
         useGenConfigDefaults = true;
         user = "qbittorrent";
       };
     };
+
     secrets = { secrets, ... }: {
       cross-seed-api-key = {
         generator.script = "alnum";
         intermediary = true;
       };
+
       # webuiPort below is qbittorrent.nix's hardcoded `port` (8080) - kept as a literal rather
       # than read from `config` because requesting `config` on this field (alongside `secrets`)
       # makes Den attach a collision-validator module to the same evalModules pass that builds
@@ -36,12 +40,13 @@
             sonarr-api-key
             ;
         };
+
         script =
           {
-            decrypt,
-            deps,
             lib,
             pkgs,
+            decrypt,
+            deps,
             ...
           }:
           ''

--- a/modules/aspects/my/discord.nix
+++ b/modules/aspects/my/discord.nix
@@ -1,7 +1,7 @@
 { den, ... }: {
   my.discord = {
+    includes = [ (den._.unfree [ "discord" ]) ];
     darwin.homebrew.casks = [ "discord" ];
     hmLinux = { pkgs, ... }: { home.packages = [ pkgs.discord ]; };
-    includes = [ (den._.unfree [ "discord" ]) ];
   };
 }

--- a/modules/aspects/my/discord.nix
+++ b/modules/aspects/my/discord.nix
@@ -1,9 +1,7 @@
 { den, ... }: {
   my.discord = {
-    includes = [ (den._.unfree [ "discord" ]) ];
-
     darwin.homebrew.casks = [ "discord" ];
-
     hmLinux = { pkgs, ... }: { home.packages = [ pkgs.discord ]; };
+    includes = [ (den._.unfree [ "discord" ]) ];
   };
 }

--- a/modules/aspects/my/dns.nix
+++ b/modules/aspects/my/dns.nix
@@ -74,15 +74,17 @@
         # Credentials aren't set here - the provider reads api_token from CLOUDFLARE_API_TOKEN, so
         # nothing sensitive lands in this config or in Terraform state.
         provider.cloudflare = { };
+
         # Unlike Namecheap's setHosts (which replaces the entire zone in one call), each record
         # here is its own independent resource - Terraform only ever touches what's declared
         # below, so there's no OVERWRITE-style footgun for the rest of the zone.
         resource.cloudflare_dns_record =
           lib.listToAttrs (
             map (vh: {
-              name = vh.name;
+              inherit (vh) name;
+
               value = {
-                inherit (host.dns-record) type content;
+                inherit (host.dns-record) content type;
                 name = "${vh.name}.${domain}";
                 # DNS-only (not proxied through Cloudflare's edge). This one-level name is
                 # actually covered by Cloudflare's free Universal SSL cert, but the per-host
@@ -105,20 +107,22 @@
             # `url = "${host.name}.${domain}"` deliberately doesn't go through the `global`/
             # `globalHosts` path above either (that would produce `homepage.${domain}`, not this).
             "${host.name}-root" = {
-              inherit (host.dns-record) type content;
+              inherit (host.dns-record) content type;
               name = "${host.name}.${domain}";
               proxied = false;
               ttl = 1800;
               zone_id = host.cloudflare-zone-id;
             };
+
             "${host.name}-wildcard" = {
-              inherit (host.dns-record) type content;
+              inherit (host.dns-record) content type;
               name = "*.${host.name}.${domain}";
               proxied = false;
               ttl = 1800;
               zone_id = host.cloudflare-zone-id;
             };
           };
+
         terraform.required_providers.cloudflare = {
           source = "cloudflare/cloudflare";
           version = "~> 5";
@@ -129,6 +133,13 @@
   perSystem =
     { lib, pkgs, ... }:
     let
+      allEntries = lib.concatLists (
+        lib.mapAttrsToList (host: hostnames: map (hostname: { inherit host hostname; }) hostnames) hostnamesByHost
+      );
+      # Group by hostname; anything claimed by more than one DISTINCT host is a collision.
+      collisions = lib.filterAttrs (_: entries: lib.length (lib.unique (map (e: e.host) entries)) > 1) (
+        lib.groupBy (e: e.hostname) allEntries
+      );
       # host -> every hostname its nginx vhosts actually claim: both `serverAliases` AND each
       # vhost's own PRIMARY name (the attribute key). The primary name matters too, not just
       # aliases: a service's `url` override can already equal the canonical global name (e.g.
@@ -141,22 +152,9 @@
       hostnamesByHost = lib.mapAttrs (
         _: hostCfg:
         lib.concatLists (
-          lib.mapAttrsToList (name: vh: [ name ] ++ (vh.serverAliases or [ ])) (
-            hostCfg.config.services.nginx.virtualHosts or { }
-          )
+          lib.mapAttrsToList (name: vh: [ name ] ++ (vh.serverAliases or [ ])) (hostCfg.config.services.nginx.virtualHosts or { })
         )
       ) config.flake.nixosConfigurations;
-
-      allEntries = lib.concatLists (
-        lib.mapAttrsToList (
-          host: hostnames: map (hostname: { inherit host hostname; }) hostnames
-        ) hostnamesByHost
-      );
-
-      # Group by hostname; anything claimed by more than one DISTINCT host is a collision.
-      collisions = lib.filterAttrs (_: entries: lib.length (lib.unique (map (e: e.host) entries)) > 1) (
-        lib.groupBy (e: e.hostname) allEntries
-      );
     in
     {
       checks.dns-global-uniqueness =
@@ -169,8 +167,7 @@
             Cloudflare DNS records for it:
             ${lib.concatStringsSep "\n" (
               lib.mapAttrsToList (
-                hostname: entries:
-                "  ${hostname}: ${lib.concatStringsSep ", " (lib.unique (map (e: e.host) entries))}"
+                hostname: entries: "  ${hostname}: ${lib.concatStringsSep ", " (lib.unique (map (e: e.host) entries))}"
               ) collisions
             )}
             Rename one of the services, or drop `global` from all but one host.

--- a/modules/aspects/my/dns.nix
+++ b/modules/aspects/my/dns.nix
@@ -58,28 +58,22 @@
   my.dns = { host, ... }: {
     secrets = {
       cloudflare-api-token = {
-        rekeyFile = ../../../secrets/cloudflare-api-token.age;
         intermediary = true;
+        rekeyFile = ../../../secrets/cloudflare-api-token.age;
         settings.terraform = true;
       };
     };
 
     terranix =
-      { virtual-host, lib, ... }:
+      { lib, virtual-host, ... }:
       let
         domain = "silverlight-nex.us";
         globalHosts = lib.filter (vh: vh.global or false) virtual-host;
       in
       lib.optionalAttrs (host ? dns-record) {
-        terraform.required_providers.cloudflare = {
-          source = "cloudflare/cloudflare";
-          version = "~> 5";
-        };
-
         # Credentials aren't set here - the provider reads api_token from CLOUDFLARE_API_TOKEN, so
         # nothing sensitive lands in this config or in Terraform state.
         provider.cloudflare = { };
-
         # Unlike Namecheap's setHosts (which replaces the entire zone in one call), each record
         # here is its own independent resource - Terraform only ever touches what's declared
         # below, so there's no OVERWRITE-style footgun for the rest of the zone.
@@ -88,10 +82,8 @@
             map (vh: {
               name = vh.name;
               value = {
-                zone_id = host.cloudflare-zone-id;
-                name = "${vh.name}.${domain}";
                 inherit (host.dns-record) type content;
-                ttl = 1800;
+                name = "${vh.name}.${domain}";
                 # DNS-only (not proxied through Cloudflare's edge). This one-level name is
                 # actually covered by Cloudflare's free Universal SSL cert, but the per-host
                 # wildcard below (`*.${host.name}.${domain}`) is namespaced two levels deep,
@@ -102,35 +94,40 @@
                 # port-forward rules no longer restrict to Cloudflare's IPs) and nginx already
                 # terminates with its own per-host ACME cert.
                 proxied = false;
+                ttl = 1800;
+                zone_id = host.cloudflare-zone-id;
               };
             }) globalHosts
           )
           // {
-            "${host.name}-wildcard" = {
-              zone_id = host.cloudflare-zone-id;
-              name = "*.${host.name}.${domain}";
-              inherit (host.dns-record) type content;
-              ttl = 1800;
-              proxied = false;
-            };
-
             # The host's own root/apex hostname - NOT covered by the wildcard above (a wildcard
             # only matches names with something before it, never its own apex), and homepage.nix's
             # `url = "${host.name}.${domain}"` deliberately doesn't go through the `global`/
             # `globalHosts` path above either (that would produce `homepage.${domain}`, not this).
             "${host.name}-root" = {
-              zone_id = host.cloudflare-zone-id;
-              name = "${host.name}.${domain}";
               inherit (host.dns-record) type content;
-              ttl = 1800;
+              name = "${host.name}.${domain}";
               proxied = false;
+              ttl = 1800;
+              zone_id = host.cloudflare-zone-id;
+            };
+            "${host.name}-wildcard" = {
+              inherit (host.dns-record) type content;
+              name = "*.${host.name}.${domain}";
+              proxied = false;
+              ttl = 1800;
+              zone_id = host.cloudflare-zone-id;
             };
           };
+        terraform.required_providers.cloudflare = {
+          source = "cloudflare/cloudflare";
+          version = "~> 5";
+        };
       };
   };
 
   perSystem =
-    { pkgs, lib, ... }:
+    { lib, pkgs, ... }:
     let
       # host -> every hostname its nginx vhosts actually claim: both `serverAliases` AND each
       # vhost's own PRIMARY name (the attribute key). The primary name matters too, not just
@@ -144,12 +141,16 @@
       hostnamesByHost = lib.mapAttrs (
         _: hostCfg:
         lib.concatLists (
-          lib.mapAttrsToList (name: vh: [ name ] ++ (vh.serverAliases or [ ])) (hostCfg.config.services.nginx.virtualHosts or { })
+          lib.mapAttrsToList (name: vh: [ name ] ++ (vh.serverAliases or [ ])) (
+            hostCfg.config.services.nginx.virtualHosts or { }
+          )
         )
       ) config.flake.nixosConfigurations;
 
       allEntries = lib.concatLists (
-        lib.mapAttrsToList (host: hostnames: map (hostname: { inherit host hostname; }) hostnames) hostnamesByHost
+        lib.mapAttrsToList (
+          host: hostnames: map (hostname: { inherit host hostname; }) hostnames
+        ) hostnamesByHost
       );
 
       # Group by hostname; anything claimed by more than one DISTINCT host is a collision.
@@ -168,7 +169,8 @@
             Cloudflare DNS records for it:
             ${lib.concatStringsSep "\n" (
               lib.mapAttrsToList (
-                hostname: entries: "  ${hostname}: ${lib.concatStringsSep ", " (lib.unique (map (e: e.host) entries))}"
+                hostname: entries:
+                "  ${hostname}: ${lib.concatStringsSep ", " (lib.unique (map (e: e.host) entries))}"
               ) collisions
             )}
             Rename one of the services, or drop `global` from all but one host.

--- a/modules/aspects/my/doc-browser.nix
+++ b/modules/aspects/my/doc-browser.nix
@@ -1,7 +1,6 @@
 {
   my.doc-browser = {
     darwin.homebrew.casks = [ "dash" ];
-
     hmLinux = { pkgs, ... }: { home.packages = [ pkgs.zeal ]; };
   };
 }

--- a/modules/aspects/my/emacs/emacs.nix
+++ b/modules/aspects/my/emacs/emacs.nix
@@ -2,29 +2,58 @@
 
 {
   flake-file.inputs.nix-doom-emacs-unstraightened = {
-    url = "github:marienz/nix-doom-emacs-unstraightened";
     inputs = {
-      nixpkgs.follows = "nixpkgs";
-      systems.follows = "systems";
       # Unused: we set `doomDir` explicitly below instead of relying on this
       # input's default. Left unfollowed, it resolves to a mutable relative
       # `path` input inside nix-doom-emacs-unstraightened, which Lix refuses
       # to write into our (immutable, git-committed) flake.lock.
       doomdir.follows = "nixpkgs";
+      nixpkgs.follows = "nixpkgs";
+      systems.follows = "systems";
     };
+    url = "github:marienz/nix-doom-emacs-unstraightened";
   };
 
   my.emacs = {
-    includes = [ (den._.unfree [ "aspell-dict-en-science" ]) ];
-
+    hmDarwin = { pkgs, ... }: {
+      programs.doom-emacs.emacs =
+        with pkgs;
+        emacs-pgtk.overrideAttrs (old: {
+          patches = (old.patches or [ ]) ++ [
+            # fix-window-role
+            (fetchpatch {
+              sha256 = "sha256-+z/KfsBm1lvZTZNiMbxzXQGRTjkCFO4QPlEK35upjsE=";
+              url = "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/d60d824b3d622f423c822b487a567805a195ac91/patches/emacs-28/fix-window-role.patch";
+            })
+            # system-appearance
+            (fetchpatch {
+              sha256 = "sha256-3QLq91AQ6E921/W9nfDjdOUWR8YVsqBAT/W9c1woqAw=";
+              url = "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/d60d824b3d622f423c822b487a567805a195ac91/patches/emacs-30/system-appearance.patch";
+            })
+            # round-undecorated-frame
+            (fetchpatch {
+              sha256 = "sha256-fesZ0H3LO6T2AiRV8ASozKxZBpvVzwLEcLDy6rctR6c=";
+              url = "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/d60d824b3d622f423c822b487a567805a195ac91/patches/emacs-30/round-undecorated-frame.patch";
+            })
+            # fix-macos-tahoe-scrolling
+            (fetchpatch {
+              sha256 = "sha256-Hf9oZ5ImBnxTLa6yS02UDzBEgJEGAwNq/svJ3S35uKw=";
+              url = "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/d60d824b3d622f423c822b487a567805a195ac91/patches/emacs-30/fix-macos-tahoe-scrolling.patch";
+            })
+            # fix-ns-x-colors
+            (fetchpatch {
+              sha256 = "sha256-oe3DFgEXwp0cZJl+ufWqTonaeWSliikTRsVDNbcy4Yw=";
+              url = "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/d60d824b3d622f423c822b487a567805a195ac91/patches/emacs-30/fix-ns-x-colors.patch";
+            })
+          ];
+        });
+    };
     homeManager = { pkgs, ... }: {
-      imports = [ (inputs.nix-doom-emacs-unstraightened.homeModule or { }) ];
-
       home.sessionVariables.EDITOR = "emacs -nw";
-
+      imports = [ (inputs.nix-doom-emacs-unstraightened.homeModule or { }) ];
       programs.doom-emacs = {
-        enable = true;
         doomDir = ./doom;
+        enable = true;
         experimentalFetchTree = true;
         extraBinPackages = with pkgs; [
           coreutils
@@ -71,42 +100,8 @@
         ];
         extraPackages = epkgs: [ epkgs.treesit-grammars.with-all-grammars ];
       };
-
       services.emacs.enable = true;
     };
-
-    hmDarwin = { pkgs, ... }: {
-      programs.doom-emacs.emacs =
-        with pkgs;
-        emacs-pgtk.overrideAttrs (old: {
-          patches = (old.patches or [ ]) ++ [
-            # fix-window-role
-            (fetchpatch {
-              url = "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/d60d824b3d622f423c822b487a567805a195ac91/patches/emacs-28/fix-window-role.patch";
-              sha256 = "sha256-+z/KfsBm1lvZTZNiMbxzXQGRTjkCFO4QPlEK35upjsE=";
-            })
-            # system-appearance
-            (fetchpatch {
-              url = "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/d60d824b3d622f423c822b487a567805a195ac91/patches/emacs-30/system-appearance.patch";
-              sha256 = "sha256-3QLq91AQ6E921/W9nfDjdOUWR8YVsqBAT/W9c1woqAw=";
-            })
-            # round-undecorated-frame
-            (fetchpatch {
-              url = "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/d60d824b3d622f423c822b487a567805a195ac91/patches/emacs-30/round-undecorated-frame.patch";
-              sha256 = "sha256-fesZ0H3LO6T2AiRV8ASozKxZBpvVzwLEcLDy6rctR6c=";
-            })
-            # fix-macos-tahoe-scrolling
-            (fetchpatch {
-              url = "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/d60d824b3d622f423c822b487a567805a195ac91/patches/emacs-30/fix-macos-tahoe-scrolling.patch";
-              sha256 = "sha256-Hf9oZ5ImBnxTLa6yS02UDzBEgJEGAwNq/svJ3S35uKw=";
-            })
-            # fix-ns-x-colors
-            (fetchpatch {
-              url = "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/d60d824b3d622f423c822b487a567805a195ac91/patches/emacs-30/fix-ns-x-colors.patch";
-              sha256 = "sha256-oe3DFgEXwp0cZJl+ufWqTonaeWSliikTRsVDNbcy4Yw=";
-            })
-          ];
-        });
-    };
+    includes = [ (den._.unfree [ "aspell-dict-en-science" ]) ];
   };
 }

--- a/modules/aspects/my/emacs/emacs.nix
+++ b/modules/aspects/my/emacs/emacs.nix
@@ -2,6 +2,8 @@
 
 {
   flake-file.inputs.nix-doom-emacs-unstraightened = {
+    url = "github:marienz/nix-doom-emacs-unstraightened";
+
     inputs = {
       # Unused: we set `doomDir` explicitly below instead of relying on this
       # input's default. Left unfollowed, it resolves to a mutable relative
@@ -11,10 +13,11 @@
       nixpkgs.follows = "nixpkgs";
       systems.follows = "systems";
     };
-    url = "github:marienz/nix-doom-emacs-unstraightened";
   };
 
   my.emacs = {
+    includes = [ (den._.unfree [ "aspell-dict-en-science" ]) ];
+
     hmDarwin = { pkgs, ... }: {
       programs.doom-emacs.emacs =
         with pkgs;
@@ -48,13 +51,16 @@
           ];
         });
     };
+
     homeManager = { pkgs, ... }: {
-      home.sessionVariables.EDITOR = "emacs -nw";
       imports = [ (inputs.nix-doom-emacs-unstraightened.homeModule or { }) ];
+      home.sessionVariables.EDITOR = "emacs -nw";
+
       programs.doom-emacs = {
-        doomDir = ./doom;
         enable = true;
+        doomDir = ./doom;
         experimentalFetchTree = true;
+
         extraBinPackages = with pkgs; [
           coreutils
           fd
@@ -98,10 +104,11 @@
           vscode-langservers-extracted
           yaml-language-server
         ];
+
         extraPackages = epkgs: [ epkgs.treesit-grammars.with-all-grammars ];
       };
+
       services.emacs.enable = true;
     };
-    includes = [ (den._.unfree [ "aspell-dict-en-science" ]) ];
   };
 }

--- a/modules/aspects/my/fish.nix
+++ b/modules/aspects/my/fish.nix
@@ -2,7 +2,6 @@
   my.fish.homeManager = {
     programs.fish = {
       enable = true;
-
       # Fish 4.4+ bundles Catppuccin (with light/dark variants baked into
       # each flavor) as a built-in theme; `theme choose` re-applies whichever
       # variant matches the terminal's reported background color, and reacts

--- a/modules/aspects/my/ghostty.nix
+++ b/modules/aspects/my/ghostty.nix
@@ -1,20 +1,18 @@
 {
   my.ghostty = {
+    hmDarwin = { pkgs, ... }: { programs.ghostty.package = pkgs.ghostty-bin; };
     homeManager = { lib, ... }: {
       programs.ghostty = {
         enable = true;
         settings = {
+          auto-update = "off";
           keybind = [ "global:super+Backquote=toggle_quick_terminal" ];
           macos-option-as-alt = true;
-          auto-update = "off";
-
           # Follow the system light/dark appearance instead of Stylix's single
           # (dark-only) base16 theme.
           theme = lib.mkForce "light:Catppuccin Latte,dark:Catppuccin Mocha";
         };
       };
     };
-
-    hmDarwin = { pkgs, ... }: { programs.ghostty.package = pkgs.ghostty-bin; };
   };
 }

--- a/modules/aspects/my/ghostty.nix
+++ b/modules/aspects/my/ghostty.nix
@@ -1,9 +1,11 @@
 {
   my.ghostty = {
     hmDarwin = { pkgs, ... }: { programs.ghostty.package = pkgs.ghostty-bin; };
+
     homeManager = { lib, ... }: {
       programs.ghostty = {
         enable = true;
+
         settings = {
           auto-update = "off";
           keybind = [ "global:super+Backquote=toggle_quick_terminal" ];

--- a/modules/aspects/my/git.nix
+++ b/modules/aspects/my/git.nix
@@ -2,10 +2,12 @@
   my.git = user: {
     homeManager.programs.git = {
       enable = true;
+
       settings = {
         inherit user;
         init.defaultBranch = "main";
         pull.rebase = true;
+
         push = {
           autoSetupRemote = true;
           default = "current";

--- a/modules/aspects/my/gluetun.nix
+++ b/modules/aspects/my/gluetun.nix
@@ -7,32 +7,40 @@
           SERVER_COUNTRIES = "United States";
           TZ = config.time.timeZone;
           VPN_PORT_FORWARDING = "on";
+
           VPN_PORT_FORWARDING_DOWN_COMMAND = ''
             /bin/sh -c 'wget -O- --retry-connrefused --post-data "json={\"listen_port\":0,\"current_network_interface\":\"lo\"}" http://127.0.0.1:8080/api/v2/app/setPreferences 2>&1'
           '';
+
           VPN_PORT_FORWARDING_UP_COMMAND = ''
             /bin/sh -c 'wget -O- --retry-connrefused --post-data "json={\"listen_port\":{{PORT}},\"current_network_interface\":\"{{VPN_INTERFACE}}\",\"random_port\":false,\"upnp\":false}" http://127.0.0.1:8080/api/v2/app/setPreferences 2>&1'
           '';
+
           VPN_SERVICE_PROVIDER = "protonvpn";
           VPN_TYPE = "wireguard";
         };
+
         environmentFiles = [ config.age.secrets."gluetun.env".path ];
+
         extraOptions = [
           "--cap-add=NET_ADMIN"
           "--device=/dev/net/tun:/dev/net/tun"
         ];
+
         image = "qmcgaw/gluetun:v3.41.1@sha256:1a5bf4b4820a879cdf8d93d7ef0d2d963af56670c9ebff8981860b6804ebc8ab";
         volumes = [ "/var/lib/gluetun:/gluetun" ];
       };
     };
+
     secrets = { secrets, ... }: {
       "gluetun.env".generator = {
         dependencies = { inherit (secrets) proton-vpn-wireguard-private-key; };
+
         script =
           {
+            lib,
             decrypt,
             deps,
-            lib,
             ...
           }:
           ''
@@ -41,6 +49,7 @@
             )"
           '';
       };
+
       proton-vpn-wireguard-private-key = {
         intermediary = true;
         rekeyFile = ../../../secrets/proton-vpn-wireguard-private-key.age;

--- a/modules/aspects/my/gluetun.nix
+++ b/modules/aspects/my/gluetun.nix
@@ -1,17 +1,38 @@
 {
   my.gluetun = {
-    secrets = { secrets, ... }: {
-      proton-vpn-wireguard-private-key = {
-        rekeyFile = ../../../secrets/proton-vpn-wireguard-private-key.age;
-        intermediary = true;
+    nixos = { config, ... }: {
+      virtualisation.oci-containers.containers.gluetun = {
+        environment = {
+          PORT_FORWARD_ONLY = "on";
+          SERVER_COUNTRIES = "United States";
+          TZ = config.time.timeZone;
+          VPN_PORT_FORWARDING = "on";
+          VPN_PORT_FORWARDING_DOWN_COMMAND = ''
+            /bin/sh -c 'wget -O- --retry-connrefused --post-data "json={\"listen_port\":0,\"current_network_interface\":\"lo\"}" http://127.0.0.1:8080/api/v2/app/setPreferences 2>&1'
+          '';
+          VPN_PORT_FORWARDING_UP_COMMAND = ''
+            /bin/sh -c 'wget -O- --retry-connrefused --post-data "json={\"listen_port\":{{PORT}},\"current_network_interface\":\"{{VPN_INTERFACE}}\",\"random_port\":false,\"upnp\":false}" http://127.0.0.1:8080/api/v2/app/setPreferences 2>&1'
+          '';
+          VPN_SERVICE_PROVIDER = "protonvpn";
+          VPN_TYPE = "wireguard";
+        };
+        environmentFiles = [ config.age.secrets."gluetun.env".path ];
+        extraOptions = [
+          "--cap-add=NET_ADMIN"
+          "--device=/dev/net/tun:/dev/net/tun"
+        ];
+        image = "qmcgaw/gluetun:v3.41.1@sha256:1a5bf4b4820a879cdf8d93d7ef0d2d963af56670c9ebff8981860b6804ebc8ab";
+        volumes = [ "/var/lib/gluetun:/gluetun" ];
       };
+    };
+    secrets = { secrets, ... }: {
       "gluetun.env".generator = {
         dependencies = { inherit (secrets) proton-vpn-wireguard-private-key; };
         script =
           {
-            lib,
             decrypt,
             deps,
+            lib,
             ...
           }:
           ''
@@ -20,31 +41,9 @@
             )"
           '';
       };
-    };
-
-    nixos = { config, ... }: {
-      virtualisation.oci-containers.containers.gluetun = {
-        image = "qmcgaw/gluetun:v3.41.1@sha256:1a5bf4b4820a879cdf8d93d7ef0d2d963af56670c9ebff8981860b6804ebc8ab";
-        volumes = [ "/var/lib/gluetun:/gluetun" ];
-        environment = {
-          VPN_SERVICE_PROVIDER = "protonvpn";
-          VPN_TYPE = "wireguard";
-          VPN_PORT_FORWARDING = "on";
-          VPN_PORT_FORWARDING_UP_COMMAND = ''
-            /bin/sh -c 'wget -O- --retry-connrefused --post-data "json={\"listen_port\":{{PORT}},\"current_network_interface\":\"{{VPN_INTERFACE}}\",\"random_port\":false,\"upnp\":false}" http://127.0.0.1:8080/api/v2/app/setPreferences 2>&1'
-          '';
-          VPN_PORT_FORWARDING_DOWN_COMMAND = ''
-            /bin/sh -c 'wget -O- --retry-connrefused --post-data "json={\"listen_port\":0,\"current_network_interface\":\"lo\"}" http://127.0.0.1:8080/api/v2/app/setPreferences 2>&1'
-          '';
-          SERVER_COUNTRIES = "United States";
-          PORT_FORWARD_ONLY = "on";
-          TZ = config.time.timeZone;
-        };
-        environmentFiles = [ config.age.secrets."gluetun.env".path ];
-        extraOptions = [
-          "--cap-add=NET_ADMIN"
-          "--device=/dev/net/tun:/dev/net/tun"
-        ];
+      proton-vpn-wireguard-private-key = {
+        intermediary = true;
+        rekeyFile = ../../../secrets/proton-vpn-wireguard-private-key.age;
       };
     };
   };

--- a/modules/aspects/my/gnome.nix
+++ b/modules/aspects/my/gnome.nix
@@ -1,6 +1,7 @@
 {
   my.gnome = {
     hmLinux.dconf.enable = true;
+
     nixos = { pkgs, ... }: {
       environment = {
         gnome.excludePackages = with pkgs; [

--- a/modules/aspects/my/gnome.nix
+++ b/modules/aspects/my/gnome.nix
@@ -1,5 +1,6 @@
 {
   my.gnome = {
+    hmLinux.dconf.enable = true;
     nixos = { pkgs, ... }: {
       environment = {
         gnome.excludePackages = with pkgs; [
@@ -27,7 +28,5 @@
         displayManager.gdm.enable = true;
       };
     };
-
-    hmLinux.dconf.enable = true;
   };
 }

--- a/modules/aspects/my/google-chrome.nix
+++ b/modules/aspects/my/google-chrome.nix
@@ -1,6 +1,6 @@
 { den, ... }: {
   my.chrome = {
-    homeManager = { pkgs, ... }: { home.packages = [ pkgs.google-chrome ]; };
     includes = [ (den._.unfree [ "google-chrome" ]) ];
+    homeManager = { pkgs, ... }: { home.packages = [ pkgs.google-chrome ]; };
   };
 }

--- a/modules/aspects/my/google-chrome.nix
+++ b/modules/aspects/my/google-chrome.nix
@@ -1,7 +1,6 @@
 { den, ... }: {
   my.chrome = {
-    includes = [ (den._.unfree [ "google-chrome" ]) ];
-
     homeManager = { pkgs, ... }: { home.packages = [ pkgs.google-chrome ]; };
+    includes = [ (den._.unfree [ "google-chrome" ]) ];
   };
 }

--- a/modules/aspects/my/gpg.nix
+++ b/modules/aspects/my/gpg.nix
@@ -2,6 +2,7 @@
   my.gpg = {
     hmDarwin = { pkgs, ... }: { home.packages = [ pkgs.pinentry_mac ]; };
     hmLinux = { pkgs, ... }: { home.packages = [ pkgs.pinentry-all ]; };
+
     homeManager = {
       programs.gpg.enable = true;
       services.gpg-agent.enable = true;

--- a/modules/aspects/my/gpg.nix
+++ b/modules/aspects/my/gpg.nix
@@ -1,12 +1,10 @@
 {
   my.gpg = {
+    hmDarwin = { pkgs, ... }: { home.packages = [ pkgs.pinentry_mac ]; };
+    hmLinux = { pkgs, ... }: { home.packages = [ pkgs.pinentry-all ]; };
     homeManager = {
       programs.gpg.enable = true;
       services.gpg-agent.enable = true;
     };
-
-    hmLinux = { pkgs, ... }: { home.packages = [ pkgs.pinentry-all ]; };
-
-    hmDarwin = { pkgs, ... }: { home.packages = [ pkgs.pinentry_mac ]; };
   };
 }

--- a/modules/aspects/my/homebrew.nix
+++ b/modules/aspects/my/homebrew.nix
@@ -1,6 +1,7 @@
 {
   my.homebrew.darwin.homebrew = {
     enable = true;
+
     onActivation = {
       autoUpdate = true;
       upgrade = true;

--- a/modules/aspects/my/homepage.nix
+++ b/modules/aspects/my/homepage.nix
@@ -1,9 +1,9 @@
 { lib, ... }:
 let
   domain = "silverlight-nex.us";
+  env-var-for = name: "HOMEPAGE_VAR_${lib.toUpper name}_API_KEY";
   port = 8082;
   port' = toString port;
-  env-var-for = name: "HOMEPAGE_VAR_${lib.toUpper name}_API_KEY";
 in
 {
   my.homepage = { host, ... }: {
@@ -15,11 +15,6 @@ in
         ...
       }:
       let
-        urlFor = vh: vh.url or "${vh.name}.${vh.host}.${domain}";
-        hosts = lib.listToAttrs (map (vh: lib.nameValuePair vh.name vh) virtual-host);
-
-        homepageServices = lib.filter (vh: vh ? homepage) virtual-host;
-        groups = lib.unique (map (vh: vh.group) homepageServices);
         entryToService =
           vh:
           let
@@ -49,10 +44,16 @@ in
               // removeAttrs widget [ "api-key" ];
             };
           };
+        groups = lib.unique (map (vh: vh.group) homepageServices);
+        homepageServices = lib.filter (vh: vh ? homepage) virtual-host;
+        hosts = lib.listToAttrs (map (vh: lib.nameValuePair vh.name vh) virtual-host);
+        urlFor = vh: vh.url or "${vh.name}.${vh.host}.${domain}";
       in
       {
         services.homepage-dashboard = {
+          enable = true;
           allowedHosts = "localhost:${port'},127.0.0.1:${port'},${urlFor hosts.homepage}";
+
           bookmarks = [
             {
               "Servers" = [
@@ -67,19 +68,20 @@ in
               ];
             }
           ];
-          enable = true;
+
           environmentFiles = [ config.age.secrets."homepage-dashboard.env".path ];
-          services = map (group: {
-            ${group} = map entryToService (lib.filter (vh: vh.group == group) homepageServices);
-          }) groups;
+          services = map (group: { ${group} = map entryToService (lib.filter (vh: vh.group == group) homepageServices); }) groups;
+
           widgets = [
             {
               glances = {
                 cputemp = true;
+
                 disk = [
                   "/"
                   "/metalminds"
                 ];
+
                 expanded = true;
                 uptime = true;
                 url = "http://127.0.0.1:${toString config.services.glances.port}";
@@ -89,6 +91,7 @@ in
           ];
         };
       };
+
     # Each API-key secret names the service it belongs to via its own `settings.homepage` (e.g.
     # sonarr.nix sets `secrets.sonarr-api-key.settings.homepage = "sonarr";`) - collected here by
     # scanning `config.age.secrets` directly, so a new API-key widget only needs that one field on
@@ -112,9 +115,7 @@ in
         # the WHOLE chain (not just the last step), so this is safe even when `sec.settings`
         # itself is `null` (see modules/terranix.nix's identical `terraform-mode-of` for the same
         # pattern spelled out further).
-        api-key-secrets = lib.filterAttrs (
-          _: sec: (sec.settings.homepage or null) != null
-        ) config.age.secrets;
+        api-key-secrets = lib.filterAttrs (_: sec: (sec.settings.homepage or null) != null) config.age.secrets;
       in
       {
         # This key's PRESENCE is unconditional (always generated, even if no widget currently sets
@@ -125,11 +126,12 @@ in
         # the long version of this).
         "homepage-dashboard.env".generator = {
           dependencies = lib.mapAttrs (name: _: secrets.${name}) api-key-secrets;
+
           script =
             {
+              lib,
               decrypt,
               deps,
-              lib,
               ...
             }:
             lib.concatMapStrings (name: ''
@@ -139,6 +141,7 @@ in
             '') (lib.attrNames api-key-secrets);
         };
       };
+
     # No `homepage` block of its own: Homepage doesn't list itself as one of its own tiles, but
     # `label`/`icon`/`group` still feed its Authentik application (see virtual-host.nix).
     virtual-host = {

--- a/modules/aspects/my/homepage.nix
+++ b/modules/aspects/my/homepage.nix
@@ -7,76 +7,11 @@ let
 in
 {
   my.homepage = { host, ... }: {
-    # No `homepage` block of its own: Homepage doesn't list itself as one of its own tiles, but
-    # `label`/`icon`/`group` still feed its Authentik application (see virtual-host.nix).
-    virtual-host = {
-      name = "homepage";
-      host = host.name;
-      # Homepage is the host's own root landing page, not a per-service subdomain, so it
-      # deliberately doesn't follow the `${name}.${host.name}.${domain}` pattern nginx.nix derives
-      # for everything else.
-      url = "${host.name}.${domain}";
-      protected = true;
-      label = "Homepage";
-      icon = "https://raw.githubusercontent.com/gethomepage/homepage/dev/public/android-chrome-512x512.png";
-      group = "Infra";
-      inherit port;
-    };
-
-    # Each API-key secret names the service it belongs to via its own `settings.homepage` (e.g.
-    # sonarr.nix sets `secrets.sonarr-api-key.settings.homepage = "sonarr";`) - collected here by
-    # scanning `config.age.secrets` directly, so a new API-key widget only needs that one field on
-    # its own secret and nothing here has to change. This sidesteps `virtual-host` entirely: Den's
-    # `wrapClassModule` attaches a collision-validator to any field mixing a den-recognized quirk
-    # (like `virtual-host`) with a non-recognized arg, and `age.secrets` - a flat `attrsOf
-    # submodule` - has no `warnings` option to absorb that validator's output, unlike `terranix`'s
-    # allowlisted JSON schema (see modules/terranix.nix). `config`/`secrets` here are both NOT
-    # den-recognized, so this field is delivered unwrapped via ordinary NixOS `_module.args` -
-    # safe, and simpler than bridging `virtual-host` data through an internal option the way this
-    # used to.
-    secrets =
-      {
-        config,
-        secrets,
-        lib,
-        ...
-      }:
-      let
-        # `sec.settings` is a declared option, default `null` - `a.b.c or default` short-circuits
-        # the WHOLE chain (not just the last step), so this is safe even when `sec.settings`
-        # itself is `null` (see modules/terranix.nix's identical `terraform-mode-of` for the same
-        # pattern spelled out further).
-        api-key-secrets = lib.filterAttrs (_: sec: (sec.settings.homepage or null) != null) config.age.secrets;
-      in
-      {
-        # This key's PRESENCE is unconditional (always generated, even if no widget currently sets
-        # `api-key`) - a value may safely depend on the fully-merged `config.age.secrets` (used for
-        # `api-key-secrets` above), but making the KEY conditional on that same scan would make
-        # `config.age.secrets`'s own key set depend on whether THIS module contributes this SAME
-        # key - "infinite recursion encountered" (see modules/terranix.nix's identical pattern for
-        # the long version of this).
-        "homepage-dashboard.env".generator = {
-          dependencies = lib.mapAttrs (name: _: secrets.${name}) api-key-secrets;
-          script =
-            {
-              lib,
-              decrypt,
-              deps,
-              ...
-            }:
-            lib.concatMapStrings (name: ''
-              printf '${env-var-for api-key-secrets.${name}.settings.homepage}="%s"\n' "$(
-                ${decrypt} ${lib.escapeShellArg deps.${name}.file}
-              )"
-            '') (lib.attrNames api-key-secrets);
-        };
-      };
-
     nixos =
       {
         config,
-        virtual-host,
         lib,
+        virtual-host,
         ...
       }:
       let
@@ -117,25 +52,7 @@ in
       in
       {
         services.homepage-dashboard = {
-          enable = true;
-          environmentFiles = [ config.age.secrets."homepage-dashboard.env".path ];
           allowedHosts = "localhost:${port'},127.0.0.1:${port'},${urlFor hosts.homepage}";
-          widgets = [
-            {
-              glances = {
-                url = "http://127.0.0.1:${toString config.services.glances.port}";
-                version = 4;
-                cputemp = true;
-                uptime = true;
-                disk = [
-                  "/"
-                  "/metalminds"
-                ];
-                expanded = true;
-              };
-            }
-          ];
-          services = map (group: { ${group} = map entryToService (lib.filter (vh: vh.group == group) homepageServices); }) groups;
           bookmarks = [
             {
               "Servers" = [
@@ -150,7 +67,92 @@ in
               ];
             }
           ];
+          enable = true;
+          environmentFiles = [ config.age.secrets."homepage-dashboard.env".path ];
+          services = map (group: {
+            ${group} = map entryToService (lib.filter (vh: vh.group == group) homepageServices);
+          }) groups;
+          widgets = [
+            {
+              glances = {
+                cputemp = true;
+                disk = [
+                  "/"
+                  "/metalminds"
+                ];
+                expanded = true;
+                uptime = true;
+                url = "http://127.0.0.1:${toString config.services.glances.port}";
+                version = 4;
+              };
+            }
+          ];
         };
       };
+    # Each API-key secret names the service it belongs to via its own `settings.homepage` (e.g.
+    # sonarr.nix sets `secrets.sonarr-api-key.settings.homepage = "sonarr";`) - collected here by
+    # scanning `config.age.secrets` directly, so a new API-key widget only needs that one field on
+    # its own secret and nothing here has to change. This sidesteps `virtual-host` entirely: Den's
+    # `wrapClassModule` attaches a collision-validator to any field mixing a den-recognized quirk
+    # (like `virtual-host`) with a non-recognized arg, and `age.secrets` - a flat `attrsOf
+    # submodule` - has no `warnings` option to absorb that validator's output, unlike `terranix`'s
+    # allowlisted JSON schema (see modules/terranix.nix). `config`/`secrets` here are both NOT
+    # den-recognized, so this field is delivered unwrapped via ordinary NixOS `_module.args` -
+    # safe, and simpler than bridging `virtual-host` data through an internal option the way this
+    # used to.
+    secrets =
+      {
+        config,
+        lib,
+        secrets,
+        ...
+      }:
+      let
+        # `sec.settings` is a declared option, default `null` - `a.b.c or default` short-circuits
+        # the WHOLE chain (not just the last step), so this is safe even when `sec.settings`
+        # itself is `null` (see modules/terranix.nix's identical `terraform-mode-of` for the same
+        # pattern spelled out further).
+        api-key-secrets = lib.filterAttrs (
+          _: sec: (sec.settings.homepage or null) != null
+        ) config.age.secrets;
+      in
+      {
+        # This key's PRESENCE is unconditional (always generated, even if no widget currently sets
+        # `api-key`) - a value may safely depend on the fully-merged `config.age.secrets` (used for
+        # `api-key-secrets` above), but making the KEY conditional on that same scan would make
+        # `config.age.secrets`'s own key set depend on whether THIS module contributes this SAME
+        # key - "infinite recursion encountered" (see modules/terranix.nix's identical pattern for
+        # the long version of this).
+        "homepage-dashboard.env".generator = {
+          dependencies = lib.mapAttrs (name: _: secrets.${name}) api-key-secrets;
+          script =
+            {
+              decrypt,
+              deps,
+              lib,
+              ...
+            }:
+            lib.concatMapStrings (name: ''
+              printf '${env-var-for api-key-secrets.${name}.settings.homepage}="%s"\n' "$(
+                ${decrypt} ${lib.escapeShellArg deps.${name}.file}
+              )"
+            '') (lib.attrNames api-key-secrets);
+        };
+      };
+    # No `homepage` block of its own: Homepage doesn't list itself as one of its own tiles, but
+    # `label`/`icon`/`group` still feed its Authentik application (see virtual-host.nix).
+    virtual-host = {
+      inherit port;
+      group = "Infra";
+      host = host.name;
+      icon = "https://raw.githubusercontent.com/gethomepage/homepage/dev/public/android-chrome-512x512.png";
+      label = "Homepage";
+      name = "homepage";
+      protected = true;
+      # Homepage is the host's own root landing page, not a per-service subdomain, so it
+      # deliberately doesn't follow the `${name}.${host.name}.${domain}` pattern nginx.nix derives
+      # for everything else.
+      url = "${host.name}.${domain}";
+    };
   };
 }

--- a/modules/aspects/my/immich.nix
+++ b/modules/aspects/my/immich.nix
@@ -14,78 +14,26 @@ in
       url = "immich.${host.name}.${domain}";
     in
     {
-      virtual-host = {
-        name = "immich";
-        host = host.name;
-        inherit port global;
-        # Immich's frontend opens a WebSocket right after login for real-time updates (job
-        # progress, live sync); without this the connection silently fails and the UI hangs.
-        websockets = true;
-        # Immich sets its own secure/HttpOnly/SameSite flags on its session cookie. Without this,
-        # nginx's blanket cookie rewrite appends a second, duplicate set of those flags, producing
-        # a malformed Set-Cookie the browser silently refuses to store — login succeeds
-        # server-side but the session never sticks, so the UI hangs forever waiting for one that
-        # never arrives.
-        preserveCookieFlags = true;
-        # Requests the matching OAuth2 Provider + Application from Authentik (authentik.nix) - see
-        # virtual-host.nix's `oidc` field for the shape. Per Immich's own OIDC docs
-        # (docs.immich.app/administration/oauth) - web login redirects to `/auth/login`, the "link
-        # another device" flow redirects to `/user-settings`, and the mobile app comes in through
-        # the HTTPS override below (`mobileRedirectUri`) rather than its native
-        # `app.immich:///oauth-callback` scheme, which Authentik doesn't need to know about as a
-        # result.
-        oidc = {
-          redirect-paths = [
-            "/auth/login"
-            "/user-settings"
-            "/api/oauth/mobile-redirect"
-          ];
-          client-secret = "immich-oidc-client-secret";
-        };
-        label = "Immich";
-        icon = "immich.svg";
-        group = "Media";
-        homepage = {
-          description = "Photo & video backup";
-        };
-      };
-
-      # `settings.terraform = "variable";` (not just any secret) - it now feeds a Terraform
-      # `variable` (modules/terranix.nix's two modes) as well as Immich's own `environmentFile`-
-      # style secret consumption below, so it's NOT `intermediary` - unlike a secret that ONLY ever
-      # feeds a Terraform `variable`, this one is ALSO read directly by `services.immich` below via
-      # its own decrypted file, so it has to be materialized as a real host secret.
-      secrets = {
-        immich-oidc-client-secret = {
-          generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -hex 32";
-          settings.terraform = "variable";
-        };
-      };
-
       nixos = { config, ... }: {
-        users.users = lib.genAttrs administrators (user: {
-          extraGroups = [ "immich" ];
-        });
-
         services.immich = {
+          inherit port;
           enable = true;
           host = "127.0.0.1";
-          inherit port;
           mediaLocation = "/metalminds/pictures";
           settings = {
             oauth = {
-              enabled = true;
               # Skip Immich's own login page and bounce straight to Authentik - there's nothing else
               # to pick from it now that `passwordLogin` is off below. `/auth/login?autoLaunch=0`
               # (also `?password=1`) still renders the form instead of redirecting, which is how to
               # reach it if password login ever gets temporarily turned back on to recover.
               autoLaunch = true;
-              issuerUrl = "https://${config.services.authentik.nginx.host}/application/o/immich/";
               clientId = "immich";
               clientSecret._secret = config.age.secrets.immich-oidc-client-secret.path;
-              scope = "openid email profile";
+              enabled = true;
+              issuerUrl = "https://${config.services.authentik.nginx.host}/application/o/immich/";
               mobileOverrideEnabled = true;
               mobileRedirectUri = "https://${url}/api/oauth/mobile-redirect";
+              scope = "openid email profile";
             };
             # Authentik is the only way in; Immich's own local accounts can no longer be used.
             # Immich attaches an OAuth login to an existing account by EMAIL (its auth service
@@ -101,6 +49,55 @@ in
             passwordLogin.enabled = false;
           };
         };
+        users.users = lib.genAttrs administrators (user: {
+          extraGroups = [ "immich" ];
+        });
+      };
+      # `settings.terraform = "variable";` (not just any secret) - it now feeds a Terraform
+      # `variable` (modules/terranix.nix's two modes) as well as Immich's own `environmentFile`-
+      # style secret consumption below, so it's NOT `intermediary` - unlike a secret that ONLY ever
+      # feeds a Terraform `variable`, this one is ALSO read directly by `services.immich` below via
+      # its own decrypted file, so it has to be materialized as a real host secret.
+      secrets = {
+        immich-oidc-client-secret = {
+          generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -hex 32";
+          settings.terraform = "variable";
+        };
+      };
+      virtual-host = {
+        inherit port global;
+        group = "Media";
+        homepage = {
+          description = "Photo & video backup";
+        };
+        host = host.name;
+        icon = "immich.svg";
+        label = "Immich";
+        name = "immich";
+        # Requests the matching OAuth2 Provider + Application from Authentik (authentik.nix) - see
+        # virtual-host.nix's `oidc` field for the shape. Per Immich's own OIDC docs
+        # (docs.immich.app/administration/oauth) - web login redirects to `/auth/login`, the "link
+        # another device" flow redirects to `/user-settings`, and the mobile app comes in through
+        # the HTTPS override below (`mobileRedirectUri`) rather than its native
+        # `app.immich:///oauth-callback` scheme, which Authentik doesn't need to know about as a
+        # result.
+        oidc = {
+          client-secret = "immich-oidc-client-secret";
+          redirect-paths = [
+            "/auth/login"
+            "/user-settings"
+            "/api/oauth/mobile-redirect"
+          ];
+        };
+        # Immich sets its own secure/HttpOnly/SameSite flags on its session cookie. Without this,
+        # nginx's blanket cookie rewrite appends a second, duplicate set of those flags, producing
+        # a malformed Set-Cookie the browser silently refuses to store — login succeeds
+        # server-side but the session never sticks, so the UI hangs forever waiting for one that
+        # never arrives.
+        preserveCookieFlags = true;
+        # Immich's frontend opens a WebSocket right after login for real-time updates (job
+        # progress, live sync); without this the connection silently fails and the UI hangs.
+        websockets = true;
       };
     };
 }

--- a/modules/aspects/my/immich.nix
+++ b/modules/aspects/my/immich.nix
@@ -20,6 +20,7 @@ in
           enable = true;
           host = "127.0.0.1";
           mediaLocation = "/metalminds/pictures";
+
           settings = {
             oauth = {
               # Skip Immich's own login page and bounce straight to Authentik - there's nothing else
@@ -35,6 +36,7 @@ in
               mobileRedirectUri = "https://${url}/api/oauth/mobile-redirect";
               scope = "openid email profile";
             };
+
             # Authentik is the only way in; Immich's own local accounts can no longer be used.
             # Immich attaches an OAuth login to an existing account by EMAIL (its auth service
             # looks the user up with `getByEmail`, then stamps the `oauthId` onto that row), so
@@ -49,10 +51,12 @@ in
             passwordLogin.enabled = false;
           };
         };
+
         users.users = lib.genAttrs administrators (user: {
           extraGroups = [ "immich" ];
         });
       };
+
       # `settings.terraform = "variable";` (not just any secret) - it now feeds a Terraform
       # `variable` (modules/terranix.nix's two modes) as well as Immich's own `environmentFile`-
       # style secret consumption below, so it's NOT `intermediary` - unlike a secret that ONLY ever
@@ -64,16 +68,20 @@ in
           settings.terraform = "variable";
         };
       };
+
       virtual-host = {
-        inherit port global;
+        inherit global port;
         group = "Media";
+
         homepage = {
           description = "Photo & video backup";
         };
+
         host = host.name;
         icon = "immich.svg";
         label = "Immich";
         name = "immich";
+
         # Requests the matching OAuth2 Provider + Application from Authentik (authentik.nix) - see
         # virtual-host.nix's `oidc` field for the shape. Per Immich's own OIDC docs
         # (docs.immich.app/administration/oauth) - web login redirects to `/auth/login`, the "link
@@ -83,12 +91,14 @@ in
         # result.
         oidc = {
           client-secret = "immich-oidc-client-secret";
+
           redirect-paths = [
             "/auth/login"
             "/user-settings"
             "/api/oauth/mobile-redirect"
           ];
         };
+
         # Immich sets its own secure/HttpOnly/SameSite flags on its session cookie. Without this,
         # nginx's blanket cookie rewrite appends a second, duplicate set of those flags, producing
         # a malformed Set-Cookie the browser silently refuses to store — login succeeds

--- a/modules/aspects/my/lm-sensors.nix
+++ b/modules/aspects/my/lm-sensors.nix
@@ -2,7 +2,6 @@
   my.lm-sensors.nixos = { pkgs, ... }: {
     # Enable coretemp kernel module for temperature monitoring
     boot.kernelModules = [ "coretemp" ];
-
     # Install lm_sensors for hardware monitoring
     environment.systemPackages = with pkgs; [ lm_sensors ];
   };

--- a/modules/aspects/my/locale.nix
+++ b/modules/aspects/my/locale.nix
@@ -4,6 +4,7 @@
 
     i18n = {
       defaultLocale = "en_US.UTF-8";
+
       extraLocaleSettings = {
         LC_ADDRESS = "en_US.UTF-8";
         LC_IDENTIFICATION = "en_US.UTF-8";

--- a/modules/aspects/my/logseq.nix
+++ b/modules/aspects/my/logseq.nix
@@ -1,12 +1,14 @@
 { inputs, ... }: {
   flake-file = {
     inputs.nix-logseq-git-flake = {
-      url = "github:Bad3r/nix-logseq-git-flake";
       inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:Bad3r/nix-logseq-git-flake";
     };
     nixConfig = {
       extra-substituters = [ "https://nix-logseq-git-flake.cachix.org" ];
-      extra-trusted-public-keys = [ "nix-logseq-git-flake.cachix.org-1:DSBNW07PSRyCvS926tpIWahb53OIydwwZhsP6LhJNZo=" ];
+      extra-trusted-public-keys = [
+        "nix-logseq-git-flake.cachix.org-1:DSBNW07PSRyCvS926tpIWahb53OIydwwZhsP6LhJNZo="
+      ];
     };
   };
 
@@ -16,11 +18,13 @@
       ...
     }:
     {
-      homeManager = { pkgs, lib, ... }: {
+      homeManager = { lib, pkgs, ... }: {
         home.packages = [
           inputs.nix-logseq-git-flake.packages.${pkgs.stdenv.hostPlatform.system}.logseq-cli
         ]
-        ++ lib.optional (!cli-only) inputs.nix-logseq-git-flake.packages.${pkgs.stdenv.hostPlatform.system}.logseq;
+        ++ lib.optional (
+          !cli-only
+        ) inputs.nix-logseq-git-flake.packages.${pkgs.stdenv.hostPlatform.system}.logseq;
       };
     };
 }

--- a/modules/aspects/my/logseq.nix
+++ b/modules/aspects/my/logseq.nix
@@ -1,14 +1,13 @@
 { inputs, ... }: {
   flake-file = {
     inputs.nix-logseq-git-flake = {
-      inputs.nixpkgs.follows = "nixpkgs";
       url = "github:Bad3r/nix-logseq-git-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
+
     nixConfig = {
       extra-substituters = [ "https://nix-logseq-git-flake.cachix.org" ];
-      extra-trusted-public-keys = [
-        "nix-logseq-git-flake.cachix.org-1:DSBNW07PSRyCvS926tpIWahb53OIydwwZhsP6LhJNZo="
-      ];
+      extra-trusted-public-keys = [ "nix-logseq-git-flake.cachix.org-1:DSBNW07PSRyCvS926tpIWahb53OIydwwZhsP6LhJNZo=" ];
     };
   };
 
@@ -22,9 +21,7 @@
         home.packages = [
           inputs.nix-logseq-git-flake.packages.${pkgs.stdenv.hostPlatform.system}.logseq-cli
         ]
-        ++ lib.optional (
-          !cli-only
-        ) inputs.nix-logseq-git-flake.packages.${pkgs.stdenv.hostPlatform.system}.logseq;
+        ++ lib.optional (!cli-only) inputs.nix-logseq-git-flake.packages.${pkgs.stdenv.hostPlatform.system}.logseq;
       };
     };
 }

--- a/modules/aspects/my/mcp-servers.nix
+++ b/modules/aspects/my/mcp-servers.nix
@@ -1,4 +1,4 @@
-{ ... }: {
+_: {
   my.mcp-servers.homeManager = { config, pkgs, ... }: {
     # Declared here (not in a top-level secrets block) so it lands in the
     # home-manager config's age.secrets, which is what config.age.secrets
@@ -11,6 +11,7 @@
 
       servers = {
         context7.command = "${pkgs.context7-mcp}/bin/context7-mcp";
+
         # `programs.mcp`'s env.*.file support single-quotes the path before
         # `cat`-ing it, but agenix's Darwin secret paths are themselves an
         # unexpanded `$(getconf DARWIN_USER_TEMP_DIR)/agenix/...` shell
@@ -22,6 +23,7 @@
           export GITHUB_PERSONAL_ACCESS_TOKEN="$(cat ${config.age.secrets.github-mcp-server-github-access-token.path})"
           exec ${pkgs.github-mcp-server}/bin/github-mcp-server stdio
         ''}";
+
         nixos.command = "${pkgs.mcp-nixos}/bin/mcp-nixos";
       };
     };

--- a/modules/aspects/my/mcp-servers.nix
+++ b/modules/aspects/my/mcp-servers.nix
@@ -10,8 +10,7 @@
       enable = true;
 
       servers = {
-        nixos.command = "${pkgs.mcp-nixos}/bin/mcp-nixos";
-
+        context7.command = "${pkgs.context7-mcp}/bin/context7-mcp";
         # `programs.mcp`'s env.*.file support single-quotes the path before
         # `cat`-ing it, but agenix's Darwin secret paths are themselves an
         # unexpanded `$(getconf DARWIN_USER_TEMP_DIR)/agenix/...` shell
@@ -23,8 +22,7 @@
           export GITHUB_PERSONAL_ACCESS_TOKEN="$(cat ${config.age.secrets.github-mcp-server-github-access-token.path})"
           exec ${pkgs.github-mcp-server}/bin/github-mcp-server stdio
         ''}";
-
-        context7.command = "${pkgs.context7-mcp}/bin/context7-mcp";
+        nixos.command = "${pkgs.mcp-nixos}/bin/mcp-nixos";
       };
     };
   };

--- a/modules/aspects/my/meraki.nix
+++ b/modules/aspects/my/meraki.nix
@@ -78,18 +78,21 @@ in
         # MERAKI_DASHBOARD_API_KEY, so nothing sensitive lands in this config or in Terraform
         # state.
         provider.meraki = { };
+
         resource.meraki_networks_appliance_firewall_port_forwarding_rules.${host.name} = {
           network_id = host.meraki-network-id;
+
           rules = map (pf: {
+            inherit (pf) name;
             allowed_ips = if pf.restrict-to-cloudflare or false then cloudflareIps else [ "any" ];
             lan_ip = host.lan-ip;
             local_port = toString pf.port;
-            name = pf.name;
             protocol = pf.protocol or "tcp";
             public_port = toString pf.port;
             uplink = "both";
           }) port-forward;
         };
+
         terraform.required_providers.meraki = {
           source = "cisco-open/meraki";
           version = "1.2.4-beta";

--- a/modules/aspects/my/meraki.nix
+++ b/modules/aspects/my/meraki.nix
@@ -65,36 +65,34 @@ in
   my.meraki = { host, ... }: {
     secrets = {
       meraki-dashboard-api-key = {
-        rekeyFile = ../../../secrets/meraki-dashboard-api-key.age;
         intermediary = true;
+        rekeyFile = ../../../secrets/meraki-dashboard-api-key.age;
         settings.terraform = true;
       };
     };
 
     terranix =
-      { port-forward, lib, ... }:
+      { lib, port-forward, ... }:
       lib.optionalAttrs (host ? lan-ip) {
-        terraform.required_providers.meraki = {
-          source = "cisco-open/meraki";
-          version = "1.2.4-beta";
-        };
-
         # Credentials aren't set here - the provider reads meraki_dashboard_api_key from
         # MERAKI_DASHBOARD_API_KEY, so nothing sensitive lands in this config or in Terraform
         # state.
         provider.meraki = { };
-
         resource.meraki_networks_appliance_firewall_port_forwarding_rules.${host.name} = {
           network_id = host.meraki-network-id;
           rules = map (pf: {
+            allowed_ips = if pf.restrict-to-cloudflare or false then cloudflareIps else [ "any" ];
+            lan_ip = host.lan-ip;
+            local_port = toString pf.port;
             name = pf.name;
             protocol = pf.protocol or "tcp";
             public_port = toString pf.port;
-            local_port = toString pf.port;
-            lan_ip = host.lan-ip;
             uplink = "both";
-            allowed_ips = if pf.restrict-to-cloudflare or false then cloudflareIps else [ "any" ];
           }) port-forward;
+        };
+        terraform.required_providers.meraki = {
+          source = "cisco-open/meraki";
+          version = "1.2.4-beta";
         };
       };
   };

--- a/modules/aspects/my/minecraft-servers.nix
+++ b/modules/aspects/my/minecraft-servers.nix
@@ -1,17 +1,18 @@
 {
+  lib,
   den,
   inputs,
-  lib,
   ...
 }:
 {
   flake-file.inputs.nix-minecraft = {
+    url = "github:Infinidoge/nix-minecraft";
+
     inputs = {
       flake-compat.follows = "flake-compat";
       nixpkgs.follows = "nixpkgs";
       systems.follows = "systems";
     };
-    url = "github:Infinidoge/nix-minecraft";
   };
 
   # `worlds` is an attrset keyed by world name:
@@ -26,37 +27,39 @@
   # a real `pkgs` at all.
   my.minecraft-servers =
     {
-      administrators ? [ ],
       worlds,
+      administrators ? [ ],
     }:
     { host, ... }:
     let
       domain = "silverlight-nex.us";
     in
     {
-      dataset = {
-        guestAccess = true;
-        name = "minecraft-worlds";
-        pool = "metalminds";
-        samba = true;
-      };
       includes = [
         (den._.unfree [
           "minecraft-server"
           "neoforge"
         ])
       ];
+
+      dataset = {
+        guestAccess = true;
+        name = "minecraft-worlds";
+        pool = "metalminds";
+        samba = true;
+      };
+
       nixos = { config, pkgs, ... }: {
         imports = [ (inputs.nix-minecraft.nixosModules.minecraft-servers or { }) ];
-
         nixpkgs.overlays = [ (inputs.nix-minecraft.overlay or { }) ];
 
         services.minecraft-servers = {
-          dataDir = "/metalminds/minecraft-worlds";
           enable = true;
+          dataDir = "/metalminds/minecraft-worlds";
           environmentFile = config.age.secrets."minecraft-servers.env".path;
           eula = true;
           openFirewall = true;
+
           servers = lib.mapAttrs (
             _: world:
             let
@@ -75,19 +78,22 @@
           extraGroups = [ "minecraft" ];
         });
       };
+
       # One inbound rule per world, on its own game port (see modules/aspects/my/meraki.nix).
       port-forward = lib.mapAttrsToList (name: world: {
         inherit (world) port;
         name = "minecraft-${name}";
       }) worlds;
+
       secrets = { secrets, ... }: {
         "minecraft-servers.env".generator = {
           dependencies = { inherit (secrets) oscar-password; };
+
           script =
             {
+              lib,
               decrypt,
               deps,
-              lib,
               ...
             }:
             ''
@@ -95,6 +101,7 @@
             '';
         };
       };
+
       # A world at `<name>.minecraft.${domain}` (an A/CNAME record, same type/content as every
       # other DNS record this host produces - see modules/aspects/my/dns.nix) plus a
       # `_minecraft._tcp` SRV record pointing at that same hostname on its actual game port, so
@@ -107,12 +114,13 @@
       terranix = lib.optionalAttrs (host ? dns-record) {
         resource.cloudflare_dns_record = lib.concatMapAttrs (name: world: {
           "minecraft-${name}" = {
-            inherit (host.dns-record) type content;
+            inherit (host.dns-record) content type;
             name = "${name}.minecraft.${domain}";
             proxied = false;
             ttl = 1800;
             zone_id = host.cloudflare-zone-id;
           };
+
           "minecraft-${name}-srv" = {
             data = {
               inherit (world) port;
@@ -122,6 +130,7 @@
               target = "${name}.minecraft.${domain}";
               weight = 0;
             };
+
             name = "_minecraft._tcp.${name}.minecraft.${domain}";
             priority = 0;
             ttl = 1800;

--- a/modules/aspects/my/minecraft-servers.nix
+++ b/modules/aspects/my/minecraft-servers.nix
@@ -6,12 +6,12 @@
 }:
 {
   flake-file.inputs.nix-minecraft = {
-    url = "github:Infinidoge/nix-minecraft";
     inputs = {
       flake-compat.follows = "flake-compat";
       nixpkgs.follows = "nixpkgs";
       systems.follows = "systems";
     };
+    url = "github:Infinidoge/nix-minecraft";
   };
 
   # `worlds` is an attrset keyed by world name:
@@ -26,97 +26,37 @@
   # a real `pkgs` at all.
   my.minecraft-servers =
     {
-      worlds,
       administrators ? [ ],
+      worlds,
     }:
     { host, ... }:
     let
       domain = "silverlight-nex.us";
     in
     {
+      dataset = {
+        guestAccess = true;
+        name = "minecraft-worlds";
+        pool = "metalminds";
+        samba = true;
+      };
       includes = [
         (den._.unfree [
           "minecraft-server"
           "neoforge"
         ])
       ];
-
-      dataset = {
-        pool = "metalminds";
-        name = "minecraft-worlds";
-        samba = true;
-        guestAccess = true;
-      };
-
-      secrets = { secrets, ... }: {
-        "minecraft-servers.env".generator = {
-          dependencies = { inherit (secrets) oscar-password; };
-          script =
-            {
-              lib,
-              decrypt,
-              deps,
-              ...
-            }:
-            ''
-              printf 'RCON_PASSWORD="%s"\n' "$(${decrypt} ${lib.escapeShellArg deps.oscar-password.file})"
-            '';
-        };
-      };
-
-      # One inbound rule per world, on its own game port (see modules/aspects/my/meraki.nix).
-      port-forward = lib.mapAttrsToList (name: world: {
-        name = "minecraft-${name}";
-        inherit (world) port;
-      }) worlds;
-
-      # A world at `<name>.minecraft.${domain}` (an A/CNAME record, same type/content as every
-      # other DNS record this host produces - see modules/aspects/my/dns.nix) plus a
-      # `_minecraft._tcp` SRV record pointing at that same hostname on its actual game port, so
-      # players can connect to `<name>.minecraft.${domain}` without specifying a port. No new
-      # quirk needed - unlike the HTTP services in dns.nix, nothing else (nginx, Homepage) needs to
-      # know about Minecraft worlds, so this aspect just contributes directly to the shared
-      # `terranix` class alongside dns.nix's own contribution (same host, same
-      # `host.cloudflare-zone-id` - see modules/den.nix). A plain attrset, not a function - see
-      # modules/terranix.nix for why that matters.
-      terranix = lib.optionalAttrs (host ? dns-record) {
-        resource.cloudflare_dns_record = lib.concatMapAttrs (name: world: {
-          "minecraft-${name}" = {
-            zone_id = host.cloudflare-zone-id;
-            name = "${name}.minecraft.${domain}";
-            inherit (host.dns-record) type content;
-            ttl = 1800;
-            proxied = false;
-          };
-          "minecraft-${name}-srv" = {
-            zone_id = host.cloudflare-zone-id;
-            name = "_minecraft._tcp.${name}.minecraft.${domain}";
-            type = "SRV";
-            ttl = 1800;
-            priority = 0;
-            data = {
-              priority = 0;
-              weight = 0;
-              inherit (world) port;
-              target = "${name}.minecraft.${domain}";
-              proto = "_tcp";
-              name = "${name}.minecraft.${domain}";
-            };
-          };
-        }) worlds;
-      };
-
       nixos = { config, pkgs, ... }: {
         imports = [ (inputs.nix-minecraft.nixosModules.minecraft-servers or { }) ];
 
         nixpkgs.overlays = [ (inputs.nix-minecraft.overlay or { }) ];
 
         services.minecraft-servers = {
-          enable = true;
-          openFirewall = true;
-          eula = true;
           dataDir = "/metalminds/minecraft-worlds";
+          enable = true;
           environmentFile = config.age.secrets."minecraft-servers.env".path;
+          eula = true;
+          openFirewall = true;
           servers = lib.mapAttrs (
             _: world:
             let
@@ -134,6 +74,61 @@
         users.users = lib.genAttrs administrators (user: {
           extraGroups = [ "minecraft" ];
         });
+      };
+      # One inbound rule per world, on its own game port (see modules/aspects/my/meraki.nix).
+      port-forward = lib.mapAttrsToList (name: world: {
+        inherit (world) port;
+        name = "minecraft-${name}";
+      }) worlds;
+      secrets = { secrets, ... }: {
+        "minecraft-servers.env".generator = {
+          dependencies = { inherit (secrets) oscar-password; };
+          script =
+            {
+              decrypt,
+              deps,
+              lib,
+              ...
+            }:
+            ''
+              printf 'RCON_PASSWORD="%s"\n' "$(${decrypt} ${lib.escapeShellArg deps.oscar-password.file})"
+            '';
+        };
+      };
+      # A world at `<name>.minecraft.${domain}` (an A/CNAME record, same type/content as every
+      # other DNS record this host produces - see modules/aspects/my/dns.nix) plus a
+      # `_minecraft._tcp` SRV record pointing at that same hostname on its actual game port, so
+      # players can connect to `<name>.minecraft.${domain}` without specifying a port. No new
+      # quirk needed - unlike the HTTP services in dns.nix, nothing else (nginx, Homepage) needs to
+      # know about Minecraft worlds, so this aspect just contributes directly to the shared
+      # `terranix` class alongside dns.nix's own contribution (same host, same
+      # `host.cloudflare-zone-id` - see modules/den.nix). A plain attrset, not a function - see
+      # modules/terranix.nix for why that matters.
+      terranix = lib.optionalAttrs (host ? dns-record) {
+        resource.cloudflare_dns_record = lib.concatMapAttrs (name: world: {
+          "minecraft-${name}" = {
+            inherit (host.dns-record) type content;
+            name = "${name}.minecraft.${domain}";
+            proxied = false;
+            ttl = 1800;
+            zone_id = host.cloudflare-zone-id;
+          };
+          "minecraft-${name}-srv" = {
+            data = {
+              inherit (world) port;
+              name = "${name}.minecraft.${domain}";
+              priority = 0;
+              proto = "_tcp";
+              target = "${name}.minecraft.${domain}";
+              weight = 0;
+            };
+            name = "_minecraft._tcp.${name}.minecraft.${domain}";
+            priority = 0;
+            ttl = 1800;
+            type = "SRV";
+            zone_id = host.cloudflare-zone-id;
+          };
+        }) worlds;
       };
     };
 }

--- a/modules/aspects/my/netdata.nix
+++ b/modules/aspects/my/netdata.nix
@@ -9,12 +9,18 @@ in
     { host, ... }: {
       # withCloudUi's dashboard files (below) are under the non-free Netdata Cloud UI License.
       includes = [ (den._.unfree [ "netdata" ]) ];
+
       nixos = { config, pkgs, ... }: {
         # Netdata monitoring (metrics, dashboards, and Discord health alerts)
         # Includes built-in ZFS pool health/capacity alerting.
         services.netdata = {
           # Bind only to loopback; nginx handles external access
           config.web."bind to" = "127.0.0.1";
+          enable = true;
+          # withCloudUi pulls in the local dashboard's static files; without it the package omits
+          # them entirely and every request 404s with "File does not exist, or is not accessible:".
+          package = pkgs.netdata.override { withCloudUi = true; };
+
           # Discord notifications via health_alarm_notify.conf.
           # The file is a bash script sourced by Netdata's alarm-notify.sh;
           # sourcing the age secret sets DISCORD_WEBHOOK_URL at runtime.
@@ -24,27 +30,27 @@ in
             SEND_DISCORD="YES"
             DEFAULT_RECIPIENT_DISCORD="alarms"
           '';
-          enable = true;
+
           # smartmontools gives the smartctl collector S.M.A.R.T. access to individual disks
           # (pre-fail indicators), complementing the built-in ZFS pool-level health alerting above.
           extraNdsudoPackages = [ pkgs.smartmontools ];
-          # withCloudUi pulls in the local dashboard's static files; without it the package omits
-          # them entirely and every request 404s with "File does not exist, or is not accessible:".
-          package = pkgs.netdata.override { withCloudUi = true; };
         };
       };
+
       secrets = { secrets, ... }: {
         discord-webhook-url = {
           intermediary = true;
           rekeyFile = ../../../secrets/discord-webhook-url.age;
         };
+
         "netdata-secrets.env".generator = {
           dependencies = { inherit (secrets) discord-webhook-url; };
+
           script =
             {
+              lib,
               decrypt,
               deps,
-              lib,
               ...
             }:
             ''
@@ -54,11 +60,14 @@ in
             '';
         };
       };
+
       virtual-host = {
-        inherit port global;
+        inherit global port;
         group = "Infra";
+
         homepage = {
           description = "System monitoring & alerts";
+
           widget = {
             type = "netdata";
             # Hit Netdata directly rather than through nginx, since the public URL sits behind
@@ -67,6 +76,7 @@ in
             url = "http://127.0.0.1:${toString port}";
           };
         };
+
         host = host.name;
         icon = "netdata.svg";
         label = "Netdata";

--- a/modules/aspects/my/netdata.nix
+++ b/modules/aspects/my/netdata.nix
@@ -9,14 +9,53 @@ in
     { host, ... }: {
       # withCloudUi's dashboard files (below) are under the non-free Netdata Cloud UI License.
       includes = [ (den._.unfree [ "netdata" ]) ];
-
+      nixos = { config, pkgs, ... }: {
+        # Netdata monitoring (metrics, dashboards, and Discord health alerts)
+        # Includes built-in ZFS pool health/capacity alerting.
+        services.netdata = {
+          # Bind only to loopback; nginx handles external access
+          config.web."bind to" = "127.0.0.1";
+          # Discord notifications via health_alarm_notify.conf.
+          # The file is a bash script sourced by Netdata's alarm-notify.sh;
+          # sourcing the age secret sets DISCORD_WEBHOOK_URL at runtime.
+          configDir."health_alarm_notify.conf" = pkgs.writeText "health_alarm_notify.conf" ''
+            # shellcheck disable=SC1090
+            source "${config.age.secrets."netdata-secrets.env".path}"
+            SEND_DISCORD="YES"
+            DEFAULT_RECIPIENT_DISCORD="alarms"
+          '';
+          enable = true;
+          # smartmontools gives the smartctl collector S.M.A.R.T. access to individual disks
+          # (pre-fail indicators), complementing the built-in ZFS pool-level health alerting above.
+          extraNdsudoPackages = [ pkgs.smartmontools ];
+          # withCloudUi pulls in the local dashboard's static files; without it the package omits
+          # them entirely and every request 404s with "File does not exist, or is not accessible:".
+          package = pkgs.netdata.override { withCloudUi = true; };
+        };
+      };
+      secrets = { secrets, ... }: {
+        discord-webhook-url = {
+          intermediary = true;
+          rekeyFile = ../../../secrets/discord-webhook-url.age;
+        };
+        "netdata-secrets.env".generator = {
+          dependencies = { inherit (secrets) discord-webhook-url; };
+          script =
+            {
+              decrypt,
+              deps,
+              lib,
+              ...
+            }:
+            ''
+              printf 'DISCORD_WEBHOOK_URL="%s"\n' "$(
+                ${decrypt} ${lib.escapeShellArg deps.discord-webhook-url.file}
+              )"
+            '';
+        };
+      };
       virtual-host = {
-        name = "netdata";
-        host = host.name;
-        protected = true;
         inherit port global;
-        label = "Netdata";
-        icon = "netdata.svg";
         group = "Infra";
         homepage = {
           description = "System monitoring & alerts";
@@ -28,53 +67,11 @@ in
             url = "http://127.0.0.1:${toString port}";
           };
         };
-      };
-
-      secrets = { secrets, ... }: {
-        discord-webhook-url = {
-          rekeyFile = ../../../secrets/discord-webhook-url.age;
-          intermediary = true;
-        };
-        "netdata-secrets.env".generator = {
-          dependencies = { inherit (secrets) discord-webhook-url; };
-          script =
-            {
-              lib,
-              decrypt,
-              deps,
-              ...
-            }:
-            ''
-              printf 'DISCORD_WEBHOOK_URL="%s"\n' "$(
-                ${decrypt} ${lib.escapeShellArg deps.discord-webhook-url.file}
-              )"
-            '';
-        };
-      };
-
-      nixos = { config, pkgs, ... }: {
-        # Netdata monitoring (metrics, dashboards, and Discord health alerts)
-        # Includes built-in ZFS pool health/capacity alerting.
-        services.netdata = {
-          enable = true;
-          # withCloudUi pulls in the local dashboard's static files; without it the package omits
-          # them entirely and every request 404s with "File does not exist, or is not accessible:".
-          package = pkgs.netdata.override { withCloudUi = true; };
-          # Bind only to loopback; nginx handles external access
-          config.web."bind to" = "127.0.0.1";
-          # smartmontools gives the smartctl collector S.M.A.R.T. access to individual disks
-          # (pre-fail indicators), complementing the built-in ZFS pool-level health alerting above.
-          extraNdsudoPackages = [ pkgs.smartmontools ];
-          # Discord notifications via health_alarm_notify.conf.
-          # The file is a bash script sourced by Netdata's alarm-notify.sh;
-          # sourcing the age secret sets DISCORD_WEBHOOK_URL at runtime.
-          configDir."health_alarm_notify.conf" = pkgs.writeText "health_alarm_notify.conf" ''
-            # shellcheck disable=SC1090
-            source "${config.age.secrets."netdata-secrets.env".path}"
-            SEND_DISCORD="YES"
-            DEFAULT_RECIPIENT_DISCORD="alarms"
-          '';
-        };
+        host = host.name;
+        icon = "netdata.svg";
+        label = "Netdata";
+        name = "netdata";
+        protected = true;
       };
     };
 }

--- a/modules/aspects/my/networkmanager.nix
+++ b/modules/aspects/my/networkmanager.nix
@@ -1,8 +1,8 @@
 {
   my.networkmanager = {
     includes = [
-      { nixos.networking.networkmanager.enable = true; }
       ({ user, ... }: { nixos.users.users.${user.userName}.extraGroups = [ "networkmanager" ]; })
+      { nixos.networking.networkmanager.enable = true; }
     ];
   };
 }

--- a/modules/aspects/my/nextcloud.nix
+++ b/modules/aspects/my/nextcloud.nix
@@ -12,46 +12,9 @@ in
     in
     {
       dataset = {
+        name = "nextcloud";
         pool = "metalminds";
-        name = "nextcloud";
       };
-
-      virtual-host = {
-        name = "nextcloud";
-        host = host.name;
-        inherit global;
-        # Deliberately no `port` — Nextcloud is PHP-FPM, not a plain HTTP service to
-        # proxy_pass to. The quirk emits only forceSSL/enableACME for this vhost, and
-        # Nextcloud's own module below supplies its `locations`/`root`, merging cleanly.
-        #
-        # Requests the matching OAuth2 Provider + Application from Authentik (authentik.nix) - see
-        # virtual-host.nix's `oidc` field for the shape. Per user_oidc's own callback route (and
-        # Authentik's Nextcloud integration guide) - `/index.php/...` only matters for installs
-        # that haven't set `overwriteprotocol`-style pretty URLs, which this one has (see
-        # `settings.overwriteprotocol` below).
-        oidc = {
-          redirect-paths = [ "/apps/user_oidc/code" ];
-          client-secret = "nextcloud-oidc-client-secret";
-        };
-        label = "Nextcloud";
-        icon = "nextcloud.svg";
-        group = "Media";
-        homepage = {
-          description = "Files, calendar & office suite";
-        };
-      };
-
-      secrets = {
-        nextcloud-admin-password.generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -base64 24";
-        # `settings.terraform = "variable";` feeds a Terraform `variable` (modules/terranix.nix's
-        # two modes); also read directly below (LoadCredential) to configure user_oidc via occ, so
-        # it's NOT `intermediary` - it has to be materialized as a real host secret too.
-        nextcloud-oidc-client-secret = {
-          generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -hex 32";
-          settings.terraform = "variable";
-        };
-      };
-
       nixos = { config, pkgs, ... }: {
         # Public DNS for this hostname resolves off-box; on-box callers (notably coolwsd's
         # server-side WOPI CheckFileInfo/GetFile requests back to Nextcloud) hit it too and hairpin
@@ -66,26 +29,21 @@ in
         networking.hosts."127.0.0.1" = [ url ];
 
         services.nextcloud = {
-          enable = true;
-          hostName = url;
-          https = true;
-          package = pkgs.nextcloud33;
-
-          database.createLocally = true;
           config = {
-            dbtype = "pgsql";
-            adminuser = "admin";
             adminpassFile = config.age.secrets.nextcloud-admin-password.path;
+            adminuser = "admin";
+            dbtype = "pgsql";
           };
-
+          database.createLocally = true;
           datadir = "/metalminds/nextcloud"; # holds both config/ (config.php) and data/ (user files)
-
+          enable = true;
           extraApps = with config.services.nextcloud.package.packages.apps; {
             inherit user_oidc richdocuments;
           };
-
+          hostName = url;
+          https = true;
+          package = pkgs.nextcloud33;
           settings = {
-            overwriteprotocol = "https";
             # Drops the username/password form from /login, leaving just the "Log in with
             # Authentik" button - the alternative-logins block sits OUTSIDE the form's `v-if` in
             # core's Login.vue, so SSO survives being hidden.
@@ -96,6 +54,7 @@ in
             # OIDC-provisioned accounts have no password to type in the first place (user_oidc is
             # their backend), so `admin` was already the only account a form could authenticate.
             hide_login_form = true;
+            overwriteprotocol = "https";
           };
         };
 
@@ -105,23 +64,14 @@ in
         # `nextcloud-authentik-richdocuments-setup` once that list stopped being two things worth
         # enumerating in a unit name.
         systemd.services.nextcloud-occ-setup = {
-          description = "Apply Nextcloud app-level config that has no NixOS option, via occ";
           after = [
             "nextcloud-setup.service"
             "coolwsd.service"
             "nginx.service"
           ];
-          requires = [ "nextcloud-setup.service" ];
-          wantedBy = [ "multi-user.target" ];
-
-          serviceConfig = {
-            Type = "oneshot";
-            User = "nextcloud";
-            LoadCredential = "oidc-client-secret:${config.age.secrets.nextcloud-oidc-client-secret.path}";
-          };
-
+          description = "Apply Nextcloud app-level config that has no NixOS option, via occ";
           path = [ config.services.nextcloud.occ ];
-
+          requires = [ "nextcloud-setup.service" ];
           script = ''
             set -euo pipefail
 
@@ -203,6 +153,47 @@ in
             # `set -e` on every subsequent boot.
             nextcloud-occ app:disable photos
           '';
+          serviceConfig = {
+            LoadCredential = "oidc-client-secret:${config.age.secrets.nextcloud-oidc-client-secret.path}";
+            Type = "oneshot";
+            User = "nextcloud";
+          };
+          wantedBy = [ "multi-user.target" ];
+        };
+      };
+      secrets = {
+        nextcloud-admin-password.generator.script =
+          { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -base64 24";
+        # `settings.terraform = "variable";` feeds a Terraform `variable` (modules/terranix.nix's
+        # two modes); also read directly below (LoadCredential) to configure user_oidc via occ, so
+        # it's NOT `intermediary` - it has to be materialized as a real host secret too.
+        nextcloud-oidc-client-secret = {
+          generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -hex 32";
+          settings.terraform = "variable";
+        };
+      };
+      virtual-host = {
+        inherit global;
+        group = "Media";
+        homepage = {
+          description = "Files, calendar & office suite";
+        };
+        host = host.name;
+        icon = "nextcloud.svg";
+        label = "Nextcloud";
+        name = "nextcloud";
+        # Deliberately no `port` — Nextcloud is PHP-FPM, not a plain HTTP service to
+        # proxy_pass to. The quirk emits only forceSSL/enableACME for this vhost, and
+        # Nextcloud's own module below supplies its `locations`/`root`, merging cleanly.
+        #
+        # Requests the matching OAuth2 Provider + Application from Authentik (authentik.nix) - see
+        # virtual-host.nix's `oidc` field for the shape. Per user_oidc's own callback route (and
+        # Authentik's Nextcloud integration guide) - `/index.php/...` only matters for installs
+        # that haven't set `overwriteprotocol`-style pretty URLs, which this one has (see
+        # `settings.overwriteprotocol` below).
+        oidc = {
+          client-secret = "nextcloud-oidc-client-secret";
+          redirect-paths = [ "/apps/user_oidc/code" ];
         };
       };
     };

--- a/modules/aspects/my/nextcloud.nix
+++ b/modules/aspects/my/nextcloud.nix
@@ -15,6 +15,7 @@ in
         name = "nextcloud";
         pool = "metalminds";
       };
+
       nixos = { config, pkgs, ... }: {
         # Public DNS for this hostname resolves off-box; on-box callers (notably coolwsd's
         # server-side WOPI CheckFileInfo/GetFile requests back to Nextcloud) hit it too and hairpin
@@ -34,15 +35,19 @@ in
             adminuser = "admin";
             dbtype = "pgsql";
           };
+
+          enable = true;
+          package = pkgs.nextcloud33;
           database.createLocally = true;
           datadir = "/metalminds/nextcloud"; # holds both config/ (config.php) and data/ (user files)
-          enable = true;
+
           extraApps = with config.services.nextcloud.package.packages.apps; {
-            inherit user_oidc richdocuments;
+            inherit richdocuments user_oidc;
           };
+
           hostName = url;
           https = true;
-          package = pkgs.nextcloud33;
+
           settings = {
             # Drops the username/password form from /login, leaving just the "Log in with
             # Authentik" button - the alternative-logins block sits OUTSIDE the form's `v-if` in
@@ -64,14 +69,18 @@ in
         # `nextcloud-authentik-richdocuments-setup` once that list stopped being two things worth
         # enumerating in a unit name.
         systemd.services.nextcloud-occ-setup = {
+          description = "Apply Nextcloud app-level config that has no NixOS option, via occ";
+          wantedBy = [ "multi-user.target" ];
+
           after = [
             "nextcloud-setup.service"
             "coolwsd.service"
             "nginx.service"
           ];
-          description = "Apply Nextcloud app-level config that has no NixOS option, via occ";
+
           path = [ config.services.nextcloud.occ ];
           requires = [ "nextcloud-setup.service" ];
+
           script = ''
             set -euo pipefail
 
@@ -153,17 +162,18 @@ in
             # `set -e` on every subsequent boot.
             nextcloud-occ app:disable photos
           '';
+
           serviceConfig = {
             LoadCredential = "oidc-client-secret:${config.age.secrets.nextcloud-oidc-client-secret.path}";
             Type = "oneshot";
             User = "nextcloud";
           };
-          wantedBy = [ "multi-user.target" ];
         };
       };
+
       secrets = {
-        nextcloud-admin-password.generator.script =
-          { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -base64 24";
+        nextcloud-admin-password.generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -base64 24";
+
         # `settings.terraform = "variable";` feeds a Terraform `variable` (modules/terranix.nix's
         # two modes); also read directly below (LoadCredential) to configure user_oidc via occ, so
         # it's NOT `intermediary` - it has to be materialized as a real host secret too.
@@ -172,16 +182,20 @@ in
           settings.terraform = "variable";
         };
       };
+
       virtual-host = {
         inherit global;
         group = "Media";
+
         homepage = {
           description = "Files, calendar & office suite";
         };
+
         host = host.name;
         icon = "nextcloud.svg";
         label = "Nextcloud";
         name = "nextcloud";
+
         # Deliberately no `port` — Nextcloud is PHP-FPM, not a plain HTTP service to
         # proxy_pass to. The quirk emits only forceSSL/enableACME for this vhost, and
         # Nextcloud's own module below supplies its `locations`/`root`, merging cleanly.

--- a/modules/aspects/my/nginx.nix
+++ b/modules/aspects/my/nginx.nix
@@ -1,21 +1,10 @@
 {
   my.nginx = {
-    port-forward = [
-      {
-        name = "http";
-        port = 80;
-      }
-      {
-        name = "https";
-        port = 443;
-      }
-    ];
-
     nixos =
       {
-        virtual-host,
         host,
         lib,
+        virtual-host,
         ...
       }:
       let
@@ -37,158 +26,16 @@
         '';
       in
       {
+        # Open firewall ports for HTTP and HTTPS
+        networking.firewall.allowedTCPPorts = [
+          80
+          443
+        ];
         security.acme = {
           acceptTerms = true;
           defaults.email = "letsencrypt@alias.oscarmarshall.com";
         };
-
         services.nginx = {
-          enable = true;
-
-          recommendedBrotliSettings = true;
-          recommendedGzipSettings = true;
-          recommendedOptimisation = true;
-          recommendedProxySettings = true;
-          recommendedTlsSettings = true;
-
-          # Exposes /nginx_status on localhost for Netdata's nginx collector (request/connection
-          # metrics).
-          statusPage = true;
-
-          # nginx's default bucket size can't fit our longest server_name once enough
-          # <service>.<host>.<domain> vhosts pile up (e.g. bookshelf-audiobooks.harmony.…, 47
-          # chars) - it then refuses to start at all ("could not build server_names_hash, you
-          # should increase server_names_hash_bucket_size"). 128 leaves headroom for future
-          # services without revisiting this.
-          serverNamesHashBucketSize = 128;
-
-          virtualHosts = lib.listToAttrs (
-            map (
-              vh:
-              let
-                # Every service is namespaced under its host by default (immich.harmony.…), so
-                # multiple hosts can run the same service without colliding on one wildcard DNS
-                # entry. A service opts into also being reachable at the bare, host-agnostic name
-                # (immich.…) via `global = true;` on its `virtual-host` record — surfaced as an
-                # nginx `serverAlias`, which nixos's ACME integration automatically adds as a SAN
-                # on the same certificate.
-                url = vh.url or "${vh.name}.${host.name}.${domain}";
-                global-url = "${vh.name}.${domain}";
-              in
-              lib.nameValuePair url (
-                {
-                  forceSSL = true;
-                  enableACME = true;
-                  # Skips adding `global-url` when a service's own `url` override (e.g.
-                  # authentik.nix's, when `global`) already IS the canonical name - the usual case
-                  # is `url` staying host-scoped, with `global-url` merely an alias alongside it.
-                  serverAliases = lib.optionals (vh.global or false && url != global-url) [ global-url ];
-                  # appendHttpConfig's proxy_cookie_path rewrite appends its own secure/HttpOnly/
-                  # SameSite flags to every Set-Cookie header, even ones a backend already set its
-                  # own correct flags on. That produces a Set-Cookie with duplicated attributes,
-                  # which browsers can silently refuse to store — breaking login for any backend
-                  # that manages its own cookie security (e.g. Immich). Opt out per host via
-                  # `preserveCookieFlags = true;` on the `virtual-host` record.
-                  extraConfig = lib.optionalString (vh.preserveCookieFlags or false) ''
-                    proxy_cookie_path / /;
-                  '';
-                }
-                // lib.optionalAttrs (vh ? port) {
-                  locations = {
-                    "/" = {
-                      # No trailing URI here (deliberately, like the regex bypassAuthPaths
-                      # locations below): with one, nginx has to decode+re-merge the request URI to
-                      # splice it onto the backend path, and an encoded slash anywhere in it (e.g.
-                      # Collabora's WOPI websocket path, which embeds a full url-encoded WOPISrc
-                      # URL) trips that merge and nginx 400s the request before it ever reaches the
-                      # backend - confirmed by bisecting: `/foo%2Fbar` 400s, `/foo` doesn't, on this
-                      # exact location. Omitting the URI makes nginx forward $request_uri verbatim,
-                      # which every location here is "/" (matches the whole path) so this is a
-                      # no-op for every other backend already relying on the old behavior.
-                      proxyPass = "http://127.0.0.1:${toString vh.port}";
-                      # recommendedProxySettings clears the Connection header (`proxy_set_header
-                      # Connection "";`), which breaks WebSocket upgrades. Backends that use them
-                      # (e.g. Immich's real-time updates) opt in via `websockets = true;` on their
-                      # `virtual-host` record — nginx's standard websocket idiom (see
-                      # https://nginx.org/en/docs/http/websocket.html), which sends `Connection:
-                      # close` instead of keep-alive for non-Upgrade requests on that host. Fine
-                      # here: upstream is always 127.0.0.1, so the lost keep-alive just costs an
-                      # extra loopback handshake, not a real round trip.
-                      proxyWebsockets = vh.websockets or false;
-                      extraConfig = lib.optionalString (vh.protected or false) ''
-                        auth_request /outpost.goauthentik.io/auth/nginx;
-                        error_page 401 = @goauthentik_proxy_signin;
-
-                        auth_request_set $auth_cookie $upstream_http_set_cookie;
-                        add_header Set-Cookie $auth_cookie;
-                        ${securityHeaders}
-
-                        auth_request_set $authentik_username $upstream_http_x_authentik_username;
-                        auth_request_set $authentik_groups $upstream_http_x_authentik_groups;
-                        auth_request_set $authentik_email $upstream_http_x_authentik_email;
-                        auth_request_set $authentik_name $upstream_http_x_authentik_name;
-                        auth_request_set $authentik_uid $upstream_http_x_authentik_uid;
-
-                        proxy_set_header X-authentik-username $authentik_username;
-                        proxy_set_header X-authentik-groups $authentik_groups;
-                        proxy_set_header X-authentik-email $authentik_email;
-                        proxy_set_header X-authentik-name $authentik_name;
-                        proxy_set_header X-authentik-uid $authentik_uid;
-                      '';
-                    };
-                  }
-                  // lib.optionalAttrs (vh.protected or false) (
-                    lib.listToAttrs (
-                      map (
-                        path:
-                        lib.nameValuePair "~ ${path}" {
-                          # No URI on proxyPass: regex locations can't auto-rewrite the matched path, so this
-                          # forwards the original path+query untouched, without the auth_request config below.
-                          proxyPass = "http://127.0.0.1:${toString vh.port}";
-                        }
-                      ) (vh.bypassAuthPaths or [ ])
-                    )
-                  )
-                  // lib.optionalAttrs (vh.protected or false) {
-                    "@goauthentik_proxy_signin" = {
-                      extraConfig = ''
-                        internal;
-                        add_header Set-Cookie $auth_cookie;
-                        ${securityHeaders}
-                        # Authentik's own forward-auth (single application) docs redirect back to
-                        # the CURRENT app's own domain, not Authentik's - every protected vhost
-                        # already has its own "/outpost.goauthentik.io" location (below) proxying
-                        # to the same embedded outpost, so $http_host lands back on a domain the
-                        # outpost can actually match to this provider. Redirecting to Authentik's
-                        # own domain instead landed on "Not Found", since that domain has no
-                        # per-provider Host-header context for the outpost to key off of.
-                        return 302 "https://$http_host/outpost.goauthentik.io/start?rd=$scheme://$http_host$request_uri";
-                      '';
-                    };
-                    "/outpost.goauthentik.io" = {
-                      proxyPass = "${authentikOutpost}/outpost.goauthentik.io";
-                      extraConfig = ''
-                        # No explicit `proxy_set_header Host` here: recommendedProxySettings
-                        # already adds one (any location with proxyPass gets it) and nginx doesn't
-                        # deduplicate repeated proxy_set_header lines for the same name — an
-                        # explicit second one here sent the upstream a request with two literal
-                        # `Host:` header lines. Go's net/http (Authentik's outpost server) rejects
-                        # that outright with a bare 400 before any application code runs, which is
-                        # why it never showed up in Authentik's own logs, even at trace level.
-                        proxy_set_header X-Original-URL $scheme://$http_host$request_uri;
-                        add_header Set-Cookie $auth_cookie;
-                        ${securityHeaders}
-                        auth_request_set $auth_cookie $upstream_http_set_cookie;
-                        proxy_pass_request_body off;
-                        proxy_set_header Content-Length "";
-                      '';
-                    };
-                  };
-                }
-              )
-            ) virtual-host
-          );
-
           appendHttpConfig = ''
             # Add HSTS header with preloading to HTTPS requests.
             # Adding this header to HTTP requests is discouraged
@@ -212,13 +59,158 @@
             # This might create errors
             proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";
           '';
-        };
+          enable = true;
+          recommendedBrotliSettings = true;
+          recommendedGzipSettings = true;
+          recommendedOptimisation = true;
+          recommendedProxySettings = true;
+          recommendedTlsSettings = true;
+          # nginx's default bucket size can't fit our longest server_name once enough
+          # <service>.<host>.<domain> vhosts pile up (e.g. bookshelf-audiobooks.harmony.…, 47
+          # chars) - it then refuses to start at all ("could not build server_names_hash, you
+          # should increase server_names_hash_bucket_size"). 128 leaves headroom for future
+          # services without revisiting this.
+          serverNamesHashBucketSize = 128;
+          # Exposes /nginx_status on localhost for Netdata's nginx collector (request/connection
+          # metrics).
+          statusPage = true;
+          virtualHosts = lib.listToAttrs (
+            map (
+              vh:
+              let
+                # Every service is namespaced under its host by default (immich.harmony.…), so
+                # multiple hosts can run the same service without colliding on one wildcard DNS
+                # entry. A service opts into also being reachable at the bare, host-agnostic name
+                # (immich.…) via `global = true;` on its `virtual-host` record — surfaced as an
+                # nginx `serverAlias`, which nixos's ACME integration automatically adds as a SAN
+                # on the same certificate.
+                url = vh.url or "${vh.name}.${host.name}.${domain}";
+                global-url = "${vh.name}.${domain}";
+              in
+              lib.nameValuePair url (
+                {
+                  enableACME = true;
+                  # appendHttpConfig's proxy_cookie_path rewrite appends its own secure/HttpOnly/
+                  # SameSite flags to every Set-Cookie header, even ones a backend already set its
+                  # own correct flags on. That produces a Set-Cookie with duplicated attributes,
+                  # which browsers can silently refuse to store — breaking login for any backend
+                  # that manages its own cookie security (e.g. Immich). Opt out per host via
+                  # `preserveCookieFlags = true;` on the `virtual-host` record.
+                  extraConfig = lib.optionalString (vh.preserveCookieFlags or false) ''
+                    proxy_cookie_path / /;
+                  '';
+                  forceSSL = true;
+                  # Skips adding `global-url` when a service's own `url` override (e.g.
+                  # authentik.nix's, when `global`) already IS the canonical name - the usual case
+                  # is `url` staying host-scoped, with `global-url` merely an alias alongside it.
+                  serverAliases = lib.optionals (vh.global or false && url != global-url) [ global-url ];
+                }
+                // lib.optionalAttrs (vh ? port) {
+                  locations = {
+                    "/" = {
+                      extraConfig = lib.optionalString (vh.protected or false) ''
+                        auth_request /outpost.goauthentik.io/auth/nginx;
+                        error_page 401 = @goauthentik_proxy_signin;
 
-        # Open firewall ports for HTTP and HTTPS
-        networking.firewall.allowedTCPPorts = [
-          80
-          443
-        ];
+                        auth_request_set $auth_cookie $upstream_http_set_cookie;
+                        add_header Set-Cookie $auth_cookie;
+                        ${securityHeaders}
+
+                        auth_request_set $authentik_username $upstream_http_x_authentik_username;
+                        auth_request_set $authentik_groups $upstream_http_x_authentik_groups;
+                        auth_request_set $authentik_email $upstream_http_x_authentik_email;
+                        auth_request_set $authentik_name $upstream_http_x_authentik_name;
+                        auth_request_set $authentik_uid $upstream_http_x_authentik_uid;
+
+                        proxy_set_header X-authentik-username $authentik_username;
+                        proxy_set_header X-authentik-groups $authentik_groups;
+                        proxy_set_header X-authentik-email $authentik_email;
+                        proxy_set_header X-authentik-name $authentik_name;
+                        proxy_set_header X-authentik-uid $authentik_uid;
+                      '';
+                      # No trailing URI here (deliberately, like the regex bypassAuthPaths
+                      # locations below): with one, nginx has to decode+re-merge the request URI to
+                      # splice it onto the backend path, and an encoded slash anywhere in it (e.g.
+                      # Collabora's WOPI websocket path, which embeds a full url-encoded WOPISrc
+                      # URL) trips that merge and nginx 400s the request before it ever reaches the
+                      # backend - confirmed by bisecting: `/foo%2Fbar` 400s, `/foo` doesn't, on this
+                      # exact location. Omitting the URI makes nginx forward $request_uri verbatim,
+                      # which every location here is "/" (matches the whole path) so this is a
+                      # no-op for every other backend already relying on the old behavior.
+                      proxyPass = "http://127.0.0.1:${toString vh.port}";
+                      # recommendedProxySettings clears the Connection header (`proxy_set_header
+                      # Connection "";`), which breaks WebSocket upgrades. Backends that use them
+                      # (e.g. Immich's real-time updates) opt in via `websockets = true;` on their
+                      # `virtual-host` record — nginx's standard websocket idiom (see
+                      # https://nginx.org/en/docs/http/websocket.html), which sends `Connection:
+                      # close` instead of keep-alive for non-Upgrade requests on that host. Fine
+                      # here: upstream is always 127.0.0.1, so the lost keep-alive just costs an
+                      # extra loopback handshake, not a real round trip.
+                      proxyWebsockets = vh.websockets or false;
+                    };
+                  }
+                  // lib.optionalAttrs (vh.protected or false) (
+                    lib.listToAttrs (
+                      map (
+                        path:
+                        lib.nameValuePair "~ ${path}" {
+                          # No URI on proxyPass: regex locations can't auto-rewrite the matched path, so this
+                          # forwards the original path+query untouched, without the auth_request config below.
+                          proxyPass = "http://127.0.0.1:${toString vh.port}";
+                        }
+                      ) (vh.bypassAuthPaths or [ ])
+                    )
+                  )
+                  // lib.optionalAttrs (vh.protected or false) {
+                    "/outpost.goauthentik.io" = {
+                      extraConfig = ''
+                        # No explicit `proxy_set_header Host` here: recommendedProxySettings
+                        # already adds one (any location with proxyPass gets it) and nginx doesn't
+                        # deduplicate repeated proxy_set_header lines for the same name — an
+                        # explicit second one here sent the upstream a request with two literal
+                        # `Host:` header lines. Go's net/http (Authentik's outpost server) rejects
+                        # that outright with a bare 400 before any application code runs, which is
+                        # why it never showed up in Authentik's own logs, even at trace level.
+                        proxy_set_header X-Original-URL $scheme://$http_host$request_uri;
+                        add_header Set-Cookie $auth_cookie;
+                        ${securityHeaders}
+                        auth_request_set $auth_cookie $upstream_http_set_cookie;
+                        proxy_pass_request_body off;
+                        proxy_set_header Content-Length "";
+                      '';
+                      proxyPass = "${authentikOutpost}/outpost.goauthentik.io";
+                    };
+                    "@goauthentik_proxy_signin" = {
+                      extraConfig = ''
+                        internal;
+                        add_header Set-Cookie $auth_cookie;
+                        ${securityHeaders}
+                        # Authentik's own forward-auth (single application) docs redirect back to
+                        # the CURRENT app's own domain, not Authentik's - every protected vhost
+                        # already has its own "/outpost.goauthentik.io" location (below) proxying
+                        # to the same embedded outpost, so $http_host lands back on a domain the
+                        # outpost can actually match to this provider. Redirecting to Authentik's
+                        # own domain instead landed on "Not Found", since that domain has no
+                        # per-provider Host-header context for the outpost to key off of.
+                        return 302 "https://$http_host/outpost.goauthentik.io/start?rd=$scheme://$http_host$request_uri";
+                      '';
+                    };
+                  };
+                }
+              )
+            ) virtual-host
+          );
+        };
       };
+    port-forward = [
+      {
+        name = "http";
+        port = 80;
+      }
+      {
+        name = "https";
+        port = 443;
+      }
+    ];
   };
 }

--- a/modules/aspects/my/nginx.nix
+++ b/modules/aspects/my/nginx.nix
@@ -2,18 +2,16 @@
   my.nginx = {
     nixos =
       {
-        host,
         lib,
+        host,
         virtual-host,
         ...
       }:
       let
-        domain = "silverlight-nex.us";
-
         # Address of Authentik's embedded outpost, used to gate `protected` virtual hosts behind
         # forward-auth. Matches the address authentik-nix's own nginx integration proxies to.
         authentikOutpost = "https://127.0.0.1:9443";
-
+        domain = "silverlight-nex.us";
         # nginx only inherits a parent context's `add_header` directives into a location that
         # doesn't declare any of its own. Forward-auth locations below need `add_header
         # Set-Cookie` to propagate Authentik's session cookie, which would otherwise silently
@@ -31,11 +29,15 @@
           80
           443
         ];
+
         security.acme = {
           acceptTerms = true;
           defaults.email = "letsencrypt@alias.oscarmarshall.com";
         };
+
         services.nginx = {
+          enable = true;
+
           appendHttpConfig = ''
             # Add HSTS header with preloading to HTTPS requests.
             # Adding this header to HTTP requests is discouraged
@@ -59,7 +61,7 @@
             # This might create errors
             proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";
           '';
-          enable = true;
+
           recommendedBrotliSettings = true;
           recommendedGzipSettings = true;
           recommendedOptimisation = true;
@@ -74,10 +76,12 @@
           # Exposes /nginx_status on localhost for Netdata's nginx collector (request/connection
           # metrics).
           statusPage = true;
+
           virtualHosts = lib.listToAttrs (
             map (
               vh:
               let
+                global-url = "${vh.name}.${domain}";
                 # Every service is namespaced under its host by default (immich.harmony.…), so
                 # multiple hosts can run the same service without colliding on one wildcard DNS
                 # entry. A service opts into also being reachable at the bare, host-agnostic name
@@ -85,11 +89,11 @@
                 # nginx `serverAlias`, which nixos's ACME integration automatically adds as a SAN
                 # on the same certificate.
                 url = vh.url or "${vh.name}.${host.name}.${domain}";
-                global-url = "${vh.name}.${domain}";
               in
               lib.nameValuePair url (
                 {
                   enableACME = true;
+
                   # appendHttpConfig's proxy_cookie_path rewrite appends its own secure/HttpOnly/
                   # SameSite flags to every Set-Cookie header, even ones a backend already set its
                   # own correct flags on. That produces a Set-Cookie with duplicated attributes,
@@ -99,6 +103,7 @@
                   extraConfig = lib.optionalString (vh.preserveCookieFlags or false) ''
                     proxy_cookie_path / /;
                   '';
+
                   forceSSL = true;
                   # Skips adding `global-url` when a service's own `url` override (e.g.
                   # authentik.nix's, when `global`) already IS the canonical name - the usual case
@@ -128,6 +133,7 @@
                         proxy_set_header X-authentik-name $authentik_name;
                         proxy_set_header X-authentik-uid $authentik_uid;
                       '';
+
                       # No trailing URI here (deliberately, like the regex bypassAuthPaths
                       # locations below): with one, nginx has to decode+re-merge the request URI to
                       # splice it onto the backend path, and an encoded slash anywhere in it (e.g.
@@ -178,8 +184,10 @@
                         proxy_pass_request_body off;
                         proxy_set_header Content-Length "";
                       '';
+
                       proxyPass = "${authentikOutpost}/outpost.goauthentik.io";
                     };
+
                     "@goauthentik_proxy_signin" = {
                       extraConfig = ''
                         internal;
@@ -202,6 +210,7 @@
           );
         };
       };
+
     port-forward = [
       {
         name = "http";

--- a/modules/aspects/my/nh.nix
+++ b/modules/aspects/my/nh.nix
@@ -1,10 +1,10 @@
 {
   my.nh.homeManager.programs.nh = {
-    enable = true;
-    flake = "github:OscarMarshall/dotfiles";
     clean = {
       enable = true;
       extraArgs = "--keep-since 7d";
     };
+    enable = true;
+    flake = "github:OscarMarshall/dotfiles";
   };
 }

--- a/modules/aspects/my/nh.nix
+++ b/modules/aspects/my/nh.nix
@@ -1,10 +1,12 @@
 {
   my.nh.homeManager.programs.nh = {
+    enable = true;
+
     clean = {
       enable = true;
       extraArgs = "--keep-since 7d";
     };
-    enable = true;
+
     flake = "github:OscarMarshall/dotfiles";
   };
 }

--- a/modules/aspects/my/nix-index.nix
+++ b/modules/aspects/my/nix-index.nix
@@ -1,7 +1,7 @@
 { inputs, ... }: {
   flake-file.inputs.nix-index-database = {
-    inputs.nixpkgs.follows = "nixpkgs";
     url = "github:nix-community/nix-index-database";
+    inputs.nixpkgs.follows = "nixpkgs";
   };
 
   my.nix-index.homeManager = {

--- a/modules/aspects/my/nix-index.nix
+++ b/modules/aspects/my/nix-index.nix
@@ -1,7 +1,7 @@
 { inputs, ... }: {
   flake-file.inputs.nix-index-database = {
-    url = "github:nix-community/nix-index-database";
     inputs.nixpkgs.follows = "nixpkgs";
+    url = "github:nix-community/nix-index-database";
   };
 
   my.nix-index.homeManager = {

--- a/modules/aspects/my/nix.nix
+++ b/modules/aspects/my/nix.nix
@@ -1,4 +1,4 @@
-{ lib, config, ... }:
+{ config, lib, ... }:
 let
   flakeFileNixConfig = config.flake-file.nixConfig;
   mkNixConfig = { config, pkgs }: {
@@ -18,6 +18,7 @@ let
   };
 in
 {
+  flake.nixConfig = flakeFileNixConfig;
   flake-file.nixConfig = {
     extra-substituters = [
       "https://nix-community.cachix.org"
@@ -28,36 +29,8 @@ in
       "oscarmarshall.cachix.org-1:Fa13vGeBXoJ7jWpvnalg/PCRTtvCpyuHUFL5jQXt/9w="
     ];
   };
-  flake.nixConfig = flakeFileNixConfig;
-
   my.nix = {
-    secrets = { secrets, ... }: {
-      nix-github-access-token = {
-        rekeyFile = ../../../secrets/nix-github-access-token.age;
-        # World-readable, same as nix-access-tokens below (which already
-        # exposes this same token in the clear): lets other consumers (e.g.
-        # Starship) read the bare token without nix.conf's `access-tokens =
-        # github.com=` wrapper.
-        mode = "0444";
-      };
-
-      nix-access-tokens = {
-        # World-readable: nix fetches via the client process, not the daemon,
-        # so all users need to read this for authenticated GitHub API access.
-        mode = "0444";
-        generator = {
-          dependencies = { inherit (secrets) nix-github-access-token; };
-          script = { decrypt, deps, ... }: ''
-            printf 'access-tokens = github.com=%s\n' "$(
-              ${decrypt} ${lib.escapeShellArg deps.nix-github-access-token.file}
-            )"
-          '';
-        };
-      };
-    };
-
     homeManager = { config, pkgs, ... }: mkNixConfig { inherit config pkgs; };
-
     os =
       { config, pkgs, ... }:
       lib.mkMerge [
@@ -70,5 +43,28 @@ in
           nix.optimise.automatic = true;
         }
       ];
+    secrets = { secrets, ... }: {
+      nix-access-tokens = {
+        generator = {
+          dependencies = { inherit (secrets) nix-github-access-token; };
+          script = { decrypt, deps, ... }: ''
+            printf 'access-tokens = github.com=%s\n' "$(
+              ${decrypt} ${lib.escapeShellArg deps.nix-github-access-token.file}
+            )"
+          '';
+        };
+        # World-readable: nix fetches via the client process, not the daemon,
+        # so all users need to read this for authenticated GitHub API access.
+        mode = "0444";
+      };
+      nix-github-access-token = {
+        # World-readable, same as nix-access-tokens below (which already
+        # exposes this same token in the clear): lets other consumers (e.g.
+        # Starship) read the bare token without nix.conf's `access-tokens =
+        # github.com=` wrapper.
+        mode = "0444";
+        rekeyFile = ../../../secrets/nix-github-access-token.age;
+      };
+    };
   };
 }

--- a/modules/aspects/my/nix.nix
+++ b/modules/aspects/my/nix.nix
@@ -3,10 +3,12 @@ let
   flakeFileNixConfig = config.flake-file.nixConfig;
   mkNixConfig = { config, pkgs }: {
     nix = {
+      package = pkgs.lixPackageSets.stable.lix;
+
       extraOptions = ''
         !include ${config.age.secrets.nix-access-tokens.path}
       '';
-      package = pkgs.lixPackageSets.stable.lix;
+
       settings = {
         experimental-features = [
           "nix-command"
@@ -18,45 +20,56 @@ let
   };
 in
 {
-  flake.nixConfig = flakeFileNixConfig;
   flake-file.nixConfig = {
     extra-substituters = [
       "https://nix-community.cachix.org"
       "https://oscarmarshall.cachix.org"
     ];
+
     extra-trusted-public-keys = [
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       "oscarmarshall.cachix.org-1:Fa13vGeBXoJ7jWpvnalg/PCRTtvCpyuHUFL5jQXt/9w="
     ];
   };
+
+  flake.nixConfig = flakeFileNixConfig;
+
   my.nix = {
     homeManager = { config, pkgs, ... }: mkNixConfig { inherit config pkgs; };
+
     os =
       { config, pkgs, ... }:
       lib.mkMerge [
         (mkNixConfig { inherit config pkgs; })
         {
-          nix.gc = {
-            automatic = true;
-            options = "--delete-older-than 7d";
+          nix = {
+            gc = {
+              options = "--delete-older-than 7d";
+              automatic = true;
+            };
+
+            optimise.automatic = true;
           };
-          nix.optimise.automatic = true;
         }
       ];
+
     secrets = { secrets, ... }: {
       nix-access-tokens = {
         generator = {
           dependencies = { inherit (secrets) nix-github-access-token; };
+
           script = { decrypt, deps, ... }: ''
             printf 'access-tokens = github.com=%s\n' "$(
               ${decrypt} ${lib.escapeShellArg deps.nix-github-access-token.file}
             )"
           '';
         };
+
         # World-readable: nix fetches via the client process, not the daemon,
         # so all users need to read this for authenticated GitHub API access.
         mode = "0444";
       };
+
       nix-github-access-token = {
         # World-readable, same as nix-access-tokens below (which already
         # exposes this same token in the clear): lets other consumers (e.g.

--- a/modules/aspects/my/openai.nix
+++ b/modules/aspects/my/openai.nix
@@ -1,14 +1,14 @@
 {
+  lib,
   den,
   inputs,
-  lib,
   my,
   ...
 }:
 {
   flake-file.inputs.codex-cli-nix = {
-    inputs.nixpkgs.follows = "nixpkgs";
     url = "github:sadjow/codex-cli-nix";
+    inputs.nixpkgs.follows = "nixpkgs";
   };
 
   my.openai =
@@ -16,14 +16,16 @@
       chatgpt ? false,
     }:
     {
+      includes = [ my.mcp-servers ] ++ lib.optional chatgpt (den._.unfree [ "chatgpt" ]);
+
       homeManager = { pkgs, ... }: {
         home.packages = lib.optional chatgpt pkgs.chatgpt;
+
         programs.codex = {
           enable = true;
-          enableMcpIntegration = true;
           package = inputs.codex-cli-nix.packages.${pkgs.stdenv.hostPlatform.system}.codex;
+          enableMcpIntegration = true;
         };
       };
-      includes = [ my.mcp-servers ] ++ lib.optional chatgpt (den._.unfree [ "chatgpt" ]);
     };
 }

--- a/modules/aspects/my/openai.nix
+++ b/modules/aspects/my/openai.nix
@@ -7,8 +7,8 @@
 }:
 {
   flake-file.inputs.codex-cli-nix = {
-    url = "github:sadjow/codex-cli-nix";
     inputs.nixpkgs.follows = "nixpkgs";
+    url = "github:sadjow/codex-cli-nix";
   };
 
   my.openai =
@@ -16,16 +16,14 @@
       chatgpt ? false,
     }:
     {
-      includes = [ my.mcp-servers ] ++ lib.optional chatgpt (den._.unfree [ "chatgpt" ]);
-
       homeManager = { pkgs, ... }: {
+        home.packages = lib.optional chatgpt pkgs.chatgpt;
         programs.codex = {
           enable = true;
-          package = inputs.codex-cli-nix.packages.${pkgs.stdenv.hostPlatform.system}.codex;
           enableMcpIntegration = true;
+          package = inputs.codex-cli-nix.packages.${pkgs.stdenv.hostPlatform.system}.codex;
         };
-
-        home.packages = lib.optional chatgpt pkgs.chatgpt;
       };
+      includes = [ my.mcp-servers ] ++ lib.optional chatgpt (den._.unfree [ "chatgpt" ]);
     };
 }

--- a/modules/aspects/my/orca-slicer.nix
+++ b/modules/aspects/my/orca-slicer.nix
@@ -1,7 +1,6 @@
 {
   my.orca-slicer = {
-    hmLinux = { pkgs, ... }: { home.packages = [ pkgs.orca-slicer ]; };
-
     darwin.homebrew.casks = [ "orcaslicer" ];
+    hmLinux = { pkgs, ... }: { home.packages = [ pkgs.orca-slicer ]; };
   };
 }

--- a/modules/aspects/my/pipewire.nix
+++ b/modules/aspects/my/pipewire.nix
@@ -1,12 +1,15 @@
 {
   my.pipewire.nixos = {
     security.rtkit.enable = true;
+
     services.pipewire = {
+      enable = true;
+
       alsa = {
         enable = true;
         support32Bit = true;
       };
-      enable = true;
+
       pulse.enable = true;
     };
   };

--- a/modules/aspects/my/pipewire.nix
+++ b/modules/aspects/my/pipewire.nix
@@ -2,11 +2,11 @@
   my.pipewire.nixos = {
     security.rtkit.enable = true;
     services.pipewire = {
-      enable = true;
       alsa = {
         enable = true;
         support32Bit = true;
       };
+      enable = true;
       pulse.enable = true;
     };
   };

--- a/modules/aspects/my/plex.nix
+++ b/modules/aspects/my/plex.nix
@@ -5,22 +5,27 @@
     }:
     { host, ... }: {
       includes = [ (den._.unfree [ "plexmediaserver" ]) ];
+
       nixos = {
         services.plex = {
           enable = true;
           openFirewall = true;
         };
       };
+
       port-forward = {
         name = "plex";
         port = 32400;
       };
+
       virtual-host = {
         inherit global;
         group = "Media";
+
         homepage = {
           description = "Media server";
         };
+
         host = host.name;
         icon = "plex.svg";
         label = "Plex";

--- a/modules/aspects/my/plex.nix
+++ b/modules/aspects/my/plex.nix
@@ -5,30 +5,27 @@
     }:
     { host, ... }: {
       includes = [ (den._.unfree [ "plexmediaserver" ]) ];
-
-      virtual-host = {
-        name = "plex";
-        host = host.name;
-        port = 32400;
-        inherit global;
-        label = "Plex";
-        icon = "plex.svg";
-        group = "Media";
-        homepage = {
-          description = "Media server";
-        };
-      };
-
-      port-forward = {
-        name = "plex";
-        port = 32400;
-      };
-
       nixos = {
         services.plex = {
           enable = true;
           openFirewall = true;
         };
+      };
+      port-forward = {
+        name = "plex";
+        port = 32400;
+      };
+      virtual-host = {
+        inherit global;
+        group = "Media";
+        homepage = {
+          description = "Media server";
+        };
+        host = host.name;
+        icon = "plex.svg";
+        label = "Plex";
+        name = "plex";
+        port = 32400;
       };
     };
 }

--- a/modules/aspects/my/profilarr.nix
+++ b/modules/aspects/my/profilarr.nix
@@ -12,24 +12,30 @@
         name = "profilarr";
         pool = "metalminds";
       };
+
       nixos = { config, ... }: {
         virtualisation.oci-containers.containers.profilarr = {
           environment.TZ = config.time.timeZone;
           image = "santiagosayshey/profilarr:v1.1.5@sha256:8033e9c6d6995f37625afeb93d7020e99566f549ae83b65f1db7e11048952d0f";
+
           ports =
             let
               port' = toString port;
             in
             [ "127.0.0.1:${port'}:${port'}" ];
+
           volumes = [ "/metalminds/profilarr:/config" ];
         };
       };
+
       virtual-host = {
-        inherit port global;
+        inherit global port;
         group = "Arr Stack";
+
         homepage = {
           description = "Radarr/Sonarr custom format manager";
         };
+
         host = host.name;
         icon = "https://raw.githubusercontent.com/Dictionarry-Hub/profilarr/develop/src/lib/client/assets/logo-512.png";
         label = "Profilarr";

--- a/modules/aspects/my/profilarr.nix
+++ b/modules/aspects/my/profilarr.nix
@@ -9,25 +9,12 @@
     in
     {
       dataset = {
+        name = "profilarr";
         pool = "metalminds";
-        name = "profilarr";
       };
-
-      virtual-host = {
-        name = "profilarr";
-        host = host.name;
-        protected = true;
-        inherit port global;
-        label = "Profilarr";
-        icon = "https://raw.githubusercontent.com/Dictionarry-Hub/profilarr/develop/src/lib/client/assets/logo-512.png";
-        group = "Arr Stack";
-        homepage = {
-          description = "Radarr/Sonarr custom format manager";
-        };
-      };
-
       nixos = { config, ... }: {
         virtualisation.oci-containers.containers.profilarr = {
+          environment.TZ = config.time.timeZone;
           image = "santiagosayshey/profilarr:v1.1.5@sha256:8033e9c6d6995f37625afeb93d7020e99566f549ae83b65f1db7e11048952d0f";
           ports =
             let
@@ -35,8 +22,19 @@
             in
             [ "127.0.0.1:${port'}:${port'}" ];
           volumes = [ "/metalminds/profilarr:/config" ];
-          environment.TZ = config.time.timeZone;
         };
+      };
+      virtual-host = {
+        inherit port global;
+        group = "Arr Stack";
+        homepage = {
+          description = "Radarr/Sonarr custom format manager";
+        };
+        host = host.name;
+        icon = "https://raw.githubusercontent.com/Dictionarry-Hub/profilarr/develop/src/lib/client/assets/logo-512.png";
+        label = "Profilarr";
+        name = "profilarr";
+        protected = true;
       };
     };
 }

--- a/modules/aspects/my/programmer-dvorak.nix
+++ b/modules/aspects/my/programmer-dvorak.nix
@@ -1,22 +1,27 @@
 {
   my.programmer-dvorak = {
-    # macOS ships plain Dvorak but not Programmer Dvorak, so it's installed via the Homebrew cask
-    # (https://formulae.brew.sh/cask/programmer-dvorak), which places the bundle in the
-    # system-wide /Library/Keyboard Layouts rather than per-user.
-    darwin.homebrew.casks = [ "programmer-dvorak" ];
-    # macOS caches the list of installed keyboard layouts (com.apple.IntlDataCache.le*) and only
-    # rescans it at boot, so a newly (un)installed .bundle won't show up in System Settings ->
-    # Keyboard -> Input Sources until the cache is cleared and the machine is rebooted.
-    darwin.system.activationScripts.postActivation.text = ''
-      rm -f /System/Library/Caches/com.apple.IntlDataCache.le*
-      rm -f /private/var/folders/*/*/C/com.apple.IntlDataCache.le*
-    '';
+    darwin = {
+      # macOS ships plain Dvorak but not Programmer Dvorak, so it's installed via the Homebrew cask
+      # (https://formulae.brew.sh/cask/programmer-dvorak), which places the bundle in the
+      # system-wide /Library/Keyboard Layouts rather than per-user.
+      homebrew.casks = [ "programmer-dvorak" ];
+
+      # macOS caches the list of installed keyboard layouts (com.apple.IntlDataCache.le*) and only
+      # rescans it at boot, so a newly (un)installed .bundle won't show up in System Settings ->
+      # Keyboard -> Input Sources until the cache is cleared and the machine is rebooted.
+      system.activationScripts.postActivation.text = ''
+        rm -f /System/Library/Caches/com.apple.IntlDataCache.le*
+        rm -f /private/var/folders/*/*/C/com.apple.IntlDataCache.le*
+      '';
+    };
+
     # xkeyboard-config's "us" layout, "dvp" variant is Programmer Dvorak. Listing it as a second
     # GNOME input source (rather than replacing "us") keeps English (US) the default and current
     # source; it just becomes selectable via the input source switcher.
     hmLinux = { lib, ... }: {
       dconf.settings."org/gnome/desktop/input-sources" = {
         current = lib.hm.gvariant.mkUint32 0;
+
         sources = map lib.hm.gvariant.mkTuple [
           [
             "xkb"

--- a/modules/aspects/my/programmer-dvorak.nix
+++ b/modules/aspects/my/programmer-dvorak.nix
@@ -1,5 +1,9 @@
 {
   my.programmer-dvorak = {
+    # macOS ships plain Dvorak but not Programmer Dvorak, so it's installed via the Homebrew cask
+    # (https://formulae.brew.sh/cask/programmer-dvorak), which places the bundle in the
+    # system-wide /Library/Keyboard Layouts rather than per-user.
+    darwin.homebrew.casks = [ "programmer-dvorak" ];
     # macOS caches the list of installed keyboard layouts (com.apple.IntlDataCache.le*) and only
     # rescans it at boot, so a newly (un)installed .bundle won't show up in System Settings ->
     # Keyboard -> Input Sources until the cache is cleared and the machine is rebooted.
@@ -7,17 +11,12 @@
       rm -f /System/Library/Caches/com.apple.IntlDataCache.le*
       rm -f /private/var/folders/*/*/C/com.apple.IntlDataCache.le*
     '';
-
-    # macOS ships plain Dvorak but not Programmer Dvorak, so it's installed via the Homebrew cask
-    # (https://formulae.brew.sh/cask/programmer-dvorak), which places the bundle in the
-    # system-wide /Library/Keyboard Layouts rather than per-user.
-    darwin.homebrew.casks = [ "programmer-dvorak" ];
-
     # xkeyboard-config's "us" layout, "dvp" variant is Programmer Dvorak. Listing it as a second
     # GNOME input source (rather than replacing "us") keeps English (US) the default and current
     # source; it just becomes selectable via the input source switcher.
     hmLinux = { lib, ... }: {
       dconf.settings."org/gnome/desktop/input-sources" = {
+        current = lib.hm.gvariant.mkUint32 0;
         sources = map lib.hm.gvariant.mkTuple [
           [
             "xkb"
@@ -28,7 +27,6 @@
             "us+dvp"
           ]
         ];
-        current = lib.hm.gvariant.mkUint32 0;
       };
     };
   };

--- a/modules/aspects/my/proton-pass.nix
+++ b/modules/aspects/my/proton-pass.nix
@@ -1,11 +1,11 @@
 { den, ... }: {
   my.proton-pass = {
+    includes = [ (den._.unfree [ "proton-pass-cli" ]) ];
     # Upstream defaults this agent to the launchd "user" domain, which has no
     # window-server session. Keychain access for the DB encryption key needs
     # the Aqua session (the "gui" domain) or it fails with -25308
     # (errSecInteractionNotAllowed).
     hmDarwin.launchd.agents.proton-pass-agent.domain = "gui";
     homeManager.services.proton-pass-agent.enable = true;
-    includes = [ (den._.unfree [ "proton-pass-cli" ]) ];
   };
 }

--- a/modules/aspects/my/proton-pass.nix
+++ b/modules/aspects/my/proton-pass.nix
@@ -1,13 +1,11 @@
 { den, ... }: {
   my.proton-pass = {
-    includes = [ (den._.unfree [ "proton-pass-cli" ]) ];
-
-    homeManager.services.proton-pass-agent.enable = true;
-
     # Upstream defaults this agent to the launchd "user" domain, which has no
     # window-server session. Keychain access for the DB encryption key needs
     # the Aqua session (the "gui" domain) or it fails with -25308
     # (errSecInteractionNotAllowed).
     hmDarwin.launchd.agents.proton-pass-agent.domain = "gui";
+    homeManager.services.proton-pass-agent.enable = true;
+    includes = [ (den._.unfree [ "proton-pass-cli" ]) ];
   };
 }

--- a/modules/aspects/my/prowlarr.nix
+++ b/modules/aspects/my/prowlarr.nix
@@ -8,34 +8,23 @@
       port = 9696;
     in
     {
-      virtual-host = {
-        name = "prowlarr";
-        host = host.name;
-        protected = true;
-        # Prowlarr serves its own REST API under /api, and proxies per-indexer Torznab requests
-        # under /<indexerId>/api; nginx.nix lets both through the Authentik forward-auth gate
-        # untouched since cross-seed calls them directly with an API key, machine-to-machine, with
-        # no browser session to carry an Authentik cookie.
-        bypassAuthPaths = [
-          "^/api"
-          "^/[0-9]+/api"
-        ];
-        inherit port global;
-        label = "Prowlarr";
-        icon = "prowlarr.svg";
-        group = "Arr Stack";
-        homepage = {
-          description = "Indexer manager/proxy";
-          widget = {
-            type = "prowlarr";
-            # Hit Prowlarr directly rather than through nginx/Authentik, since Homepage's
-            # server-side widget fetch has no browser session to pass the forward-auth gate.
-            url = "http://127.0.0.1:${toString port}";
-            api-key = true;
+      nixos = { config, ... }: {
+        services = {
+          flaresolverr.enable = true;
+          prowlarr = {
+            enable = true;
+            environmentFiles = [ config.age.secrets."prowlarr.env".path ];
+            settings = {
+              # Prowlarr only reaches this vhost via nginx over loopback (its port isn't opened in
+              # the firewall), so every request it sees is "local" — this drops Prowlarr's own
+              # login screen in favor of the Authentik forward-auth gate in front of it, rather
+              # than stacking both.
+              auth.required = "DisabledForLocalAddresses";
+              server = { inherit port; };
+            };
           };
         };
       };
-
       secrets = { secrets, ... }: {
         prowlarr-api-key = {
           generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -hex 16";
@@ -46,9 +35,9 @@
           dependencies = { inherit (secrets) prowlarr-api-key; };
           script =
             {
-              lib,
               decrypt,
               deps,
+              lib,
               ...
             }:
             ''
@@ -56,23 +45,32 @@
             '';
         };
       };
-
-      nixos = { config, ... }: {
-        services = {
-          prowlarr = {
-            enable = true;
-            settings = {
-              server = { inherit port; };
-              # Prowlarr only reaches this vhost via nginx over loopback (its port isn't opened in
-              # the firewall), so every request it sees is "local" — this drops Prowlarr's own
-              # login screen in favor of the Authentik forward-auth gate in front of it, rather
-              # than stacking both.
-              auth.required = "DisabledForLocalAddresses";
-            };
-            environmentFiles = [ config.age.secrets."prowlarr.env".path ];
+      virtual-host = {
+        inherit port global;
+        # Prowlarr serves its own REST API under /api, and proxies per-indexer Torznab requests
+        # under /<indexerId>/api; nginx.nix lets both through the Authentik forward-auth gate
+        # untouched since cross-seed calls them directly with an API key, machine-to-machine, with
+        # no browser session to carry an Authentik cookie.
+        bypassAuthPaths = [
+          "^/api"
+          "^/[0-9]+/api"
+        ];
+        group = "Arr Stack";
+        homepage = {
+          description = "Indexer manager/proxy";
+          widget = {
+            api-key = true;
+            type = "prowlarr";
+            # Hit Prowlarr directly rather than through nginx/Authentik, since Homepage's
+            # server-side widget fetch has no browser session to pass the forward-auth gate.
+            url = "http://127.0.0.1:${toString port}";
           };
-          flaresolverr.enable = true;
         };
+        host = host.name;
+        icon = "prowlarr.svg";
+        label = "Prowlarr";
+        name = "prowlarr";
+        protected = true;
       };
     };
 }

--- a/modules/aspects/my/prowlarr.nix
+++ b/modules/aspects/my/prowlarr.nix
@@ -11,9 +11,11 @@
       nixos = { config, ... }: {
         services = {
           flaresolverr.enable = true;
+
           prowlarr = {
             enable = true;
             environmentFiles = [ config.age.secrets."prowlarr.env".path ];
+
             settings = {
               # Prowlarr only reaches this vhost via nginx over loopback (its port isn't opened in
               # the firewall), so every request it sees is "local" — this drops Prowlarr's own
@@ -25,19 +27,22 @@
           };
         };
       };
+
       secrets = { secrets, ... }: {
         prowlarr-api-key = {
           generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -hex 16";
           intermediary = true;
           settings.homepage = "prowlarr";
         };
+
         "prowlarr.env".generator = {
           dependencies = { inherit (secrets) prowlarr-api-key; };
+
           script =
             {
+              lib,
               decrypt,
               deps,
-              lib,
               ...
             }:
             ''
@@ -45,8 +50,10 @@
             '';
         };
       };
+
       virtual-host = {
-        inherit port global;
+        inherit global port;
+
         # Prowlarr serves its own REST API under /api, and proxies per-indexer Torznab requests
         # under /<indexerId>/api; nginx.nix lets both through the Authentik forward-auth gate
         # untouched since cross-seed calls them directly with an API key, machine-to-machine, with
@@ -55,9 +62,12 @@
           "^/api"
           "^/[0-9]+/api"
         ];
+
         group = "Arr Stack";
+
         homepage = {
           description = "Indexer manager/proxy";
+
           widget = {
             api-key = true;
             type = "prowlarr";
@@ -66,6 +76,7 @@
             url = "http://127.0.0.1:${toString port}";
           };
         };
+
         host = host.name;
         icon = "prowlarr.svg";
         label = "Prowlarr";

--- a/modules/aspects/my/prusa-slicer.nix
+++ b/modules/aspects/my/prusa-slicer.nix
@@ -2,8 +2,7 @@
 
 {
   my.prusa-slicer = {
-    hmLinux = { pkgs, ... }: { home.packages = [ pkgs.prusa-slicer ]; };
-
     darwin.homebrew.casks = [ "prusaslicer" ];
+    hmLinux = { pkgs, ... }: { home.packages = [ pkgs.prusa-slicer ]; };
   };
 }

--- a/modules/aspects/my/qbittorrent.nix
+++ b/modules/aspects/my/qbittorrent.nix
@@ -10,70 +10,69 @@ in
       global ? false,
     }:
     { host, ... }: {
-      # No `homepage` block: deliberately not a dashboard tile, but `label`/`icon`/`group` still
-      # feed its Authentik application (see virtual-host.nix).
-      virtual-host = {
-        name = "qbittorrent";
-        host = host.name;
-        protected = true;
-        label = "qBittorrent";
-        icon = "https://raw.githubusercontent.com/qbittorrent/qBittorrent/master/src/icons/qbittorrent-tray.svg";
-        group = "Arr Stack";
-        inherit port global;
-      };
-
-      secrets = { secrets, ... }: {
-        "qbittorrent.env".generator = {
-          dependencies = { inherit (secrets) cross-seed-api-key; };
-          script =
-            {
-              lib,
-              decrypt,
-              deps,
-              ...
-            }:
-            ''
-              printf 'CROSS_SEED_API_KEY=%s\n' "$(${decrypt} ${lib.escapeShellArg deps."cross-seed-api-key".file})"
-            '';
-        };
-      };
-
       nixos = { config, ... }: {
         users = {
+          groups.qbittorrent.gid = 985;
           users = {
             qbittorrent = {
-              uid = 985;
               description = "qBittorrent service user";
-              isSystemUser = true;
               group = "qbittorrent";
+              isSystemUser = true;
+              uid = 985;
             };
           }
           // (lib.genAttrs administrators (user: {
             extraGroups = [ "qbittorrent" ];
           }));
-
-          groups.qbittorrent.gid = 985;
         };
 
         virtualisation.oci-containers.containers = {
           gluetun.ports = [ "${port'}:${port'}" ];
           qbittorrent = {
+            dependsOn = [ "gluetun" ];
+            environment = {
+              PGID = toString config.users.groups.qbittorrent.gid;
+              PUID = toString config.users.users.qbittorrent.uid;
+              TZ = config.time.timeZone;
+              WEBUI_PORT = port';
+            };
+            environmentFiles = [ config.age.secrets."qbittorrent.env".path ];
+            extraOptions = [ "--network=container:gluetun" ];
             image = "lscr.io/linuxserver/qbittorrent:5.1.4-r1-ls435@sha256:e0cedcadd62f809efdeddfd32e4d1192f9a74e6e64ed6753bfc6e2c3ed4a714a";
             volumes = [
               "/var/lib/qBittorrent:/config"
               "/metalminds/torrents:/metalminds/torrents"
             ];
-            environment = {
-              PUID = toString config.users.users.qbittorrent.uid;
-              PGID = toString config.users.groups.qbittorrent.gid;
-              TZ = config.time.timeZone;
-              WEBUI_PORT = port';
-            };
-            environmentFiles = [ config.age.secrets."qbittorrent.env".path ];
-            dependsOn = [ "gluetun" ];
-            extraOptions = [ "--network=container:gluetun" ];
           };
         };
+      };
+      secrets = { secrets, ... }: {
+        "qbittorrent.env".generator = {
+          dependencies = { inherit (secrets) cross-seed-api-key; };
+          script =
+            {
+              decrypt,
+              deps,
+              lib,
+              ...
+            }:
+            ''
+              printf 'CROSS_SEED_API_KEY=%s\n' "$(${decrypt} ${
+                lib.escapeShellArg deps."cross-seed-api-key".file
+              })"
+            '';
+        };
+      };
+      # No `homepage` block: deliberately not a dashboard tile, but `label`/`icon`/`group` still
+      # feed its Authentik application (see virtual-host.nix).
+      virtual-host = {
+        inherit port global;
+        group = "Arr Stack";
+        host = host.name;
+        icon = "https://raw.githubusercontent.com/qbittorrent/qBittorrent/master/src/icons/qbittorrent-tray.svg";
+        label = "qBittorrent";
+        name = "qbittorrent";
+        protected = true;
       };
     };
 }

--- a/modules/aspects/my/qbittorrent.nix
+++ b/modules/aspects/my/qbittorrent.nix
@@ -13,6 +13,7 @@ in
       nixos = { config, ... }: {
         users = {
           groups.qbittorrent.gid = 985;
+
           users = {
             qbittorrent = {
               description = "qBittorrent service user";
@@ -28,17 +29,21 @@ in
 
         virtualisation.oci-containers.containers = {
           gluetun.ports = [ "${port'}:${port'}" ];
+
           qbittorrent = {
             dependsOn = [ "gluetun" ];
+
             environment = {
               PGID = toString config.users.groups.qbittorrent.gid;
               PUID = toString config.users.users.qbittorrent.uid;
               TZ = config.time.timeZone;
               WEBUI_PORT = port';
             };
+
             environmentFiles = [ config.age.secrets."qbittorrent.env".path ];
             extraOptions = [ "--network=container:gluetun" ];
             image = "lscr.io/linuxserver/qbittorrent:5.1.4-r1-ls435@sha256:e0cedcadd62f809efdeddfd32e4d1192f9a74e6e64ed6753bfc6e2c3ed4a714a";
+
             volumes = [
               "/var/lib/qBittorrent:/config"
               "/metalminds/torrents:/metalminds/torrents"
@@ -46,27 +51,28 @@ in
           };
         };
       };
+
       secrets = { secrets, ... }: {
         "qbittorrent.env".generator = {
           dependencies = { inherit (secrets) cross-seed-api-key; };
+
           script =
             {
+              lib,
               decrypt,
               deps,
-              lib,
               ...
             }:
             ''
-              printf 'CROSS_SEED_API_KEY=%s\n' "$(${decrypt} ${
-                lib.escapeShellArg deps."cross-seed-api-key".file
-              })"
+              printf 'CROSS_SEED_API_KEY=%s\n' "$(${decrypt} ${lib.escapeShellArg deps."cross-seed-api-key".file})"
             '';
         };
       };
+
       # No `homepage` block: deliberately not a dashboard tile, but `label`/`icon`/`group` still
       # feed its Authentik application (see virtual-host.nix).
       virtual-host = {
-        inherit port global;
+        inherit global port;
         group = "Arr Stack";
         host = host.name;
         icon = "https://raw.githubusercontent.com/qbittorrent/qBittorrent/master/src/icons/qbittorrent-tray.svg";

--- a/modules/aspects/my/radarr.nix
+++ b/modules/aspects/my/radarr.nix
@@ -18,6 +18,7 @@ in
           # in favor of the Authentik forward-auth gate in front of it, rather than stacking both.
           settings.auth.required = "DisabledForLocalAddresses";
         };
+
         users.users = {
           radarr.extraGroups = [ "qbittorrent" ];
         }
@@ -25,19 +26,22 @@ in
           extraGroups = [ "radarr" ];
         }));
       };
+
       secrets = { secrets, ... }: {
         radarr-api-key = {
           generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -hex 16";
           intermediary = true;
           settings.homepage = "radarr";
         };
+
         "radarr.env".generator = {
           dependencies = { inherit (secrets) radarr-api-key; };
+
           script =
             {
+              lib,
               decrypt,
               deps,
-              lib,
               ...
             }:
             ''
@@ -45,15 +49,18 @@ in
             '';
         };
       };
+
       virtual-host = {
-        inherit port global;
+        inherit global port;
         # Radarr serves its REST API under /api; nginx.nix lets that through the Authentik
         # forward-auth gate untouched since cross-seed/unpackerr call it directly with an API key,
         # machine-to-machine, with no browser session to carry an Authentik cookie.
         bypassAuthPaths = [ "^/api" ];
         group = "Arr Stack";
+
         homepage = {
           description = "Movie organizer/manager";
+
           widget = {
             api-key = true;
             enableQueue = true;
@@ -63,6 +70,7 @@ in
             url = "http://127.0.0.1:${toString port}";
           };
         };
+
         host = host.name;
         icon = "radarr.svg";
         label = "Radarr";

--- a/modules/aspects/my/radarr.nix
+++ b/modules/aspects/my/radarr.nix
@@ -9,31 +9,22 @@ in
       global ? false,
     }:
     { host, ... }: {
-      virtual-host = {
-        name = "radarr";
-        host = host.name;
-        protected = true;
-        # Radarr serves its REST API under /api; nginx.nix lets that through the Authentik
-        # forward-auth gate untouched since cross-seed/unpackerr call it directly with an API key,
-        # machine-to-machine, with no browser session to carry an Authentik cookie.
-        bypassAuthPaths = [ "^/api" ];
-        inherit port global;
-        label = "Radarr";
-        icon = "radarr.svg";
-        group = "Arr Stack";
-        homepage = {
-          description = "Movie organizer/manager";
-          widget = {
-            type = "radarr";
-            # Hit Radarr directly rather than through nginx/Authentik, since Homepage's
-            # server-side widget fetch has no browser session to pass the forward-auth gate.
-            url = "http://127.0.0.1:${toString port}";
-            api-key = true;
-            enableQueue = true;
-          };
+      nixos = { config, ... }: {
+        services.radarr = {
+          enable = true;
+          environmentFiles = [ config.age.secrets."radarr.env".path ];
+          # Radarr only reaches this vhost via nginx over loopback (its port isn't opened in the
+          # firewall), so every request it sees is "local" — this drops Radarr's own login screen
+          # in favor of the Authentik forward-auth gate in front of it, rather than stacking both.
+          settings.auth.required = "DisabledForLocalAddresses";
         };
+        users.users = {
+          radarr.extraGroups = [ "qbittorrent" ];
+        }
+        // (lib.genAttrs administrators (user: {
+          extraGroups = [ "radarr" ];
+        }));
       };
-
       secrets = { secrets, ... }: {
         radarr-api-key = {
           generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -hex 16";
@@ -44,9 +35,9 @@ in
           dependencies = { inherit (secrets) radarr-api-key; };
           script =
             {
-              lib,
               decrypt,
               deps,
+              lib,
               ...
             }:
             ''
@@ -54,23 +45,29 @@ in
             '';
         };
       };
-
-      nixos = { config, ... }: {
-        users.users = {
-          radarr.extraGroups = [ "qbittorrent" ];
-        }
-        // (lib.genAttrs administrators (user: {
-          extraGroups = [ "radarr" ];
-        }));
-
-        services.radarr = {
-          enable = true;
-          environmentFiles = [ config.age.secrets."radarr.env".path ];
-          # Radarr only reaches this vhost via nginx over loopback (its port isn't opened in the
-          # firewall), so every request it sees is "local" — this drops Radarr's own login screen
-          # in favor of the Authentik forward-auth gate in front of it, rather than stacking both.
-          settings.auth.required = "DisabledForLocalAddresses";
+      virtual-host = {
+        inherit port global;
+        # Radarr serves its REST API under /api; nginx.nix lets that through the Authentik
+        # forward-auth gate untouched since cross-seed/unpackerr call it directly with an API key,
+        # machine-to-machine, with no browser session to carry an Authentik cookie.
+        bypassAuthPaths = [ "^/api" ];
+        group = "Arr Stack";
+        homepage = {
+          description = "Movie organizer/manager";
+          widget = {
+            api-key = true;
+            enableQueue = true;
+            type = "radarr";
+            # Hit Radarr directly rather than through nginx/Authentik, since Homepage's
+            # server-side widget fetch has no browser session to pass the forward-auth gate.
+            url = "http://127.0.0.1:${toString port}";
+          };
         };
+        host = host.name;
+        icon = "radarr.svg";
+        label = "Radarr";
+        name = "radarr";
+        protected = true;
       };
     };
 }

--- a/modules/aspects/my/samba.nix
+++ b/modules/aspects/my/samba.nix
@@ -17,11 +17,11 @@
               map (
                 d:
                 lib.nameValuePair d.name {
-                  path = "/${d.pool}/${d.name}";
+                  browsable = "yes";
                   "guest ok" = if d.guestAccess or false then "yes" else "no";
+                  path = "/${d.pool}/${d.name}";
                   "read only" = "yes";
                   "write list" = "@users";
-                  browsable = "yes";
                 }
               ) shares
             ));

--- a/modules/aspects/my/samba.nix
+++ b/modules/aspects/my/samba.nix
@@ -1,7 +1,7 @@
 {
   my.samba = {
     nixos =
-      { dataset, lib, ... }:
+      { lib, dataset, ... }:
       let
         shares = builtins.filter (d: d.samba or false) dataset;
       in
@@ -10,6 +10,7 @@
           samba = {
             enable = true;
             openFirewall = true;
+
             settings = {
               global."map to guest" = "Bad User";
             }
@@ -26,6 +27,7 @@
               ) shares
             ));
           };
+
           samba-wsdd = {
             enable = true;
             openFirewall = true;

--- a/modules/aspects/my/satisfactory-server.nix
+++ b/modules/aspects/my/satisfactory-server.nix
@@ -5,21 +5,32 @@ in
 {
   my.satisfactory-server = {
     dataset = {
-      pool = "metalminds";
       name = "satisfactory-server";
+      pool = "metalminds";
     };
 
     nixos = { config, ... }: {
-      users = {
-        users.satisfactory-server = {
-          uid = 984;
-          isSystemUser = true;
-          group = "satisfactory-server";
-        };
-        groups.satisfactory-server.gid = 984;
+      networking.firewall = {
+        allowedTCPPorts = [
+          gamePort
+          messagingPort
+        ];
+        allowedUDPPorts = [ gamePort ];
       };
-
+      users = {
+        groups.satisfactory-server.gid = 984;
+        users.satisfactory-server = {
+          group = "satisfactory-server";
+          isSystemUser = true;
+          uid = 984;
+        };
+      };
       virtualisation.oci-containers.containers.satisfactory-server = {
+        environment = {
+          MAXPLAYERS = "4";
+          PGID = toString config.users.groups.satisfactory-server.gid;
+          PUID = toString config.users.users.satisfactory-server.uid;
+        };
         image = "wolveix/satisfactory-server:latest@sha256:e103700ae6ae4c50f19dac80eadb2a805c5b885e179ae2a40850e967bf189efd";
         ports = [
           "${toString gamePort}:${toString gamePort}/tcp"
@@ -27,19 +38,6 @@ in
           "${toString messagingPort}:${toString messagingPort}/tcp"
         ];
         volumes = [ "/metalminds/satisfactory-server:/config" ];
-        environment = {
-          PUID = toString config.users.users.satisfactory-server.uid;
-          PGID = toString config.users.groups.satisfactory-server.gid;
-          MAXPLAYERS = "4";
-        };
-      };
-
-      networking.firewall = {
-        allowedTCPPorts = [
-          gamePort
-          messagingPort
-        ];
-        allowedUDPPorts = [ gamePort ];
       };
     };
   };

--- a/modules/aspects/my/satisfactory-server.nix
+++ b/modules/aspects/my/satisfactory-server.nix
@@ -15,28 +15,35 @@ in
           gamePort
           messagingPort
         ];
+
         allowedUDPPorts = [ gamePort ];
       };
+
       users = {
         groups.satisfactory-server.gid = 984;
+
         users.satisfactory-server = {
           group = "satisfactory-server";
           isSystemUser = true;
           uid = 984;
         };
       };
+
       virtualisation.oci-containers.containers.satisfactory-server = {
         environment = {
           MAXPLAYERS = "4";
           PGID = toString config.users.groups.satisfactory-server.gid;
           PUID = toString config.users.users.satisfactory-server.uid;
         };
+
         image = "wolveix/satisfactory-server:latest@sha256:e103700ae6ae4c50f19dac80eadb2a805c5b885e179ae2a40850e967bf189efd";
+
         ports = [
           "${toString gamePort}:${toString gamePort}/tcp"
           "${toString gamePort}:${toString gamePort}/udp"
           "${toString messagingPort}:${toString messagingPort}/tcp"
         ];
+
         volumes = [ "/metalminds/satisfactory-server:/config" ];
       };
     };

--- a/modules/aspects/my/secrets.nix
+++ b/modules/aspects/my/secrets.nix
@@ -1,4 +1,4 @@
-{ inputs, lib, ... }:
+{ lib, inputs, ... }:
 let
   rekey = name: pkgs: {
     agePlugins = [ pkgs.age-plugin-yubikey ];
@@ -11,10 +11,13 @@ in
 {
   flake-file.inputs = {
     agenix-rekey = {
-      inputs.nixpkgs.follows = "nixpkgs";
       url = "github:oddlama/agenix-rekey";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
+
     ragenix = {
+      url = "github:yaxitech/ragenix";
+
       inputs = {
         agenix.inputs = {
           darwin.follows = "darwin";
@@ -22,9 +25,9 @@ in
           nixpkgs.follows = "nixpkgs";
           systems.follows = "systems";
         };
+
         nixpkgs.follows = "nixpkgs";
       };
-      url = "github:yaxitech/ragenix";
     };
   };
 
@@ -47,8 +50,6 @@ in
           home.hostName or home.name
         else
           null;
-      # Only set OS-level rekey from the host entity itself, not from user entities.
-      isHostEntity = user == null && host != null;
       # A user embedded under a host (e.g. oscar's home-manager profile on a host) is a separate
       # agenix-rekey node from that host's own OS-level node. `agenix rekey`'s local storage mode deletes
       # any file in a node's `localStorageDir` that isn't one of that node's own secrets, to clean up
@@ -56,8 +57,9 @@ in
       # whichever node ran last on a given `agenix rekey -a` pass would delete the other's exclusively-owned
       # secrets as "orphans". Giving the embedded user a separate sibling directory keeps each node's
       # cleanup pass scoped to only its own files.
-      homeManagerEntityName =
-        if host != null && user != null then "${host.name}-home-${user.userName}" else entityName;
+      homeManagerEntityName = if host != null && user != null then "${host.name}-home-${user.userName}" else entityName;
+      # Only set OS-level rekey from the host entity itself, not from user entities.
+      isHostEntity = user == null && host != null;
     in
     {
       homeManager =
@@ -68,25 +70,25 @@ in
             (inputs.agenix-rekey.homeManagerModules.default or { })
           ];
         }
-        // lib.optionalAttrs (homeManagerEntityName != null) {
-          age.rekey = rekey homeManagerEntityName pkgs;
-        };
+        // lib.optionalAttrs (homeManagerEntityName != null) { age.rekey = rekey homeManagerEntityName pkgs; };
     }
     // lib.optionalAttrs isHostEntity {
       darwin = { pkgs, ... }: {
-        age.rekey = rekey host.name pkgs;
         imports = [
           (inputs.ragenix.darwinModules.default or { })
           (inputs.agenix-rekey.darwinModules.default or { })
         ];
+
+        age.rekey = rekey host.name pkgs;
       };
 
       nixos = { pkgs, ... }: {
-        age.rekey = rekey host.name pkgs;
         imports = [
           (inputs.ragenix.nixosModules.default or { })
           (inputs.agenix-rekey.nixosModules.default or { })
         ];
+
+        age.rekey = rekey host.name pkgs;
       };
     };
 }

--- a/modules/aspects/my/secrets.nix
+++ b/modules/aspects/my/secrets.nix
@@ -1,17 +1,20 @@
 { inputs, lib, ... }:
 let
   rekey = name: pkgs: {
-    masterIdentities = [ ../../../secrets/yubikey-identity.pub ];
     agePlugins = [ pkgs.age-plugin-yubikey ];
-    storageMode = "local";
-    localStorageDir = ../../../. + "/secrets/rekeyed/${name}";
     generatedSecretsDir = ../../../secrets/generated;
+    localStorageDir = ../../../. + "/secrets/rekeyed/${name}";
+    masterIdentities = [ ../../../secrets/yubikey-identity.pub ];
+    storageMode = "local";
   };
 in
 {
   flake-file.inputs = {
+    agenix-rekey = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:oddlama/agenix-rekey";
+    };
     ragenix = {
-      url = "github:yaxitech/ragenix";
       inputs = {
         agenix.inputs = {
           darwin.follows = "darwin";
@@ -21,11 +24,7 @@ in
         };
         nixpkgs.follows = "nixpkgs";
       };
-    };
-
-    agenix-rekey = {
-      url = "github:oddlama/agenix-rekey";
-      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:yaxitech/ragenix";
     };
   };
 
@@ -34,8 +33,8 @@ in
     # this to avoid applying darwin/nixos age.rekey twice — once at host level
     # and again at the user level, which would cause a duplicate-definition error.
     {
-      host ? null,
       home ? null,
+      host ? null,
       user ? null,
       ...
     }:
@@ -57,7 +56,8 @@ in
       # whichever node ran last on a given `agenix rekey -a` pass would delete the other's exclusively-owned
       # secrets as "orphans". Giving the embedded user a separate sibling directory keeps each node's
       # cleanup pass scoped to only its own files.
-      homeManagerEntityName = if host != null && user != null then "${host.name}-home-${user.userName}" else entityName;
+      homeManagerEntityName =
+        if host != null && user != null then "${host.name}-home-${user.userName}" else entityName;
     in
     {
       homeManager =
@@ -68,25 +68,25 @@ in
             (inputs.agenix-rekey.homeManagerModules.default or { })
           ];
         }
-        // lib.optionalAttrs (homeManagerEntityName != null) { age.rekey = rekey homeManagerEntityName pkgs; };
+        // lib.optionalAttrs (homeManagerEntityName != null) {
+          age.rekey = rekey homeManagerEntityName pkgs;
+        };
     }
     // lib.optionalAttrs isHostEntity {
       darwin = { pkgs, ... }: {
+        age.rekey = rekey host.name pkgs;
         imports = [
           (inputs.ragenix.darwinModules.default or { })
           (inputs.agenix-rekey.darwinModules.default or { })
         ];
-
-        age.rekey = rekey host.name pkgs;
       };
 
       nixos = { pkgs, ... }: {
+        age.rekey = rekey host.name pkgs;
         imports = [
           (inputs.ragenix.nixosModules.default or { })
           (inputs.agenix-rekey.nixosModules.default or { })
         ];
-
-        age.rekey = rekey host.name pkgs;
       };
     };
 }

--- a/modules/aspects/my/seerr.nix
+++ b/modules/aspects/my/seerr.nix
@@ -1,7 +1,5 @@
 let
 
-  port = 5055;
-
   # Seerr has no released OIDC support yet (seerr-team/seerr#2715 is still open). Build from
   # michaelhthomas's PR branch until it lands in a release, then drop this override.
   oidcFork = {
@@ -10,6 +8,7 @@ let
     repo = "seerr";
     rev = "0078a482c9e2a1144069af5d196660e392940ea0";
   };
+  port = 5055;
 in
 {
   my.seerr =
@@ -25,34 +24,17 @@ in
           ...
         }:
         let
-          package = pkgs.seerr.overrideAttrs (old: rec {
-            pname = "seerr";
-            pnpmDeps = pkgs.fetchPnpmDeps {
-              inherit pname version src;
-              fetcherVersion = 3;
-              hash = "sha256-7nBkeXGJfDRSvNesOjOK+Mtzp6SlBvbytyfsQl9eh/Y=";
-              pnpm = pkgs.pnpm_10.override { nodejs-slim = pkgs.nodejs-slim_22; };
-            };
-            src = pkgs.fetchFromGitHub {
-              inherit (oidcFork)
-                owner
-                repo
-                rev
-                hash
-                ;
-            };
-            version = "unstable-2026-07-12";
-          });
-
           # Seerr's OIDC settings have no env-var equivalent yet — only settings.json. Merge our
           # provider config into it on every start, preserving whatever else is already there (the
           # app itself owns the rest of the file).
           configureOidc = pkgs.writeShellApplication {
             name = "seerr-configure-oidc";
+
             runtimeInputs = [
               pkgs.coreutils
               pkgs.jq
             ];
+
             text = ''
               settings="$CONFIG_DIRECTORY/settings.json"
               mkdir -p "$(dirname "$settings")"
@@ -80,10 +62,31 @@ in
               mv "$settings.tmp" "$settings"
             '';
           };
+          package = pkgs.seerr.overrideAttrs (old: rec {
+            pname = "seerr";
+
+            pnpmDeps = pkgs.fetchPnpmDeps {
+              inherit pname src version;
+              fetcherVersion = 3;
+              hash = "sha256-7nBkeXGJfDRSvNesOjOK+Mtzp6SlBvbytyfsQl9eh/Y=";
+              pnpm = pkgs.pnpm_10.override { nodejs-slim = pkgs.nodejs-slim_22; };
+            };
+
+            src = pkgs.fetchFromGitHub {
+              inherit (oidcFork)
+                hash
+                owner
+                repo
+                rev
+                ;
+            };
+
+            version = "unstable-2026-07-12";
+          });
         in
         {
           services.seerr = {
-            inherit port package;
+            inherit package port;
             enable = true;
           };
 
@@ -92,6 +95,7 @@ in
             LoadCredential = "oidc-client-secret:${config.age.secrets.seerr-oidc-client-secret.path}";
           };
         };
+
       # `settings.terraform = "variable";` feeds a Terraform `variable` (modules/terranix.nix's two
       # modes); also read directly below (LoadCredential) by `configureOidc`, so it's NOT
       # `intermediary` - it has to be materialized as a real host secret too.
@@ -101,22 +105,27 @@ in
           settings.terraform = "variable";
         };
       };
+
       virtual-host = {
-        inherit port global;
+        inherit global port;
         group = "Media";
+
         homepage = {
           description = "Media requests";
         };
+
         host = host.name;
         icon = "seerr.svg";
         label = "Seerr";
         name = "seerr";
+
         # Requests the matching OAuth2 Provider + Application from Authentik (authentik.nix) - see
         # virtual-host.nix's `oidc` field for the shape. Redirect paths per the OIDC setup docs for
         # this exact fork revision (docs/using-seerr/settings/users/oidc.md at `oidcFork.rev`
         # above).
         oidc = {
           client-secret = "seerr-oidc-client-secret";
+
           redirect-paths = [
             "/login"
             "/profile/settings/linked-accounts"

--- a/modules/aspects/my/seerr.nix
+++ b/modules/aspects/my/seerr.nix
@@ -5,10 +5,10 @@ let
   # Seerr has no released OIDC support yet (seerr-team/seerr#2715 is still open). Build from
   # michaelhthomas's PR branch until it lands in a release, then drop this override.
   oidcFork = {
+    hash = "sha256-JchL4DJk/DrveZthiawtNJW2tDtr66e3k+EaS+iPJp8=";
     owner = "michaelhthomas";
     repo = "seerr";
     rev = "0078a482c9e2a1144069af5d196660e392940ea0";
-    hash = "sha256-JchL4DJk/DrveZthiawtNJW2tDtr66e3k+EaS+iPJp8=";
   };
 in
 {
@@ -17,51 +17,22 @@ in
       global ? false,
     }:
     { host, ... }: {
-      virtual-host = {
-        name = "seerr";
-        host = host.name;
-        inherit port global;
-        # Requests the matching OAuth2 Provider + Application from Authentik (authentik.nix) - see
-        # virtual-host.nix's `oidc` field for the shape. Redirect paths per the OIDC setup docs for
-        # this exact fork revision (docs/using-seerr/settings/users/oidc.md at `oidcFork.rev`
-        # above).
-        oidc = {
-          redirect-paths = [
-            "/login"
-            "/profile/settings/linked-accounts"
-          ];
-          client-secret = "seerr-oidc-client-secret";
-        };
-        label = "Seerr";
-        icon = "seerr.svg";
-        group = "Media";
-        homepage = {
-          description = "Media requests";
-        };
-      };
-
-      # `settings.terraform = "variable";` feeds a Terraform `variable` (modules/terranix.nix's two
-      # modes); also read directly below (LoadCredential) by `configureOidc`, so it's NOT
-      # `intermediary` - it has to be materialized as a real host secret too.
-      secrets = {
-        seerr-oidc-client-secret = {
-          generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -hex 32";
-          settings.terraform = "variable";
-        };
-      };
-
       nixos =
         {
           config,
-          pkgs,
           lib,
+          pkgs,
           ...
         }:
         let
           package = pkgs.seerr.overrideAttrs (old: rec {
             pname = "seerr";
-            version = "unstable-2026-07-12";
-
+            pnpmDeps = pkgs.fetchPnpmDeps {
+              inherit pname version src;
+              fetcherVersion = 3;
+              hash = "sha256-7nBkeXGJfDRSvNesOjOK+Mtzp6SlBvbytyfsQl9eh/Y=";
+              pnpm = pkgs.pnpm_10.override { nodejs-slim = pkgs.nodejs-slim_22; };
+            };
             src = pkgs.fetchFromGitHub {
               inherit (oidcFork)
                 owner
@@ -70,13 +41,7 @@ in
                 hash
                 ;
             };
-
-            pnpmDeps = pkgs.fetchPnpmDeps {
-              inherit pname version src;
-              pnpm = pkgs.pnpm_10.override { nodejs-slim = pkgs.nodejs-slim_22; };
-              fetcherVersion = 3;
-              hash = "sha256-7nBkeXGJfDRSvNesOjOK+Mtzp6SlBvbytyfsQl9eh/Y=";
-            };
+            version = "unstable-2026-07-12";
           });
 
           # Seerr's OIDC settings have no env-var equivalent yet — only settings.json. Merge our
@@ -118,14 +83,45 @@ in
         in
         {
           services.seerr = {
-            enable = true;
             inherit port package;
+            enable = true;
           };
 
           systemd.services.seerr.serviceConfig = {
-            LoadCredential = "oidc-client-secret:${config.age.secrets.seerr-oidc-client-secret.path}";
             ExecStartPre = [ (lib.getExe configureOidc) ];
+            LoadCredential = "oidc-client-secret:${config.age.secrets.seerr-oidc-client-secret.path}";
           };
         };
+      # `settings.terraform = "variable";` feeds a Terraform `variable` (modules/terranix.nix's two
+      # modes); also read directly below (LoadCredential) by `configureOidc`, so it's NOT
+      # `intermediary` - it has to be materialized as a real host secret too.
+      secrets = {
+        seerr-oidc-client-secret = {
+          generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -hex 32";
+          settings.terraform = "variable";
+        };
+      };
+      virtual-host = {
+        inherit port global;
+        group = "Media";
+        homepage = {
+          description = "Media requests";
+        };
+        host = host.name;
+        icon = "seerr.svg";
+        label = "Seerr";
+        name = "seerr";
+        # Requests the matching OAuth2 Provider + Application from Authentik (authentik.nix) - see
+        # virtual-host.nix's `oidc` field for the shape. Redirect paths per the OIDC setup docs for
+        # this exact fork revision (docs/using-seerr/settings/users/oidc.md at `oidcFork.rev`
+        # above).
+        oidc = {
+          client-secret = "seerr-oidc-client-secret";
+          redirect-paths = [
+            "/login"
+            "/profile/settings/linked-accounts"
+          ];
+        };
+      };
     };
 }

--- a/modules/aspects/my/slack.nix
+++ b/modules/aspects/my/slack.nix
@@ -1,7 +1,6 @@
 { den, ... }: {
   my.slack = {
-    includes = [ (den._.unfree [ "slack" ]) ];
-
     homeManager = { pkgs, ... }: { home.packages = with pkgs; [ slack ]; };
+    includes = [ (den._.unfree [ "slack" ]) ];
   };
 }

--- a/modules/aspects/my/slack.nix
+++ b/modules/aspects/my/slack.nix
@@ -1,6 +1,6 @@
 { den, ... }: {
   my.slack = {
-    homeManager = { pkgs, ... }: { home.packages = with pkgs; [ slack ]; };
     includes = [ (den._.unfree [ "slack" ]) ];
+    homeManager = { pkgs, ... }: { home.packages = with pkgs; [ slack ]; };
   };
 }

--- a/modules/aspects/my/sonarr.nix
+++ b/modules/aspects/my/sonarr.nix
@@ -9,31 +9,22 @@
       port = 8989;
     in
     {
-      virtual-host = {
-        name = "sonarr";
-        host = host.name;
-        protected = true;
-        # Sonarr serves its REST API under /api; nginx.nix lets that through the Authentik
-        # forward-auth gate untouched since cross-seed/unpackerr call it directly with an API key,
-        # machine-to-machine, with no browser session to carry an Authentik cookie.
-        bypassAuthPaths = [ "^/api" ];
-        inherit port global;
-        label = "Sonarr";
-        icon = "sonarr.svg";
-        group = "Arr Stack";
-        homepage = {
-          description = "Show organizer/manager";
-          widget = {
-            type = "sonarr";
-            # Hit Sonarr directly rather than through nginx/Authentik, since Homepage's
-            # server-side widget fetch has no browser session to pass the forward-auth gate.
-            url = "http://127.0.0.1:${toString port}";
-            api-key = true;
-            enableQueue = true;
-          };
+      nixos = { config, ... }: {
+        services.sonarr = {
+          enable = true;
+          environmentFiles = [ config.age.secrets."sonarr.env".path ];
+          # Sonarr only reaches this vhost via nginx over loopback (its port isn't opened in the
+          # firewall), so every request it sees is "local" — this drops Sonarr's own login screen
+          # in favor of the Authentik forward-auth gate in front of it, rather than stacking both.
+          settings.auth.required = "DisabledForLocalAddresses";
         };
+        users.users = {
+          sonarr.extraGroups = [ "qbittorrent" ];
+        }
+        // (lib.genAttrs administrators (user: {
+          extraGroups = [ "sonarr" ];
+        }));
       };
-
       secrets = { secrets, ... }: {
         sonarr-api-key = {
           generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -hex 16";
@@ -44,9 +35,9 @@
           dependencies = { inherit (secrets) sonarr-api-key; };
           script =
             {
-              lib,
               decrypt,
               deps,
+              lib,
               ...
             }:
             ''
@@ -54,23 +45,29 @@
             '';
         };
       };
-
-      nixos = { config, ... }: {
-        users.users = {
-          sonarr.extraGroups = [ "qbittorrent" ];
-        }
-        // (lib.genAttrs administrators (user: {
-          extraGroups = [ "sonarr" ];
-        }));
-
-        services.sonarr = {
-          enable = true;
-          environmentFiles = [ config.age.secrets."sonarr.env".path ];
-          # Sonarr only reaches this vhost via nginx over loopback (its port isn't opened in the
-          # firewall), so every request it sees is "local" — this drops Sonarr's own login screen
-          # in favor of the Authentik forward-auth gate in front of it, rather than stacking both.
-          settings.auth.required = "DisabledForLocalAddresses";
+      virtual-host = {
+        inherit port global;
+        # Sonarr serves its REST API under /api; nginx.nix lets that through the Authentik
+        # forward-auth gate untouched since cross-seed/unpackerr call it directly with an API key,
+        # machine-to-machine, with no browser session to carry an Authentik cookie.
+        bypassAuthPaths = [ "^/api" ];
+        group = "Arr Stack";
+        homepage = {
+          description = "Show organizer/manager";
+          widget = {
+            api-key = true;
+            enableQueue = true;
+            type = "sonarr";
+            # Hit Sonarr directly rather than through nginx/Authentik, since Homepage's
+            # server-side widget fetch has no browser session to pass the forward-auth gate.
+            url = "http://127.0.0.1:${toString port}";
+          };
         };
+        host = host.name;
+        icon = "sonarr.svg";
+        label = "Sonarr";
+        name = "sonarr";
+        protected = true;
       };
     };
 }

--- a/modules/aspects/my/sonarr.nix
+++ b/modules/aspects/my/sonarr.nix
@@ -18,6 +18,7 @@
           # in favor of the Authentik forward-auth gate in front of it, rather than stacking both.
           settings.auth.required = "DisabledForLocalAddresses";
         };
+
         users.users = {
           sonarr.extraGroups = [ "qbittorrent" ];
         }
@@ -25,19 +26,22 @@
           extraGroups = [ "sonarr" ];
         }));
       };
+
       secrets = { secrets, ... }: {
         sonarr-api-key = {
           generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -hex 16";
           intermediary = true;
           settings.homepage = "sonarr";
         };
+
         "sonarr.env".generator = {
           dependencies = { inherit (secrets) sonarr-api-key; };
+
           script =
             {
+              lib,
               decrypt,
               deps,
-              lib,
               ...
             }:
             ''
@@ -45,15 +49,18 @@
             '';
         };
       };
+
       virtual-host = {
-        inherit port global;
+        inherit global port;
         # Sonarr serves its REST API under /api; nginx.nix lets that through the Authentik
         # forward-auth gate untouched since cross-seed/unpackerr call it directly with an API key,
         # machine-to-machine, with no browser session to carry an Authentik cookie.
         bypassAuthPaths = [ "^/api" ];
         group = "Arr Stack";
+
         homepage = {
           description = "Show organizer/manager";
+
           widget = {
             api-key = true;
             enableQueue = true;
@@ -63,6 +70,7 @@
             url = "http://127.0.0.1:${toString port}";
           };
         };
+
         host = host.name;
         icon = "sonarr.svg";
         label = "Sonarr";

--- a/modules/aspects/my/ssh-client.nix
+++ b/modules/aspects/my/ssh-client.nix
@@ -3,6 +3,7 @@
     programs.ssh = {
       enable = true;
       enableDefaultConfig = false;
+
       settings = {
         "*" = {
           AddKeysToAgent = "no";

--- a/modules/aspects/my/ssh-server.nix
+++ b/modules/aspects/my/ssh-server.nix
@@ -1,7 +1,6 @@
 {
   my.ssh-server.nixos = { pkgs, ... }: {
     environment.systemPackages = with pkgs; [ ghostty.terminfo ];
-
     programs.tmux.enable = true;
 
     services.openssh = {

--- a/modules/aspects/my/starship.nix
+++ b/modules/aspects/my/starship.nix
@@ -25,11 +25,6 @@ in
           enable = true;
           presets = [ "nerd-font-symbols" ];
           settings.custom.nix-config = {
-            description = "Shows the current nix config status";
-            shell = [ "${pkgs.bash}/bin/bash" ];
-            style = "bold blue";
-            ignore_timeout = true;
-            when = true;
             # Accumulate all applicable indicators into $symbols.
             # Both the dirty marker and the branch-status marker may appear
             # at the same time (e.g. uncommitted changes on a non-main rev).
@@ -64,7 +59,10 @@ in
                         status=$(cat "$cache_file")
                       else
                         github_token=${
-                          if tokenPath != null then ''"$(${pkgs.coreutils}/bin/cat ${tokenPath} 2>/dev/null || true)"'' else ''""''
+                          if tokenPath != null then
+                            ''"$(${pkgs.coreutils}/bin/cat ${tokenPath} 2>/dev/null || true)"''
+                          else
+                            ''""''
                         }
                         status=$(
                           retries=2
@@ -109,6 +107,11 @@ in
                   echo "$symbols"
                 fi
               '';
+            description = "Shows the current nix config status";
+            ignore_timeout = true;
+            shell = [ "${pkgs.bash}/bin/bash" ];
+            style = "bold blue";
+            when = true;
           };
         };
       };

--- a/modules/aspects/my/starship.nix
+++ b/modules/aspects/my/starship.nix
@@ -3,48 +3,28 @@ let
   isDirty = self ? dirtyRev;
   # Extract the base commit SHA: self.rev when clean, or strip the "-dirty" suffix
   # from self.dirtyRev (available in Nix >= 2.11) when dirty.
-  rev =
-    if self ? rev then
-      self.rev
-    else if self ? dirtyRev then
-      builtins.substring 0 40 self.dirtyRev
-    else
-      null;
+  rev = self.rev or (if self ? dirtyRev then builtins.substring 0 40 self.dirtyRev else null);
 in
 {
   my.starship = {
     homeManager =
       {
         config,
-        osConfig ? { },
         pkgs,
+        osConfig ? { },
         ...
       }:
       {
         programs.starship = {
           enable = true;
           presets = [ "nerd-font-symbols" ];
+
           settings.custom.nix-config = {
             # Accumulate all applicable indicators into $symbols.
             # Both the dirty marker and the branch-status marker may appear
             # at the same time (e.g. uncommitted changes on a non-main rev).
             command =
               let
-                dirtyPart = if isDirty then ''symbols="''${symbols}!"'' else "";
-                # Reuse the token already provisioned for authenticated Nix
-                # flake fetches (modules/aspects/my/nix.nix) instead of
-                # provisioning a second GitHub PAT just for this rate-limit
-                # workaround.
-                #
-                # On host-embedded users (melaan/harmony/the MacBook), my.nix's
-                # secret lives in the system (osConfig), not this home-manager
-                # config; on a standalone home (dev203) it lives in this config
-                # directly and osConfig is empty. Check both.
-                tokenPath =
-                  let
-                    osPath = osConfig.age.secrets.nix-github-access-token.path or null;
-                  in
-                  if osPath != null then osPath else config.age.secrets.nix-github-access-token.path or null;
                 apiPart =
                   if rev != null then
                     ''
@@ -59,10 +39,7 @@ in
                         status=$(cat "$cache_file")
                       else
                         github_token=${
-                          if tokenPath != null then
-                            ''"$(${pkgs.coreutils}/bin/cat ${tokenPath} 2>/dev/null || true)"''
-                          else
-                            ''""''
+                          if tokenPath != null then ''"$(${pkgs.coreutils}/bin/cat ${tokenPath} 2>/dev/null || true)"'' else ''""''
                         }
                         status=$(
                           retries=2
@@ -98,6 +75,21 @@ in
                     ''
                   else
                     "";
+                dirtyPart = if isDirty then ''symbols="''${symbols}!"'' else "";
+                # Reuse the token already provisioned for authenticated Nix
+                # flake fetches (modules/aspects/my/nix.nix) instead of
+                # provisioning a second GitHub PAT just for this rate-limit
+                # workaround.
+                #
+                # On host-embedded users (melaan/harmony/the MacBook), my.nix's
+                # secret lives in the system (osConfig), not this home-manager
+                # config; on a standalone home (dev203) it lives in this config
+                # directly and osConfig is empty. Check both.
+                tokenPath =
+                  let
+                    osPath = osConfig.age.secrets.nix-github-access-token.path or null;
+                  in
+                  if osPath != null then osPath else config.age.secrets.nix-github-access-token.path or null;
               in
               ''
                 symbols=""
@@ -107,6 +99,7 @@ in
                   echo "$symbols"
                 fi
               '';
+
             description = "Shows the current nix config status";
             ignore_timeout = true;
             shell = [ "${pkgs.bash}/bin/bash" ];

--- a/modules/aspects/my/steam.nix
+++ b/modules/aspects/my/steam.nix
@@ -1,13 +1,12 @@
 { den, ... }: {
   my.steam = {
+    darwin.homebrew.casks = [ "steam" ];
     includes = [
       (den._.unfree [
         "steam"
         "steam-unwrapped"
       ])
     ];
-
-    darwin.homebrew.casks = [ "steam" ];
     nixos.programs.steam.enable = true;
   };
 }

--- a/modules/aspects/my/steam.nix
+++ b/modules/aspects/my/steam.nix
@@ -1,12 +1,13 @@
 { den, ... }: {
   my.steam = {
-    darwin.homebrew.casks = [ "steam" ];
     includes = [
       (den._.unfree [
         "steam"
         "steam-unwrapped"
       ])
     ];
+
+    darwin.homebrew.casks = [ "steam" ];
     nixos.programs.steam.enable = true;
   };
 }

--- a/modules/aspects/my/storyteller.nix
+++ b/modules/aspects/my/storyteller.nix
@@ -21,14 +21,75 @@ in
     in
     {
       dataset = {
+        name = "storyteller";
         pool = "metalminds";
-        name = "storyteller";
       };
-
+      nixos = { config, ... }: {
+        virtualisation.oci-containers.containers.storyteller = {
+          environment = {
+            # Storyteller's Auth.js base URL: its own origin plus Auth.js's `basePath`. Required for
+            # OAuth/OIDC login, and what its session cookie's `Domain` is pinned to - see `url`
+            # above for why that forces a single canonical hostname.
+            AUTH_URL = "https://${url}/api/v2/auth";
+            ENABLE_WEB_READER = "true";
+          };
+          environmentFiles = [ config.age.secrets."storyteller.env".path ];
+          # Pinned to the current `latest` tag's digest at the time this was written --
+          # storyteller-platform doesn't cut stable releases, so there's nothing more specific to
+          # pin to. Re-resolve via the GitLab registry API if bumping:
+          #   curl -s "https://gitlab.com/api/v4/projects/67994333/registry/repositories/8429296/tags/latest"
+          image = "registry.gitlab.com/storyteller-platform/storyteller@sha256:a15609ec102de6aace73b5aae3794f7f8e9f40ed3ac2f57e923ef72daa505668";
+          ports =
+            let
+              port' = toString port;
+            in
+            [ "127.0.0.1:${port'}:${port'}" ];
+          volumes = [ "/metalminds/storyteller:/data" ];
+        };
+      };
+      secrets = { secrets, ... }: {
+        # `intermediary` (unlike immich/nextcloud/seerr's equivalents, which are NOT) - Storyteller
+        # keeps its OIDC provider config in its own settings DATABASE, entered through the settings
+        # UI, with no env-var or config-file equivalent to point at a decrypted secret. So nothing
+        # on the host ever reads this; it exists only to feed Authentik's side via a Terraform
+        # `variable` (modules/terranix.nix's two modes), and gets typed into Storyteller by hand -
+        # read it back with `agenix view secrets/generated/storyteller-oidc-client-secret.age`.
+        storyteller-oidc-client-secret = {
+          generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -hex 32";
+          intermediary = true;
+          settings.terraform = "variable";
+        };
+        storyteller-secret-key = {
+          generator.script = "alnum";
+          intermediary = true;
+        };
+        "storyteller.env".generator = {
+          dependencies = { inherit (secrets) storyteller-secret-key; };
+          script =
+            {
+              decrypt,
+              deps,
+              lib,
+              ...
+            }:
+            ''
+              printf 'STORYTELLER_SECRET_KEY="%s"\n' "$(
+                ${decrypt} ${lib.escapeShellArg deps.storyteller-secret-key.file}
+              )"
+            '';
+        };
+      };
       virtual-host = {
-        name = "storyteller";
-        host = host.name;
         inherit port global url;
+        group = "Media";
+        homepage = {
+          description = "Read-aloud book alignment";
+        };
+        host = host.name;
+        # No dashboard-icons entry for this app - its own upstream logo instead.
+        icon = "https://gitlab.com/storyteller-platform/storyteller/-/raw/main/applications/docs/static/img/Storyteller_Logo.png";
+        label = "Storyteller";
+        name = "storyteller";
         # Deliberately NOT `protected`: Storyteller does its own OIDC login against Authentik via
         # the `oidc` field below, so forward-auth on top would mean logging in twice (once at the
         # outpost, again at Storyteller's own login page) and would break its mobile/OPDS clients,
@@ -41,72 +102,8 @@ in
         # (`customProviderId`, same file) - so the name MUST be entered as "Authentik" in
         # Storyteller's settings for this registered URI to match.
         oidc = {
-          redirect-paths = [ "/api/v2/auth/callback/authentik" ];
           client-secret = "storyteller-oidc-client-secret";
-        };
-        label = "Storyteller";
-        # No dashboard-icons entry for this app - its own upstream logo instead.
-        icon = "https://gitlab.com/storyteller-platform/storyteller/-/raw/main/applications/docs/static/img/Storyteller_Logo.png";
-        group = "Media";
-        homepage = {
-          description = "Read-aloud book alignment";
-        };
-      };
-
-      secrets = { secrets, ... }: {
-        storyteller-secret-key = {
-          generator.script = "alnum";
-          intermediary = true;
-        };
-        # `intermediary` (unlike immich/nextcloud/seerr's equivalents, which are NOT) - Storyteller
-        # keeps its OIDC provider config in its own settings DATABASE, entered through the settings
-        # UI, with no env-var or config-file equivalent to point at a decrypted secret. So nothing
-        # on the host ever reads this; it exists only to feed Authentik's side via a Terraform
-        # `variable` (modules/terranix.nix's two modes), and gets typed into Storyteller by hand -
-        # read it back with `agenix view secrets/generated/storyteller-oidc-client-secret.age`.
-        storyteller-oidc-client-secret = {
-          generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -hex 32";
-          intermediary = true;
-          settings.terraform = "variable";
-        };
-        "storyteller.env".generator = {
-          dependencies = { inherit (secrets) storyteller-secret-key; };
-          script =
-            {
-              lib,
-              decrypt,
-              deps,
-              ...
-            }:
-            ''
-              printf 'STORYTELLER_SECRET_KEY="%s"\n' "$(
-                ${decrypt} ${lib.escapeShellArg deps.storyteller-secret-key.file}
-              )"
-            '';
-        };
-      };
-
-      nixos = { config, ... }: {
-        virtualisation.oci-containers.containers.storyteller = {
-          # Pinned to the current `latest` tag's digest at the time this was written --
-          # storyteller-platform doesn't cut stable releases, so there's nothing more specific to
-          # pin to. Re-resolve via the GitLab registry API if bumping:
-          #   curl -s "https://gitlab.com/api/v4/projects/67994333/registry/repositories/8429296/tags/latest"
-          image = "registry.gitlab.com/storyteller-platform/storyteller@sha256:a15609ec102de6aace73b5aae3794f7f8e9f40ed3ac2f57e923ef72daa505668";
-          ports =
-            let
-              port' = toString port;
-            in
-            [ "127.0.0.1:${port'}:${port'}" ];
-          volumes = [ "/metalminds/storyteller:/data" ];
-          environment = {
-            ENABLE_WEB_READER = "true";
-            # Storyteller's Auth.js base URL: its own origin plus Auth.js's `basePath`. Required for
-            # OAuth/OIDC login, and what its session cookie's `Domain` is pinned to - see `url`
-            # above for why that forces a single canonical hostname.
-            AUTH_URL = "https://${url}/api/v2/auth";
-          };
-          environmentFiles = [ config.age.secrets."storyteller.env".path ];
+          redirect-paths = [ "/api/v2/auth/callback/authentik" ];
         };
       };
     };

--- a/modules/aspects/my/storyteller.nix
+++ b/modules/aspects/my/storyteller.nix
@@ -24,6 +24,7 @@ in
         name = "storyteller";
         pool = "metalminds";
       };
+
       nixos = { config, ... }: {
         virtualisation.oci-containers.containers.storyteller = {
           environment = {
@@ -33,20 +34,24 @@ in
             AUTH_URL = "https://${url}/api/v2/auth";
             ENABLE_WEB_READER = "true";
           };
+
           environmentFiles = [ config.age.secrets."storyteller.env".path ];
           # Pinned to the current `latest` tag's digest at the time this was written --
           # storyteller-platform doesn't cut stable releases, so there's nothing more specific to
           # pin to. Re-resolve via the GitLab registry API if bumping:
           #   curl -s "https://gitlab.com/api/v4/projects/67994333/registry/repositories/8429296/tags/latest"
           image = "registry.gitlab.com/storyteller-platform/storyteller@sha256:a15609ec102de6aace73b5aae3794f7f8e9f40ed3ac2f57e923ef72daa505668";
+
           ports =
             let
               port' = toString port;
             in
             [ "127.0.0.1:${port'}:${port'}" ];
+
           volumes = [ "/metalminds/storyteller:/data" ];
         };
       };
+
       secrets = { secrets, ... }: {
         # `intermediary` (unlike immich/nextcloud/seerr's equivalents, which are NOT) - Storyteller
         # keeps its OIDC provider config in its own settings DATABASE, entered through the settings
@@ -59,17 +64,20 @@ in
           intermediary = true;
           settings.terraform = "variable";
         };
+
         storyteller-secret-key = {
           generator.script = "alnum";
           intermediary = true;
         };
+
         "storyteller.env".generator = {
           dependencies = { inherit (secrets) storyteller-secret-key; };
+
           script =
             {
+              lib,
               decrypt,
               deps,
-              lib,
               ...
             }:
             ''
@@ -79,17 +87,21 @@ in
             '';
         };
       };
+
       virtual-host = {
-        inherit port global url;
+        inherit global port url;
         group = "Media";
+
         homepage = {
           description = "Read-aloud book alignment";
         };
+
         host = host.name;
         # No dashboard-icons entry for this app - its own upstream logo instead.
         icon = "https://gitlab.com/storyteller-platform/storyteller/-/raw/main/applications/docs/static/img/Storyteller_Logo.png";
         label = "Storyteller";
         name = "storyteller";
+
         # Deliberately NOT `protected`: Storyteller does its own OIDC login against Authentik via
         # the `oidc` field below, so forward-auth on top would mean logging in twice (once at the
         # outpost, again at Storyteller's own login page) and would break its mobile/OPDS clients,

--- a/modules/aspects/my/stylix.nix
+++ b/modules/aspects/my/stylix.nix
@@ -1,18 +1,19 @@
 { inputs, ... }: {
   flake-file.inputs.stylix = {
-    url = "github:nix-community/stylix";
     inputs.nixpkgs.follows = "nixpkgs";
+    url = "github:nix-community/stylix";
   };
 
   my.stylix = {
     darwin.imports = [ (inputs.stylix.darwinModules.stylix or { }) ];
-    homeManager = { home, ... }: builtins.seq home { imports = [ (inputs.stylix.homeModules.stylix or { }) ]; };
+    homeManager =
+      { home, ... }: builtins.seq home { imports = [ (inputs.stylix.homeModules.stylix or { }) ]; };
     nixos.imports = [ (inputs.stylix.nixosModules.stylix or { }) ];
 
     os = { pkgs, ... }: {
       stylix = {
-        enable = true;
         base16Scheme = "${pkgs.base16-schemes}/share/themes/catppuccin-mocha.yaml";
+        enable = true;
         opacity = {
           applications = 0.95;
           popups = 0.95;

--- a/modules/aspects/my/stylix.nix
+++ b/modules/aspects/my/stylix.nix
@@ -1,19 +1,19 @@
 { inputs, ... }: {
   flake-file.inputs.stylix = {
-    inputs.nixpkgs.follows = "nixpkgs";
     url = "github:nix-community/stylix";
+    inputs.nixpkgs.follows = "nixpkgs";
   };
 
   my.stylix = {
     darwin.imports = [ (inputs.stylix.darwinModules.stylix or { }) ];
-    homeManager =
-      { home, ... }: builtins.seq home { imports = [ (inputs.stylix.homeModules.stylix or { }) ]; };
+    homeManager = { home, ... }: builtins.seq home { imports = [ (inputs.stylix.homeModules.stylix or { }) ]; };
     nixos.imports = [ (inputs.stylix.nixosModules.stylix or { }) ];
 
     os = { pkgs, ... }: {
       stylix = {
-        base16Scheme = "${pkgs.base16-schemes}/share/themes/catppuccin-mocha.yaml";
         enable = true;
+        base16Scheme = "${pkgs.base16-schemes}/share/themes/catppuccin-mocha.yaml";
+
         opacity = {
           applications = 0.95;
           popups = 0.95;

--- a/modules/aspects/my/tautulli.nix
+++ b/modules/aspects/my/tautulli.nix
@@ -7,24 +7,23 @@ in
       global ? false,
     }:
     { host, ... }: {
+      nixos = {
+        services.tautulli = {
+          inherit port;
+          enable = true;
+        };
+      };
       virtual-host = {
-        name = "tautulli";
-        host = host.name;
-        protected = true;
         inherit port global;
-        label = "Tautulli";
-        icon = "tautulli.svg";
         group = "Infra";
         homepage = {
           description = "Plex monitoring & stats";
         };
-      };
-
-      nixos = {
-        services.tautulli = {
-          enable = true;
-          inherit port;
-        };
+        host = host.name;
+        icon = "tautulli.svg";
+        label = "Tautulli";
+        name = "tautulli";
+        protected = true;
       };
     };
 }

--- a/modules/aspects/my/tautulli.nix
+++ b/modules/aspects/my/tautulli.nix
@@ -13,12 +13,15 @@ in
           enable = true;
         };
       };
+
       virtual-host = {
-        inherit port global;
+        inherit global port;
         group = "Infra";
+
         homepage = {
           description = "Plex monitoring & stats";
         };
+
         host = host.name;
         icon = "tautulli.svg";
         label = "Tautulli";

--- a/modules/aspects/my/unpackerr.nix
+++ b/modules/aspects/my/unpackerr.nix
@@ -9,8 +9,10 @@
       }:
       {
         systemd.services.unpackerr = {
-          after = [ "network-online.target" ];
           description = "Unpackerr daemon";
+          wantedBy = [ "multi-user.target" ];
+          after = [ "network-online.target" ];
+
           serviceConfig = {
             Environment = [
               "UN_SONARR_0_URL=https://sonarr.harmony.silverlight-nex.us"
@@ -18,6 +20,7 @@
               "UN_RADARR_0_URL=https://radarr.harmony.silverlight-nex.us"
               "UN_RADARR_0_PATHS_0=/metalminds/torrents/downloads"
             ];
+
             EnvironmentFile = config.age.secrets."unpackerr.env".path;
             ExecStart = lib.getExe pkgs.unpackerr;
             Group = "qbittorrent";
@@ -26,18 +29,20 @@
             Type = "simple";
             User = "qbittorrent";
           };
-          wantedBy = [ "multi-user.target" ];
+
           wants = [ "network-online.target" ];
         };
       };
+
     secrets = { secrets, ... }: {
       "unpackerr.env".generator = {
         dependencies = { inherit (secrets) radarr-api-key sonarr-api-key; };
+
         script =
           {
+            lib,
             decrypt,
             deps,
-            lib,
             ...
           }:
           ''

--- a/modules/aspects/my/unpackerr.nix
+++ b/modules/aspects/my/unpackerr.nix
@@ -1,22 +1,5 @@
 {
   my.unpackerr = {
-    secrets = { secrets, ... }: {
-      "unpackerr.env".generator = {
-        dependencies = { inherit (secrets) radarr-api-key sonarr-api-key; };
-        script =
-          {
-            lib,
-            decrypt,
-            deps,
-            ...
-          }:
-          ''
-            printf 'UN_RADARR_0_API_KEY="%s"\n' "$(${decrypt} ${lib.escapeShellArg deps."radarr-api-key".file})"
-            printf 'UN_SONARR_0_API_KEY="%s"\n' "$(${decrypt} ${lib.escapeShellArg deps."sonarr-api-key".file})"
-          '';
-      };
-    };
-
     nixos =
       {
         config,
@@ -26,26 +9,42 @@
       }:
       {
         systemd.services.unpackerr = {
-          description = "Unpackerr daemon";
           after = [ "network-online.target" ];
-          wants = [ "network-online.target" ];
-          wantedBy = [ "multi-user.target" ];
+          description = "Unpackerr daemon";
           serviceConfig = {
-            Type = "simple";
-            User = "qbittorrent";
-            Group = "qbittorrent";
-            EnvironmentFile = config.age.secrets."unpackerr.env".path;
             Environment = [
               "UN_SONARR_0_URL=https://sonarr.harmony.silverlight-nex.us"
               "UN_SONARR_0_PATHS_0=/metalminds/torrents/downloads"
               "UN_RADARR_0_URL=https://radarr.harmony.silverlight-nex.us"
               "UN_RADARR_0_PATHS_0=/metalminds/torrents/downloads"
             ];
+            EnvironmentFile = config.age.secrets."unpackerr.env".path;
             ExecStart = lib.getExe pkgs.unpackerr;
+            Group = "qbittorrent";
             Restart = "always";
             RestartSec = "5s";
+            Type = "simple";
+            User = "qbittorrent";
           };
+          wantedBy = [ "multi-user.target" ];
+          wants = [ "network-online.target" ];
         };
       };
+    secrets = { secrets, ... }: {
+      "unpackerr.env".generator = {
+        dependencies = { inherit (secrets) radarr-api-key sonarr-api-key; };
+        script =
+          {
+            decrypt,
+            deps,
+            lib,
+            ...
+          }:
+          ''
+            printf 'UN_RADARR_0_API_KEY="%s"\n' "$(${decrypt} ${lib.escapeShellArg deps."radarr-api-key".file})"
+            printf 'UN_SONARR_0_API_KEY="%s"\n' "$(${decrypt} ${lib.escapeShellArg deps."sonarr-api-key".file})"
+          '';
+      };
+    };
   };
 }

--- a/modules/aspects/my/vm-bootable.nix
+++ b/modules/aspects/my/vm-bootable.nix
@@ -1,12 +1,14 @@
 let
   installer = variant: {
-    nixos = { modulesPath, ... }: { imports = [ (modulesPath + "/installer/cd-dvd/installation-cd-${variant}.nix") ]; };
+    nixos = { modulesPath, ... }: {
+      imports = [ (modulesPath + "/installer/cd-dvd/installation-cd-${variant}.nix") ];
+    };
   };
 in
 {
   # make USB/VM installers.
   my.vm-bootable.provides = {
-    tui = installer "minimal";
     gui = installer "graphical-base";
+    tui = installer "minimal";
   };
 }

--- a/modules/aspects/my/vm-bootable.nix
+++ b/modules/aspects/my/vm-bootable.nix
@@ -1,8 +1,6 @@
 let
   installer = variant: {
-    nixos = { modulesPath, ... }: {
-      imports = [ (modulesPath + "/installer/cd-dvd/installation-cd-${variant}.nix") ];
-    };
+    nixos = { modulesPath, ... }: { imports = [ (modulesPath + "/installer/cd-dvd/installation-cd-${variant}.nix") ]; };
   };
 in
 {

--- a/modules/aspects/my/xfce-desktop.nix
+++ b/modules/aspects/my/xfce-desktop.nix
@@ -2,16 +2,15 @@
   my.xfce-desktop.nixos = { lib, ... }: {
     # https://gist.github.com/nat-418/1101881371c9a7b419ba5f944a7118b0
     services = {
-      xserver = {
-        enable = true;
-        desktopManager = {
-          xterm.enable = false;
-          xfce.enable = true;
-        };
-      };
-
       displayManager = {
         defaultSession = lib.mkDefault "xfce";
+        enable = true;
+      };
+      xserver = {
+        desktopManager = {
+          xfce.enable = true;
+          xterm.enable = false;
+        };
         enable = true;
       };
     };

--- a/modules/aspects/my/xfce-desktop.nix
+++ b/modules/aspects/my/xfce-desktop.nix
@@ -3,15 +3,17 @@
     # https://gist.github.com/nat-418/1101881371c9a7b419ba5f944a7118b0
     services = {
       displayManager = {
-        defaultSession = lib.mkDefault "xfce";
         enable = true;
+        defaultSession = lib.mkDefault "xfce";
       };
+
       xserver = {
+        enable = true;
+
         desktopManager = {
           xfce.enable = true;
           xterm.enable = false;
         };
-        enable = true;
       };
     };
   };

--- a/modules/aspects/my/zen-browser.nix
+++ b/modules/aspects/my/zen-browser.nix
@@ -2,11 +2,11 @@
 
 {
   flake-file.inputs.zen-browser = {
-    url = "github:0xc000022070/zen-browser-flake";
     inputs = {
       home-manager.follows = "home-manager";
       nixpkgs.follows = "nixpkgs";
     };
+    url = "github:0xc000022070/zen-browser-flake";
   };
 
   my.zen-browser.homeManager = {

--- a/modules/aspects/my/zen-browser.nix
+++ b/modules/aspects/my/zen-browser.nix
@@ -2,16 +2,16 @@
 
 {
   flake-file.inputs.zen-browser = {
+    url = "github:0xc000022070/zen-browser-flake";
+
     inputs = {
       home-manager.follows = "home-manager";
       nixpkgs.follows = "nixpkgs";
     };
-    url = "github:0xc000022070/zen-browser-flake";
   };
 
   my.zen-browser.homeManager = {
     imports = [ (inputs.zen-browser.homeModules.twilight or { }) ];
-
     programs.zen-browser.enable = true;
   };
 }

--- a/modules/aspects/my/zfs.nix
+++ b/modules/aspects/my/zfs.nix
@@ -14,20 +14,23 @@
           name: kernelPackages:
           (builtins.match "linux_[0-9]+_[0-9]+" name) != null
           && (builtins.tryEval kernelPackages).success
-          && (builtins.tryEval (!kernelPackages.${defaultZfsPackage.kernelModuleAttribute}.meta.broken)).value or false
+          && (builtins.tryEval (!kernelPackages.${defaultZfsPackage.kernelModuleAttribute}.meta.broken)).value
+            or false
         ) pkgs.linuxKernel.packages;
 
         # Select the latest compatible kernel version
         latestKernelPackage = lib.last (
-          lib.sort (a: b: (lib.versionOlder a.kernel.version b.kernel.version)) (builtins.attrValues zfsCompatibleKernelPackages)
+          lib.sort (a: b: (lib.versionOlder a.kernel.version b.kernel.version)) (
+            builtins.attrValues zfsCompatibleKernelPackages
+          )
         );
       in
       {
         boot = {
-          supportedFilesystems = [ "zfs" ];
           # Use latest ZFS-compatible kernel instead of absolute latest
           # Note: this might jump back and forth as kernels are added or removed
           kernelPackages = latestKernelPackage;
+          supportedFilesystems = [ "zfs" ];
           zfs = {
             extraPools = pools;
             forceImportRoot = false;

--- a/modules/aspects/my/zfs.nix
+++ b/modules/aspects/my/zfs.nix
@@ -8,22 +8,17 @@
         # Use the default ZFS package for compatibility checking to avoid infinite recursion
         # We can't use config.boot.zfs.package here because it depends on kernelPackages which we're trying to determine
         defaultZfsPackage = pkgs.zfs;
-
+        # Select the latest compatible kernel version
+        latestKernelPackage = lib.last (
+          lib.sort (a: b: (lib.versionOlder a.kernel.version b.kernel.version)) (builtins.attrValues zfsCompatibleKernelPackages)
+        );
         # Find all ZFS-compatible kernel packages
         zfsCompatibleKernelPackages = lib.filterAttrs (
           name: kernelPackages:
           (builtins.match "linux_[0-9]+_[0-9]+" name) != null
           && (builtins.tryEval kernelPackages).success
-          && (builtins.tryEval (!kernelPackages.${defaultZfsPackage.kernelModuleAttribute}.meta.broken)).value
-            or false
+          && (builtins.tryEval (!kernelPackages.${defaultZfsPackage.kernelModuleAttribute}.meta.broken)).value or false
         ) pkgs.linuxKernel.packages;
-
-        # Select the latest compatible kernel version
-        latestKernelPackage = lib.last (
-          lib.sort (a: b: (lib.versionOlder a.kernel.version b.kernel.version)) (
-            builtins.attrValues zfsCompatibleKernelPackages
-          )
-        );
       in
       {
         boot = {
@@ -31,6 +26,7 @@
           # Note: this might jump back and forth as kernels are added or removed
           kernelPackages = latestKernelPackage;
           supportedFilesystems = [ "zfs" ];
+
           zfs = {
             extraPools = pools;
             forceImportRoot = false;

--- a/modules/aspects/my/zoom.nix
+++ b/modules/aspects/my/zoom.nix
@@ -1,6 +1,6 @@
 { den, ... }: {
   my.zoom = {
-    homeManager = { pkgs, ... }: { home.packages = [ pkgs.zoom-us ]; };
     includes = [ (den._.unfree [ "zoom" ]) ];
+    homeManager = { pkgs, ... }: { home.packages = [ pkgs.zoom-us ]; };
   };
 }

--- a/modules/aspects/my/zoom.nix
+++ b/modules/aspects/my/zoom.nix
@@ -1,7 +1,6 @@
 { den, ... }: {
   my.zoom = {
-    includes = [ (den._.unfree [ "zoom" ]) ];
-
     homeManager = { pkgs, ... }: { home.packages = [ pkgs.zoom-us ]; };
+    includes = [ (den._.unfree [ "zoom" ]) ];
   };
 }

--- a/modules/aspects/users/adelline/adelline.nix
+++ b/modules/aspects/users/adelline/adelline.nix
@@ -1,5 +1,21 @@
 { den, my, ... }: {
   den.aspects.adelline = {
+    includes = [
+      (den._.user-shell "fish")
+      ({ user, ... }: {
+        nixos.users.users.${user.userName}.hashedPassword =
+          "$y$j9T$PIOU1O0/eDXQdlTWkzuf5.$AhnTDMJLgzM04nt6pzz/ae.3U.3LUWhte6PiBw.Mzb2";
+      })
+      den._.primary-user
+      my.chrome
+      my.discord
+      my.fish
+      my.ghostty
+      my.steam
+      my.zen-browser
+      my.zoom
+    ];
+
     homeManager = { pkgs, ... }: {
       dconf.settings = {
         "org/gnome/desktop/screensaver".lock-enabled = false;
@@ -19,21 +35,7 @@
         git.enable = true;
       };
     };
-    includes = [
-      den._.primary-user
-      (den._.user-shell "fish")
-      my.discord
-      my.chrome
-      my.fish
-      my.ghostty
-      my.steam
-      my.zoom
-      my.zen-browser
-      ({ user, ... }: {
-        nixos.users.users.${user.userName}.hashedPassword =
-          "$y$j9T$PIOU1O0/eDXQdlTWkzuf5.$AhnTDMJLgzM04nt6pzz/ae.3U.3LUWhte6PiBw.Mzb2";
-      })
-    ];
+
     user.description = "Adelline Marshall";
   };
 }

--- a/modules/aspects/users/adelline/adelline.nix
+++ b/modules/aspects/users/adelline/adelline.nix
@@ -1,23 +1,5 @@
 { den, my, ... }: {
   den.aspects.adelline = {
-    includes = [
-      den._.primary-user
-      (den._.user-shell "fish")
-      my.discord
-      my.chrome
-      my.fish
-      my.ghostty
-      my.steam
-      my.zoom
-      my.zen-browser
-      ({ user, ... }: {
-        nixos.users.users.${user.userName}.hashedPassword =
-          "$y$j9T$PIOU1O0/eDXQdlTWkzuf5.$AhnTDMJLgzM04nt6pzz/ae.3U.3LUWhte6PiBw.Mzb2";
-      })
-    ];
-
-    user.description = "Adelline Marshall";
-
     homeManager = { pkgs, ... }: {
       dconf.settings = {
         "org/gnome/desktop/screensaver".lock-enabled = false;
@@ -37,5 +19,21 @@
         git.enable = true;
       };
     };
+    includes = [
+      den._.primary-user
+      (den._.user-shell "fish")
+      my.discord
+      my.chrome
+      my.fish
+      my.ghostty
+      my.steam
+      my.zoom
+      my.zen-browser
+      ({ user, ... }: {
+        nixos.users.users.${user.userName}.hashedPassword =
+          "$y$j9T$PIOU1O0/eDXQdlTWkzuf5.$AhnTDMJLgzM04nt6pzz/ae.3U.3LUWhte6PiBw.Mzb2";
+      })
+    ];
+    user.description = "Adelline Marshall";
   };
 }

--- a/modules/aspects/users/oscar/minecraft-servers.nix
+++ b/modules/aspects/users/oscar/minecraft-servers.nix
@@ -3,25 +3,30 @@ let
   worlds = {
     chicken-house = {
       port = 25566;
+
       server = pkgs: {
         enable = true;
         package = pkgs.fabricServers.fabric-1_21_8;
+
         serverProperties = {
           enable-rcon = true;
           "rcon.password" = "@RCON_PASSWORD@";
           "rcon.port" = 25576;
           white-list = true;
         };
+
         symlinks.mods = pkgs.linkFarmFromDrvs "mods" (
           builtins.attrValues {
             ArchitecturyAPI = pkgs.fetchurl {
               sha256 = "sha256-tdBR+O/+j5R2+TdeEeSN+vuCF5FDW4/jaIaZADl/BdU=";
               url = "https://cdn.modrinth.com/data/lhGA9TYQ/versions/XcJm5LH4/architectury-17.0.8-fabric.jar";
             };
+
             AutoWhitelist = pkgs.fetchurl {
               sha256 = "sha256-cYTNxZEGfyUVAkSeFk8Ci3FbcpJOmgeSXqE++NB9BYM=";
               url = "https://cdn.modrinth.com/data/BMaqFQAd/versions/PIJ4HDyR/autowhitelist-1.2.4%2B1.21.6.jar";
             };
+
             # Carpet = pkgs.fetchurl {
             #   url = "https://cdn.modrinth.com/data/TQTTVgYE/versions/xksYKkvF/fabric-carpet-1.20.2-1.4.121%2Bv231011.jar";
             #   sha256 = "sha256-qGprKkfOVzmNVH/nzOCRC569Q3w7GdxyD6PAoQtji+w=";
@@ -30,26 +35,32 @@ let
               sha256 = "sha256-2KbcqdDa0f5EYio8agNIZBk045Q8jUJaJvESvObev6I=";
               url = "https://cdn.modrinth.com/data/9s6osm5g/versions/cz0b1j8R/cloth-config-19.0.147-fabric.jar";
             };
+
             FabricAPI = pkgs.fetchurl {
               sha256 = "sha256-t2MBX17VRswnCzHspYKty6JkzWKJ5FFF2fU0jGD9olk=";
               url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/jjBL6OsN/fabric-api-0.132.0%2B1.21.8.jar";
             };
+
             FabricLanguageKotlin = pkgs.fetchurl {
               sha256 = "sha256-KjxW/B3W6SKpvuNaTAukvA2Wd2Py6VL/SbdOw8ZB9Qs=";
               url = "https://cdn.modrinth.com/data/Ha28R6CL/versions/mccDBWqV/fabric-language-kotlin-1.13.4%2Bkotlin.2.2.0.jar";
             };
+
             FerriteCore = pkgs.fetchurl {
               sha256 = "sha256-K5C/AMKlgIw8U5cSpVaRGR+HFtW/pu76ujXpxMWijuo=";
               url = "https://cdn.modrinth.com/data/uXXizFIs/versions/CtMpt7Jr/ferritecore-8.0.0-fabric.jar";
             };
+
             Jade = pkgs.fetchurl {
               sha256 = "sha256-RWjPJiGJqedV9kYagfaypBNCcYF8edVOJB776Y02J9A=";
               url = "https://cdn.modrinth.com/data/nvQzSEkH/versions/o3aatc5Q/Jade-1.21.8-Fabric-19.3.2.jar";
             };
+
             Lithium = pkgs.fetchurl {
               sha256 = "sha256-kBPy+N/t6v20OBddTHZvW0E95WLc0RlaUAIwxVFxeH4=";
               url = "https://cdn.modrinth.com/data/gvQqBUqZ/versions/pDfTqezk/lithium-fabric-0.18.0%2Bmc1.21.8.jar";
             };
+
             RoughlyEnoughItems = pkgs.fetchurl {
               sha256 = "sha256-e2t1DkKcRCCF+gdFsDwnOyQiTxzngF2DnrUqmfKwJTo=";
               url = "https://cdn.modrinth.com/data/nfn13YXA/versions/hoEFy7aF/RoughlyEnoughItems-20.0.811-fabric.jar";
@@ -58,11 +69,14 @@ let
         );
       };
     };
+
     create-think-bigger = {
       port = 25567;
+
       server = pkgs: {
         enable = true;
         package = pkgs.neoforgeServers.neoforge-1_21_1;
+
         serverProperties = {
           enable-rcon = true;
           "rcon.password" = "@RCON_PASSWORD@";
@@ -71,8 +85,10 @@ let
         };
       };
     };
+
     vanilla = {
       port = 25565;
+
       server = pkgs: {
         enable = true;
         package = pkgs.fabricServers.fabric-1_21_11;

--- a/modules/aspects/users/oscar/minecraft-servers.nix
+++ b/modules/aspects/users/oscar/minecraft-servers.nix
@@ -1,84 +1,82 @@
 { my, ... }:
 let
   worlds = {
-    vanilla = {
-      port = 25565;
-      server = pkgs: {
-        enable = true;
-        package = pkgs.fabricServers.fabric-1_21_11;
-        serverProperties.white-list = false;
-      };
-    };
-
     chicken-house = {
       port = 25566;
       server = pkgs: {
         enable = true;
         package = pkgs.fabricServers.fabric-1_21_8;
         serverProperties = {
-          white-list = true;
           enable-rcon = true;
-          "rcon.port" = 25576;
           "rcon.password" = "@RCON_PASSWORD@";
+          "rcon.port" = 25576;
+          white-list = true;
         };
         symlinks.mods = pkgs.linkFarmFromDrvs "mods" (
           builtins.attrValues {
             ArchitecturyAPI = pkgs.fetchurl {
-              url = "https://cdn.modrinth.com/data/lhGA9TYQ/versions/XcJm5LH4/architectury-17.0.8-fabric.jar";
               sha256 = "sha256-tdBR+O/+j5R2+TdeEeSN+vuCF5FDW4/jaIaZADl/BdU=";
+              url = "https://cdn.modrinth.com/data/lhGA9TYQ/versions/XcJm5LH4/architectury-17.0.8-fabric.jar";
             };
             AutoWhitelist = pkgs.fetchurl {
-              url = "https://cdn.modrinth.com/data/BMaqFQAd/versions/PIJ4HDyR/autowhitelist-1.2.4%2B1.21.6.jar";
               sha256 = "sha256-cYTNxZEGfyUVAkSeFk8Ci3FbcpJOmgeSXqE++NB9BYM=";
+              url = "https://cdn.modrinth.com/data/BMaqFQAd/versions/PIJ4HDyR/autowhitelist-1.2.4%2B1.21.6.jar";
             };
             # Carpet = pkgs.fetchurl {
             #   url = "https://cdn.modrinth.com/data/TQTTVgYE/versions/xksYKkvF/fabric-carpet-1.20.2-1.4.121%2Bv231011.jar";
             #   sha256 = "sha256-qGprKkfOVzmNVH/nzOCRC569Q3w7GdxyD6PAoQtji+w=";
             # };
             ClothConfig = pkgs.fetchurl {
-              url = "https://cdn.modrinth.com/data/9s6osm5g/versions/cz0b1j8R/cloth-config-19.0.147-fabric.jar";
               sha256 = "sha256-2KbcqdDa0f5EYio8agNIZBk045Q8jUJaJvESvObev6I=";
+              url = "https://cdn.modrinth.com/data/9s6osm5g/versions/cz0b1j8R/cloth-config-19.0.147-fabric.jar";
             };
             FabricAPI = pkgs.fetchurl {
-              url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/jjBL6OsN/fabric-api-0.132.0%2B1.21.8.jar";
               sha256 = "sha256-t2MBX17VRswnCzHspYKty6JkzWKJ5FFF2fU0jGD9olk=";
+              url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/jjBL6OsN/fabric-api-0.132.0%2B1.21.8.jar";
             };
             FabricLanguageKotlin = pkgs.fetchurl {
-              url = "https://cdn.modrinth.com/data/Ha28R6CL/versions/mccDBWqV/fabric-language-kotlin-1.13.4%2Bkotlin.2.2.0.jar";
               sha256 = "sha256-KjxW/B3W6SKpvuNaTAukvA2Wd2Py6VL/SbdOw8ZB9Qs=";
+              url = "https://cdn.modrinth.com/data/Ha28R6CL/versions/mccDBWqV/fabric-language-kotlin-1.13.4%2Bkotlin.2.2.0.jar";
             };
             FerriteCore = pkgs.fetchurl {
-              url = "https://cdn.modrinth.com/data/uXXizFIs/versions/CtMpt7Jr/ferritecore-8.0.0-fabric.jar";
               sha256 = "sha256-K5C/AMKlgIw8U5cSpVaRGR+HFtW/pu76ujXpxMWijuo=";
+              url = "https://cdn.modrinth.com/data/uXXizFIs/versions/CtMpt7Jr/ferritecore-8.0.0-fabric.jar";
             };
             Jade = pkgs.fetchurl {
-              url = "https://cdn.modrinth.com/data/nvQzSEkH/versions/o3aatc5Q/Jade-1.21.8-Fabric-19.3.2.jar";
               sha256 = "sha256-RWjPJiGJqedV9kYagfaypBNCcYF8edVOJB776Y02J9A=";
+              url = "https://cdn.modrinth.com/data/nvQzSEkH/versions/o3aatc5Q/Jade-1.21.8-Fabric-19.3.2.jar";
             };
             Lithium = pkgs.fetchurl {
-              url = "https://cdn.modrinth.com/data/gvQqBUqZ/versions/pDfTqezk/lithium-fabric-0.18.0%2Bmc1.21.8.jar";
               sha256 = "sha256-kBPy+N/t6v20OBddTHZvW0E95WLc0RlaUAIwxVFxeH4=";
+              url = "https://cdn.modrinth.com/data/gvQqBUqZ/versions/pDfTqezk/lithium-fabric-0.18.0%2Bmc1.21.8.jar";
             };
             RoughlyEnoughItems = pkgs.fetchurl {
-              url = "https://cdn.modrinth.com/data/nfn13YXA/versions/hoEFy7aF/RoughlyEnoughItems-20.0.811-fabric.jar";
               sha256 = "sha256-e2t1DkKcRCCF+gdFsDwnOyQiTxzngF2DnrUqmfKwJTo=";
+              url = "https://cdn.modrinth.com/data/nfn13YXA/versions/hoEFy7aF/RoughlyEnoughItems-20.0.811-fabric.jar";
             };
           }
         );
       };
     };
-
     create-think-bigger = {
       port = 25567;
       server = pkgs: {
         enable = true;
         package = pkgs.neoforgeServers.neoforge-1_21_1;
         serverProperties = {
-          white-list = true;
           enable-rcon = true;
-          "rcon.port" = 25577;
           "rcon.password" = "@RCON_PASSWORD@";
+          "rcon.port" = 25577;
+          white-list = true;
         };
+      };
+    };
+    vanilla = {
+      port = 25565;
+      server = pkgs: {
+        enable = true;
+        package = pkgs.fabricServers.fabric-1_21_11;
+        serverProperties.white-list = false;
       };
     };
   };

--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -1,6 +1,6 @@
 {
-  den,
   lib,
+  den,
   my,
   ...
 }:
@@ -10,11 +10,10 @@ let
     nixos = { config, ... }: {
       users.users.${user.userName} = {
         hashedPasswordFile = toString config.age.secrets.oscar-hashed-password.file;
-        openssh.authorizedKeys.keys = [
-          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGt95coA4j19+fPxpOLRfIFb7AvAXdSmf1MyOPibmhe/"
-        ];
+        openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGt95coA4j19+fPxpOLRfIFb7AvAXdSmf1MyOPibmhe/" ];
       };
     };
+
     # nixos/modules/config/nix.nix and nix-darwin's equivalent both set
     # `nix.settings.trusted-users = [ "root" ]` as a real config-level definition
     # (not just an mkOption default), and trusted-users is a listOf — definitions
@@ -43,20 +42,58 @@ in
           { };
     in
     {
+      includes = [
+        (den._.user-shell "fish")
+        (my.git {
+          inherit name;
+          email = "3111765+OscarMarshall@users.noreply.github.com";
+        })
+        (my.logseq { cli-only = !(scope.graphical or false); })
+        den._.primary-user
+        den.aspects.oscar.provides.work
+        my.bat
+        my.claude
+        my.direnv
+        my.emacs
+        my.fish
+        my.gpg
+        my.nh
+        my.nix-index
+        my.proton-pass
+        my.ssh-client
+        userAspect
+      ]
+      ++ lib.optionals (scope.graphical or false) [
+        (my.catppuccin { })
+        den.aspects.oscar.provides.zen-browser
+        my.discord
+        my.doc-browser
+        my.ghostty
+        my.orca-slicer
+        my.programmer-dvorak
+        my.prusa-slicer
+        my.steam
+      ];
+
       darwin = {
         homebrew.casks = [
           "arc"
           "domzilla-caffeine"
           "proton-mail"
         ];
-        users.knownUsers = [ "oscar" ];
-        users.users.oscar.uid = 501;
+
+        users = {
+          knownUsers = [ "oscar" ];
+          users.oscar.uid = 501;
+        };
       };
+
       homeManager = { pkgs, ... }: {
         # age uses this key when rekeying home-manager-level secrets. At
         # activation time, age decrypts via the Proton Pass SSH agent
         # (SSH_AUTH_SOCK) without needing a private key file on disk.
         age.rekey.hostPubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGt95coA4j19+fPxpOLRfIFb7AvAXdSmf1MyOPibmhe/";
+
         home.packages =
           with pkgs;
           [
@@ -71,12 +108,15 @@ in
             mpv
             prismlauncher
           ];
+
         programs = {
           fzf.enable = true;
+
           gh = {
             enable = true;
             settings.git_protocol = "ssh";
           };
+
           ssh.settings."github-personal" = {
             HostName = "github.com";
             IdentitiesOnly = true;
@@ -84,6 +124,7 @@ in
             User = "git";
           };
         };
+
         # On work machines, the agent needs SSH keys from both the Personal and Meraki
         # vaults - pass-cli's ssh-agent only accepts a single --vault-name, so the only way
         # to cover more than one named vault is to omit the flag and let it scan all vaults.
@@ -91,69 +132,45 @@ in
           "--vault-name"
           "Personal"
         ];
+
         stylix.fonts = {
           monospace = {
-            name = "Maple Mono NF";
             package = pkgs.maple-mono.NF;
+            name = "Maple Mono NF";
           };
+
           sansSerif = {
-            name = "Inter";
             package = pkgs.inter;
+            name = "Inter";
           };
         };
       };
-      includes = [
-        den.aspects.oscar.provides.work
-        den._.primary-user
-        (den._.user-shell "fish")
-        my.bat
-        my.claude
-        my.direnv
-        my.emacs
-        my.fish
-        (my.git {
-          inherit name;
-          email = "3111765+OscarMarshall@users.noreply.github.com";
-        })
-        my.gpg
-        my.nh
-        my.nix-index
-        my.proton-pass
-        my.ssh-client
-        (my.logseq { cli-only = !(scope.graphical or false); })
-        userAspect
-      ]
-      ++ lib.optionals (scope.graphical or false) [
-        (my.catppuccin { })
-        my.discord
-        my.doc-browser
-        my.ghostty
-        my.orca-slicer
-        my.programmer-dvorak
-        my.prusa-slicer
-        my.steam
-        den.aspects.oscar.provides.zen-browser
-      ];
+
       nixosSecrets = { secrets, ... }: {
         oscar-hashed-password.generator = {
           dependencies = { inherit (secrets) oscar-password; };
+
           script =
             {
-              decrypt,
-              deps,
               lib,
               pkgs,
+              decrypt,
+              deps,
               ...
             }:
             ''
               ${pkgs.mkpasswd}/bin/mkpasswd "$(${decrypt} ${lib.escapeShellArg deps.oscar-password.file})"
             '';
         };
+
         oscar-password = {
           intermediary = true;
           rekeyFile = ../../../../secrets/oscar-password.age;
         };
       };
+
+      user.description = name;
+
       provides."dev203.meraki.com" = {
         hm64bit = { };
         hmAarch64 = { };
@@ -162,6 +179,7 @@ in
         # this home entity's re-walked spawn scope doesn't re-run the user aspect's own includes, so
         # hmLinux is absent at compile time without this and the forward falls through to resolveSourceFallback.
         hmLinux = { };
+
         homeManager = {
           home = {
             sessionVariables.PATH = "$HOME/.nix-profile/bin:$PATH";
@@ -169,6 +187,5 @@ in
           };
         };
       };
-      user.description = name;
     };
 }

--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -9,8 +9,10 @@ let
   userAspect = { user, ... }: {
     nixos = { config, ... }: {
       users.users.${user.userName} = {
-        openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGt95coA4j19+fPxpOLRfIFb7AvAXdSmf1MyOPibmhe/" ];
         hashedPasswordFile = toString config.age.secrets.oscar-hashed-password.file;
+        openssh.authorizedKeys.keys = [
+          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGt95coA4j19+fPxpOLRfIFb7AvAXdSmf1MyOPibmhe/"
+        ];
       };
     };
     # nixos/modules/config/nix.nix and nix-darwin's equivalent both set
@@ -23,8 +25,8 @@ in
 {
   den.aspects.oscar =
     {
-      host ? null,
       home ? null,
+      host ? null,
       ...
     }:
     let
@@ -41,6 +43,65 @@ in
           { };
     in
     {
+      darwin = {
+        homebrew.casks = [
+          "arc"
+          "domzilla-caffeine"
+          "proton-mail"
+        ];
+        users.knownUsers = [ "oscar" ];
+        users.users.oscar.uid = 501;
+      };
+      homeManager = { pkgs, ... }: {
+        # age uses this key when rekeying home-manager-level secrets. At
+        # activation time, age decrypts via the Proton Pass SSH agent
+        # (SSH_AUTH_SOCK) without needing a private key file on disk.
+        age.rekey.hostPubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGt95coA4j19+fPxpOLRfIFb7AvAXdSmf1MyOPibmhe/";
+        home.packages =
+          with pkgs;
+          [
+            fd
+            gnupg
+            ripgrep
+            rsync
+          ]
+          ++ lib.optionals (scope.graphical or false) [
+            inkscape
+            mkvtoolnix
+            mpv
+            prismlauncher
+          ];
+        programs = {
+          fzf.enable = true;
+          gh = {
+            enable = true;
+            settings.git_protocol = "ssh";
+          };
+          ssh.settings."github-personal" = {
+            HostName = "github.com";
+            IdentitiesOnly = true;
+            IdentityFile = "${./id_ed25519_personal.pub}";
+            User = "git";
+          };
+        };
+        # On work machines, the agent needs SSH keys from both the Personal and Meraki
+        # vaults - pass-cli's ssh-agent only accepts a single --vault-name, so the only way
+        # to cover more than one named vault is to omit the flag and let it scan all vaults.
+        services.proton-pass-agent.extraArgs = lib.optionals (!(scope.work or false)) [
+          "--vault-name"
+          "Personal"
+        ];
+        stylix.fonts = {
+          monospace = {
+            name = "Maple Mono NF";
+            package = pkgs.maple-mono.NF;
+          };
+          sansSerif = {
+            name = "Inter";
+            package = pkgs.inter;
+          };
+        };
+      };
       includes = [
         den.aspects.oscar.provides.work
         den._.primary-user
@@ -73,32 +134,7 @@ in
         my.steam
         den.aspects.oscar.provides.zen-browser
       ];
-
-      provides."dev203.meraki.com" = {
-        homeManager = {
-          home = {
-            sessionVariables.PATH = "$HOME/.nix-profile/bin:$PATH";
-            stateVersion = "26.05";
-          };
-        };
-
-        # See the comment on provides.oscar in OMARSHAL-M-T2QF.nix for why these sentinels are needed:
-        # this home entity's re-walked spawn scope doesn't re-run the user aspect's own includes, so
-        # hmLinux is absent at compile time without this and the forward falls through to resolveSourceFallback.
-        hmLinux = { };
-        hmDarwin = { };
-        hmAarch64 = { };
-        hm64bit = { };
-      };
-
-      user.description = name;
-
       nixosSecrets = { secrets, ... }: {
-        oscar-password = {
-          rekeyFile = ../../../../secrets/oscar-password.age;
-          intermediary = true;
-        };
-
         oscar-hashed-password.generator = {
           dependencies = { inherit (secrets) oscar-password; };
           script =
@@ -113,71 +149,26 @@ in
               ${pkgs.mkpasswd}/bin/mkpasswd "$(${decrypt} ${lib.escapeShellArg deps.oscar-password.file})"
             '';
         };
-      };
-
-      darwin = {
-        users.knownUsers = [ "oscar" ];
-        users.users.oscar.uid = 501;
-        homebrew.casks = [
-          "arc"
-          "domzilla-caffeine"
-          "proton-mail"
-        ];
-      };
-
-      homeManager = { pkgs, ... }: {
-        # age uses this key when rekeying home-manager-level secrets. At
-        # activation time, age decrypts via the Proton Pass SSH agent
-        # (SSH_AUTH_SOCK) without needing a private key file on disk.
-        age.rekey.hostPubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGt95coA4j19+fPxpOLRfIFb7AvAXdSmf1MyOPibmhe/";
-
-        # On work machines, the agent needs SSH keys from both the Personal and Meraki
-        # vaults - pass-cli's ssh-agent only accepts a single --vault-name, so the only way
-        # to cover more than one named vault is to omit the flag and let it scan all vaults.
-        services.proton-pass-agent.extraArgs = lib.optionals (!(scope.work or false)) [
-          "--vault-name"
-          "Personal"
-        ];
-
-        home.packages =
-          with pkgs;
-          [
-            fd
-            gnupg
-            ripgrep
-            rsync
-          ]
-          ++ lib.optionals (scope.graphical or false) [
-            inkscape
-            mkvtoolnix
-            mpv
-            prismlauncher
-          ];
-
-        programs = {
-          ssh.settings."github-personal" = {
-            HostName = "github.com";
-            User = "git";
-            IdentityFile = "${./id_ed25519_personal.pub}";
-            IdentitiesOnly = true;
-          };
-          fzf.enable = true;
-          gh = {
-            enable = true;
-            settings.git_protocol = "ssh";
-          };
+        oscar-password = {
+          intermediary = true;
+          rekeyFile = ../../../../secrets/oscar-password.age;
         };
-
-        stylix.fonts = {
-          monospace = {
-            package = pkgs.maple-mono.NF;
-            name = "Maple Mono NF";
-          };
-          sansSerif = {
-            package = pkgs.inter;
-            name = "Inter";
+      };
+      provides."dev203.meraki.com" = {
+        hm64bit = { };
+        hmAarch64 = { };
+        hmDarwin = { };
+        # See the comment on provides.oscar in OMARSHAL-M-T2QF.nix for why these sentinels are needed:
+        # this home entity's re-walked spawn scope doesn't re-run the user aspect's own includes, so
+        # hmLinux is absent at compile time without this and the forward falls through to resolveSourceFallback.
+        hmLinux = { };
+        homeManager = {
+          home = {
+            sessionVariables.PATH = "$HOME/.nix-profile/bin:$PATH";
+            stateVersion = "26.05";
           };
         };
       };
+      user.description = name;
     };
 }

--- a/modules/aspects/users/oscar/work/ssh-client.nix
+++ b/modules/aspects/users/oscar/work/ssh-client.nix
@@ -1,6 +1,12 @@
 let
+  aliases = toString (
+    [
+      dev-alias
+      shard-alias
+    ]
+    ++ jump-host-aliases
+  );
   dev-alias = "dev*";
-  shard-alias = "n*";
   jump-host-aliases = [
     "sva0"
     "sf100"
@@ -11,17 +17,12 @@ let
     "sin0"
     "syd0"
   ];
-  aliases = toString (
-    [
-      dev-alias
-      shard-alias
-    ]
-    ++ jump-host-aliases
-  );
+  shard-alias = "n*";
 in
 {
   den.aspects.oscar.provides.work.provides.ssh-client = {
     hmDarwin.programs.ssh.settings."*.meraki.com ${aliases}".UseKeychain = "yes";
+
     homeManager = { lib, ... }: {
       programs.ssh.settings = {
         "*.meraki.com ${aliases}" = {
@@ -30,17 +31,21 @@ in
           ServerAliveInterval = 240;
           User = "omarshal";
         };
+
         "dev" = lib.hm.dag.entryBefore [ "meraki.com aliases" ] { HostName = "dev203.meraki.com"; };
+
         "github-meraki" = {
           HostName = "github.com";
           IdentitiesOnly = true;
           IdentityFile = "${./id_ed25519_meraki.pub}";
           User = "git";
         };
+
         "meraki.com aliases" = lib.hm.dag.entryBefore [ "*.meraki.com" "n*.meraki.com" ] {
           HostName = "%h.meraki.com";
           header = "Host !*.meraki.com ${aliases}";
         };
+
         "n*.meraki.com ${shard-alias}" = {
           HostKeyAlgorithms = "+ssh-rsa";
           ProxyJump = builtins.head jump-host-aliases;

--- a/modules/aspects/users/oscar/work/ssh-client.nix
+++ b/modules/aspects/users/oscar/work/ssh-client.nix
@@ -21,14 +21,9 @@ let
 in
 {
   den.aspects.oscar.provides.work.provides.ssh-client = {
+    hmDarwin.programs.ssh.settings."*.meraki.com ${aliases}".UseKeychain = "yes";
     homeManager = { lib, ... }: {
       programs.ssh.settings = {
-        "github-meraki" = {
-          HostName = "github.com";
-          User = "git";
-          IdentityFile = "${./id_ed25519_meraki.pub}";
-          IdentitiesOnly = true;
-        };
         "*.meraki.com ${aliases}" = {
           AddKeysToAgent = "yes";
           ForwardAgent = true;
@@ -36,16 +31,21 @@ in
           User = "omarshal";
         };
         "dev" = lib.hm.dag.entryBefore [ "meraki.com aliases" ] { HostName = "dev203.meraki.com"; };
+        "github-meraki" = {
+          HostName = "github.com";
+          IdentitiesOnly = true;
+          IdentityFile = "${./id_ed25519_meraki.pub}";
+          User = "git";
+        };
         "meraki.com aliases" = lib.hm.dag.entryBefore [ "*.meraki.com" "n*.meraki.com" ] {
-          header = "Host !*.meraki.com ${aliases}";
           HostName = "%h.meraki.com";
+          header = "Host !*.meraki.com ${aliases}";
         };
         "n*.meraki.com ${shard-alias}" = {
-          ProxyJump = builtins.head jump-host-aliases;
           HostKeyAlgorithms = "+ssh-rsa";
+          ProxyJump = builtins.head jump-host-aliases;
         };
       };
     };
-    hmDarwin.programs.ssh.settings."*.meraki.com ${aliases}".UseKeychain = "yes";
   };
 }

--- a/modules/aspects/users/oscar/work/work.nix
+++ b/modules/aspects/users/oscar/work/work.nix
@@ -1,6 +1,6 @@
 {
-  den,
   lib,
+  den,
   my,
   ...
 }:
@@ -29,8 +29,15 @@ in
       scope = scopeFromArgs args;
     in
     {
+      includes = lib.optionals (scope.work or false) (
+        builtins.attrValues den.aspects.oscar.provides.work.provides
+        ++ (lib.optional (scope.graphical or false) my.slack)
+        ++ [ (my.openai { chatgpt = scope.graphical or false; }) ]
+      );
+
       homeManager = { pkgs, ... }: {
         home.packages = with pkgs; [ glab ];
+
         programs.codex.settings.mcp_servers = lib.optionalAttrs (scope.work or false) {
           grafana = {
             args = [
@@ -41,20 +48,18 @@ in
               "--log-level"
               "info"
             ];
+
             command = "${pkgs.uv}/bin/uvx";
+
             env_vars = [
               "GRAFANA_URL"
               "GRAFANA_USERNAME"
               "GRAFANA_PASSWORD"
             ];
+
             startup_timeout_sec = 30;
           };
         };
       };
-      includes = lib.optionals (scope.work or false) (
-        builtins.attrValues den.aspects.oscar.provides.work.provides
-        ++ (lib.optional (scope.graphical or false) my.slack)
-        ++ [ (my.openai { chatgpt = scope.graphical or false; }) ]
-      );
     };
 }

--- a/modules/aspects/users/oscar/work/work.nix
+++ b/modules/aspects/users/oscar/work/work.nix
@@ -11,8 +11,8 @@ let
   # `work`/`graphical`. The real attributes always live on `home` for those.
   scopeFromArgs =
     {
-      host ? null,
       home ? null,
+      host ? null,
       ...
     }@args:
     if home != null then
@@ -29,17 +29,10 @@ in
       scope = scopeFromArgs args;
     in
     {
-      includes = lib.optionals (scope.work or false) (
-        builtins.attrValues den.aspects.oscar.provides.work.provides
-        ++ (lib.optional (scope.graphical or false) my.slack)
-        ++ [ (my.openai { chatgpt = scope.graphical or false; }) ]
-      );
-
       homeManager = { pkgs, ... }: {
         home.packages = with pkgs; [ glab ];
         programs.codex.settings.mcp_servers = lib.optionalAttrs (scope.work or false) {
           grafana = {
-            command = "${pkgs.uv}/bin/uvx";
             args = [
               "mcp-grafana"
               "--enabled-tools"
@@ -48,14 +41,20 @@ in
               "--log-level"
               "info"
             ];
-            startup_timeout_sec = 30;
+            command = "${pkgs.uv}/bin/uvx";
             env_vars = [
               "GRAFANA_URL"
               "GRAFANA_USERNAME"
               "GRAFANA_PASSWORD"
             ];
+            startup_timeout_sec = 30;
           };
         };
       };
+      includes = lib.optionals (scope.work or false) (
+        builtins.attrValues den.aspects.oscar.provides.work.provides
+        ++ (lib.optional (scope.graphical or false) my.slack)
+        ++ [ (my.openai { chatgpt = scope.graphical or false; }) ]
+      );
     };
 }

--- a/modules/aspects/users/oscar/zen-browser.nix
+++ b/modules/aspects/users/oscar/zen-browser.nix
@@ -4,34 +4,24 @@ let
 in
 {
   den.aspects.oscar.provides.zen-browser = {
-    includes = [ my.zen-browser ];
-
     homeManager = {
       programs.zen-browser = {
         darwinDefaultsId = "app.zen-browser.zen";
-
-        # No-op on Darwin (it only wires up xdg.mimeApps); already the actual
-        # default browser here via macOS's LaunchServices, set outside Nix.
-        setAsDefaultBrowser = true;
-
         policies = {
           # Updates come from `nix flake update` + rebuild; the browser's own
           # updater can't write into the read-only /nix/store install anyway.
           DisableAppUpdate = true;
-          DisableTelemetry = true;
-          DisableFirefoxStudies = true;
           DisableFeedbackCommands = true;
-          DontCheckDefaultBrowser = true;
-          NoDefaultBookmarks = true;
+          DisableFirefoxStudies = true;
           DisablePocket = true;
-          OfferToSaveLogins = false;
+          DisableTelemetry = true;
+          DontCheckDefaultBrowser = true;
           EnableTrackingProtection = {
-            Value = true;
-            Locked = true;
             Cryptomining = true;
             Fingerprinting = true;
+            Locked = true;
+            Value = true;
           };
-
           ExtensionSettings =
             let
               mkExtension = slug: {
@@ -41,33 +31,36 @@ in
             in
             {
               "78272b6fa58f4a1abaac99321d503a20@proton.me" = mkExtension "proton-pass";
+              "@testpilot-containers" = mkExtension "multi-account-containers";
+              "addon@darkreader.org" = mkExtension "darkreader";
               "firefox@tampermonkey.net" = mkExtension "tampermonkey";
               "jid1-MnnxcxisBPnSXQ@jetpack" = mkExtension "privacy-badger17";
-              "addon@darkreader.org" = mkExtension "darkreader";
               "uBlock0@raymondhill.net" = mkExtension "ublock-origin";
-              "@testpilot-containers" = mkExtension "multi-account-containers";
               "{7a7a4a92-a2a0-41d1-9fd7-1e92480d612d}" = mkExtension "styl-us";
             };
+          NoDefaultBookmarks = true;
+          OfferToSaveLogins = false;
         };
-
         profiles.${profileName}.settings = {
-          "zen.view.compact.enable-at-startup" = true;
-          "zen.workspaces.force-container-workspace" = true;
-          "zen.workspaces.continue-where-left-off" = true;
+          "browser.contentblocking.category" = "standard";
           "sidebar.visibility" = "hide-sidebar";
           "signon.rememberSignons" = false;
-          "browser.contentblocking.category" = "standard";
+          "zen.view.compact.enable-at-startup" = true;
+          "zen.workspaces.continue-where-left-off" = true;
+          "zen.workspaces.force-container-workspace" = true;
         };
+        # No-op on Darwin (it only wires up xdg.mimeApps); already the actual
+        # default browser here via macOS's LaunchServices, set outside Nix.
+        setAsDefaultBrowser = true;
       };
-
-      # Required for theming to apply: the module system can't both detect
-      # declared zen-browser profile names and use them, so it's repeated here.
-      stylix.targets.zen-browser.profileNames = [ profileName ];
-
       # Zen already follows the system light/dark appearance on its own, which
       # conflicts with Stylix's injected (single-flavor) userChrome/userContent
       # CSS. Disable the CSS injection and let Zen handle its own theming.
       stylix.targets.zen-browser.enableCss = false;
+      # Required for theming to apply: the module system can't both detect
+      # declared zen-browser profile names and use them, so it's repeated here.
+      stylix.targets.zen-browser.profileNames = [ profileName ];
     };
+    includes = [ my.zen-browser ];
   };
 }

--- a/modules/aspects/users/oscar/zen-browser.nix
+++ b/modules/aspects/users/oscar/zen-browser.nix
@@ -4,9 +4,12 @@ let
 in
 {
   den.aspects.oscar.provides.zen-browser = {
+    includes = [ my.zen-browser ];
+
     homeManager = {
       programs.zen-browser = {
         darwinDefaultsId = "app.zen-browser.zen";
+
         policies = {
           # Updates come from `nix flake update` + rebuild; the browser's own
           # updater can't write into the read-only /nix/store install anyway.
@@ -16,12 +19,14 @@ in
           DisablePocket = true;
           DisableTelemetry = true;
           DontCheckDefaultBrowser = true;
+
           EnableTrackingProtection = {
             Cryptomining = true;
             Fingerprinting = true;
             Locked = true;
             Value = true;
           };
+
           ExtensionSettings =
             let
               mkExtension = slug: {
@@ -38,9 +43,11 @@ in
               "uBlock0@raymondhill.net" = mkExtension "ublock-origin";
               "{7a7a4a92-a2a0-41d1-9fd7-1e92480d612d}" = mkExtension "styl-us";
             };
+
           NoDefaultBookmarks = true;
           OfferToSaveLogins = false;
         };
+
         profiles.${profileName}.settings = {
           "browser.contentblocking.category" = "standard";
           "sidebar.visibility" = "hide-sidebar";
@@ -49,18 +56,25 @@ in
           "zen.workspaces.continue-where-left-off" = true;
           "zen.workspaces.force-container-workspace" = true;
         };
+
         # No-op on Darwin (it only wires up xdg.mimeApps); already the actual
         # default browser here via macOS's LaunchServices, set outside Nix.
         setAsDefaultBrowser = true;
       };
-      # Zen already follows the system light/dark appearance on its own, which
-      # conflicts with Stylix's injected (single-flavor) userChrome/userContent
-      # CSS. Disable the CSS injection and let Zen handle its own theming.
-      stylix.targets.zen-browser.enableCss = false;
-      # Required for theming to apply: the module system can't both detect
-      # declared zen-browser profile names and use them, so it's repeated here.
-      stylix.targets.zen-browser.profileNames = [ profileName ];
+
+      stylix = {
+        targets = {
+          zen-browser = {
+            # Zen already follows the system light/dark appearance on its own, which
+            # conflicts with Stylix's injected (single-flavor) userChrome/userContent
+            # CSS. Disable the CSS injection and let Zen handle its own theming.
+            enableCss = false;
+            # Required for theming to apply: the module system can't both detect
+            # declared zen-browser profile names and use them, so it's repeated here.
+            profileNames = [ profileName ];
+          };
+        };
+      };
     };
-    includes = [ my.zen-browser ];
   };
 }

--- a/modules/den.nix
+++ b/modules/den.nix
@@ -1,45 +1,50 @@
 { den, ... }: {
-  den.homes.x86_64-linux."omarshal@dev203.meraki.com" = {
-    aspect = den.aspects.oscar;
-    work = true;
-  };
-  den.hosts = {
-    aarch64-darwin.OMARSHAL-M-T2QF = {
-      graphical = true;
-      users.oscar = { };
+  den = {
+    homes.x86_64-linux."omarshal@dev203.meraki.com" = {
+      aspect = den.aspects.oscar;
       work = true;
     };
 
-    x86_64-linux = {
-      harmony = {
-        # Cloudflare zone ID for silverlight-nex.us (zone's Overview page in the dashboard) - not
-        # a secret, just an account-specific resource identifier, so it lives here as ordinary
-        # version-controlled Nix rather than a `TF_VAR_cloudflare_zone_id` to set by hand.
-        cloudflare-zone-id = "a4f841b1f4d00f1e36e129bae37f70d3";
-        # DNS-as-code (modules/aspects/my/dns.nix) reads this for every DNS record this host
-        # produces - its `*.harmony.silverlight-nex.us` wildcard and every canonicalized service's
-        # global alias alike. Points at the router's dynamic-DNS hostname rather than a static IP,
-        # so there's no TF_VAR_harmony_ipv4 to keep up to date by hand.
-        dns-record = {
-          content = "home-dcgmhnhtnd.dynamic-m.com";
-          type = "CNAME";
-        };
-        # Router-as-code (modules/aspects/my/meraki.nix) reads this to target every inbound
-        # port-forwarding rule this host requests (via the `port-forward` quirk) at harmony itself
-        # on the Meraki MX's LAN. A static/DHCP-reserved address on the Meraki network.
-        lan-ip = "10.10.10.16";
-        # Meraki network ID for harmony's network ("Scadrial" - Network-wide > Settings, or the
-        # Dashboard API). Same reasoning as `cloudflare-zone-id` above - not a secret.
-        meraki-network-id = "L_585467951558176291";
+    hosts = {
+      aarch64-darwin.OMARSHAL-M-T2QF = {
+        graphical = true;
         users.oscar = { };
+        work = true;
       };
 
-      melaan = {
-        graphical = true;
+      x86_64-linux = {
+        harmony = {
+          # Cloudflare zone ID for silverlight-nex.us (zone's Overview page in the dashboard) - not
+          # a secret, just an account-specific resource identifier, so it lives here as ordinary
+          # version-controlled Nix rather than a `TF_VAR_cloudflare_zone_id` to set by hand.
+          cloudflare-zone-id = "a4f841b1f4d00f1e36e129bae37f70d3";
 
-        users = {
-          adelline = { };
-          oscar = { };
+          # DNS-as-code (modules/aspects/my/dns.nix) reads this for every DNS record this host
+          # produces - its `*.harmony.silverlight-nex.us` wildcard and every canonicalized service's
+          # global alias alike. Points at the router's dynamic-DNS hostname rather than a static IP,
+          # so there's no TF_VAR_harmony_ipv4 to keep up to date by hand.
+          dns-record = {
+            content = "home-dcgmhnhtnd.dynamic-m.com";
+            type = "CNAME";
+          };
+
+          # Router-as-code (modules/aspects/my/meraki.nix) reads this to target every inbound
+          # port-forwarding rule this host requests (via the `port-forward` quirk) at harmony itself
+          # on the Meraki MX's LAN. A static/DHCP-reserved address on the Meraki network.
+          lan-ip = "10.10.10.16";
+          # Meraki network ID for harmony's network ("Scadrial" - Network-wide > Settings, or the
+          # Dashboard API). Same reasoning as `cloudflare-zone-id` above - not a secret.
+          meraki-network-id = "L_585467951558176291";
+          users.oscar = { };
+        };
+
+        melaan = {
+          graphical = true;
+
+          users = {
+            adelline = { };
+            oscar = { };
+          };
         };
       };
     };

--- a/modules/den.nix
+++ b/modules/den.nix
@@ -1,38 +1,37 @@
 { den, ... }: {
+  den.homes.x86_64-linux."omarshal@dev203.meraki.com" = {
+    aspect = den.aspects.oscar;
+    work = true;
+  };
   den.hosts = {
     aarch64-darwin.OMARSHAL-M-T2QF = {
       graphical = true;
-      work = true;
-
       users.oscar = { };
+      work = true;
     };
 
     x86_64-linux = {
       harmony = {
-        users.oscar = { };
-
+        # Cloudflare zone ID for silverlight-nex.us (zone's Overview page in the dashboard) - not
+        # a secret, just an account-specific resource identifier, so it lives here as ordinary
+        # version-controlled Nix rather than a `TF_VAR_cloudflare_zone_id` to set by hand.
+        cloudflare-zone-id = "a4f841b1f4d00f1e36e129bae37f70d3";
         # DNS-as-code (modules/aspects/my/dns.nix) reads this for every DNS record this host
         # produces - its `*.harmony.silverlight-nex.us` wildcard and every canonicalized service's
         # global alias alike. Points at the router's dynamic-DNS hostname rather than a static IP,
         # so there's no TF_VAR_harmony_ipv4 to keep up to date by hand.
         dns-record = {
-          type = "CNAME";
           content = "home-dcgmhnhtnd.dynamic-m.com";
+          type = "CNAME";
         };
-
-        # Cloudflare zone ID for silverlight-nex.us (zone's Overview page in the dashboard) - not
-        # a secret, just an account-specific resource identifier, so it lives here as ordinary
-        # version-controlled Nix rather than a `TF_VAR_cloudflare_zone_id` to set by hand.
-        cloudflare-zone-id = "a4f841b1f4d00f1e36e129bae37f70d3";
-
         # Router-as-code (modules/aspects/my/meraki.nix) reads this to target every inbound
         # port-forwarding rule this host requests (via the `port-forward` quirk) at harmony itself
         # on the Meraki MX's LAN. A static/DHCP-reserved address on the Meraki network.
         lan-ip = "10.10.10.16";
-
         # Meraki network ID for harmony's network ("Scadrial" - Network-wide > Settings, or the
         # Dashboard API). Same reasoning as `cloudflare-zone-id` above - not a secret.
         meraki-network-id = "L_585467951558176291";
+        users.oscar = { };
       };
 
       melaan = {
@@ -44,10 +43,5 @@
         };
       };
     };
-  };
-
-  den.homes.x86_64-linux."omarshal@dev203.meraki.com" = {
-    aspect = den.aspects.oscar;
-    work = true;
   };
 }

--- a/modules/dendritic.nix
+++ b/modules/dendritic.nix
@@ -1,8 +1,9 @@
-{ inputs, lib, ... }: {
+{ lib, inputs, ... }: {
   flake-file.inputs = {
-    den.url = lib.mkDefault "github:denful/den";
     flake-file.url = lib.mkDefault "github:vic/flake-file";
+    den.url = lib.mkDefault "github:denful/den";
   };
+
   imports = [
     (inputs.flake-file.flakeModules.dendritic or { })
     (inputs.den.flakeModules.dendritic or { })

--- a/modules/dendritic.nix
+++ b/modules/dendritic.nix
@@ -1,7 +1,7 @@
 { inputs, lib, ... }: {
   flake-file.inputs = {
-    flake-file.url = lib.mkDefault "github:vic/flake-file";
     den.url = lib.mkDefault "github:denful/den";
+    flake-file.url = lib.mkDefault "github:vic/flake-file";
   };
   imports = [
     (inputs.flake-file.flakeModules.dendritic or { })

--- a/modules/git-hooks.nix
+++ b/modules/git-hooks.nix
@@ -2,17 +2,19 @@
 
 {
   flake-file.inputs.git-hooks = {
+    url = "github:cachix/git-hooks.nix";
+
     inputs = {
       flake-compat.follows = "flake-compat";
       nixpkgs.follows = "nixpkgs";
     };
-    url = "github:cachix/git-hooks.nix";
   };
 
   imports = [ (inputs.git-hooks.flakeModule or { }) ];
 
   perSystem.pre-commit = {
     check.enable = true;
+
     settings.hooks = {
       flake-checker.enable = true;
       treefmt.enable = true;

--- a/modules/git-hooks.nix
+++ b/modules/git-hooks.nix
@@ -2,11 +2,11 @@
 
 {
   flake-file.inputs.git-hooks = {
-    url = "github:cachix/git-hooks.nix";
     inputs = {
       flake-compat.follows = "flake-compat";
       nixpkgs.follows = "nixpkgs";
     };
+    url = "github:cachix/git-hooks.nix";
   };
 
   imports = [ (inputs.git-hooks.flakeModule or { }) ];

--- a/modules/inputs.nix
+++ b/modules/inputs.nix
@@ -9,19 +9,17 @@
 # you are free to remove them if not being used by you.
 { ... }: {
   flake-file.inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-
-    home-manager = {
-      url = "github:nix-community/home-manager";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     darwin = {
-      url = "github:nix-darwin/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:nix-darwin/nix-darwin";
     };
-
     # Follow targets
     flake-compat.url = "github:NixOS/flake-compat";
+    home-manager = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:nix-community/home-manager";
+    };
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     systems.url = "github:nix-systems/default";
   };
 }

--- a/modules/inputs.nix
+++ b/modules/inputs.nix
@@ -7,18 +7,21 @@
 #
 # For our template, we enable home-manager and nix-darwin by default, but
 # you are free to remove them if not being used by you.
-{ ... }: {
+_: {
   flake-file.inputs = {
     darwin = {
-      inputs.nixpkgs.follows = "nixpkgs";
       url = "github:nix-darwin/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
+
     # Follow targets
     flake-compat.url = "github:NixOS/flake-compat";
+
     home-manager = {
-      inputs.nixpkgs.follows = "nixpkgs";
       url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
+
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     systems.url = "github:nix-systems/default";
   };

--- a/modules/nh.nix
+++ b/modules/nh.nix
@@ -1,4 +1,2 @@
 # Exposes flake apps under the name of each host / home for building with nh.
-{ den, ... }: {
-  perSystem = { pkgs, ... }: { packages = den.lib.nh.denPackages { fromFlake = true; } pkgs; };
-}
+{ den, ... }: { perSystem = { pkgs, ... }: { packages = den.lib.nh.denPackages { fromFlake = true; } pkgs; }; }

--- a/modules/nh.nix
+++ b/modules/nh.nix
@@ -1,2 +1,4 @@
 # Exposes flake apps under the name of each host / home for building with nh.
-{ den, ... }: { perSystem = { pkgs, ... }: { packages = den.lib.nh.denPackages { fromFlake = true; } pkgs; }; }
+{ den, ... }: {
+  perSystem = { pkgs, ... }: { packages = den.lib.nh.denPackages { fromFlake = true; } pkgs; };
+}

--- a/modules/pedantix.nix
+++ b/modules/pedantix.nix
@@ -1,0 +1,12 @@
+{ inputs, ... }:
+
+{
+  flake-file.inputs.pedantix = {
+    inputs.nixpkgs.follows = "nixpkgs";
+    url = "github:Swarsel/pedantix";
+  };
+
+  imports = [ (inputs.pedantix.flakeModules.default or { }) ];
+
+  perSystem.treefmt.programs.pedantix.enable = true;
+}

--- a/modules/pedantix.nix
+++ b/modules/pedantix.nix
@@ -2,11 +2,91 @@
 
 {
   flake-file.inputs.pedantix = {
-    inputs.nixpkgs.follows = "nixpkgs";
     url = "github:Swarsel/pedantix";
+    inputs.nixpkgs.follows = "nixpkgs";
   };
 
   imports = [ (inputs.pedantix.flakeModules.default or { }) ];
 
-  perSystem.treefmt.programs.pedantix.enable = true;
+  perSystem.treefmt.programs.pedantix = {
+    enable = true;
+
+    settings = {
+      args = {
+        first = [
+          "config"
+          "lib"
+          "pkgs"
+          "options"
+          "modulesPath"
+          "utils"
+        ];
+
+        last = [
+          "<defaulted>"
+          "..."
+        ];
+
+        sort = true;
+      };
+
+      attrs = {
+        blank-lines = 1;
+        blank-lines-mode = "multiline";
+
+        first = [
+          "flake-file"
+          "includes"
+          "imports"
+          "options"
+          "config"
+          "enable"
+          "package"
+        ];
+
+        last = [
+          "meta"
+          "provides"
+        ];
+
+        merge = true;
+        sort = true;
+      };
+
+      formatter = "off";
+      inherits.sort = true;
+      lets.sort = true;
+
+      overrides = [
+        {
+          path = "**.extraPackages";
+          lists.sort = true;
+        }
+        {
+          path = "flake-file.inputs.*";
+          attrs.first = [ "url" ];
+        }
+        {
+          path = "**.home.packages";
+          lists.sort = true;
+        }
+        {
+          path = "**.includes";
+          lists.sort = true;
+        }
+        {
+          path = "**.pedantix.settings.overrides";
+          attrs.first = [ "path" ];
+        }
+        {
+          path = "**.systemd.services.*";
+
+          attrs.first = [
+            "description"
+            "wantedBy"
+          ];
+        }
+      ];
+    };
+  };
 }

--- a/modules/terranix.nix
+++ b/modules/terranix.nix
@@ -50,17 +50,17 @@
 # .gitignore's comment, and #516). `terraform.encryption` below (contributed unconditionally for
 # every host) is what actually keeps those out of the plaintext git history.
 {
+  config,
   den,
   inputs,
   lib,
-  config,
   ...
 }:
 let
   warnings-shim = {
     options.warnings = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
       default = [ ];
+      type = lib.types.listOf lib.types.str;
     };
   };
 
@@ -76,7 +76,8 @@ let
   # The actual env var a `settings.terraform`-flagged secret surfaces as, per the two modes
   # documented above.
   terraform-env-var-for =
-    name: sec: if terraform-mode-of sec == "variable" then "TF_VAR_${env-var-for name}" else env-var-for name;
+    name: sec:
+    if terraform-mode-of sec == "variable" then "TF_VAR_${env-var-for name}" else env-var-for name;
 
   # Collects every `settings.terraform`-flagged secret, across every aspect on a host, into that
   # host's own `"${host.name}-tf.env"` generated secret - lives outside any single aspect (like
@@ -87,22 +88,14 @@ let
     secrets =
       {
         config,
-        secrets,
         lib,
+        secrets,
         ...
       }:
       let
         terraform-secrets = lib.filterAttrs (_: sec: terraform-mode-of sec != null) config.age.secrets;
       in
       {
-        # Always present (not left to opt in) - it backs `terraform.encryption` below, which every
-        # `<host>-tf` gets unconditionally (see that field's own comment for why).
-        open-tofu-state-passphrase = {
-          generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -base64 32";
-          intermediary = true;
-          settings.terraform = "variable";
-        };
-
         # This key's PRESENCE must be unconditional, even though `terraform-secrets` (its VALUE
         # depends on it) is empty exactly when only `open-tofu-state-passphrase` above is
         # flagged - making it conditional on `terraform-secrets != { }` would mean
@@ -114,9 +107,9 @@ let
           dependencies = lib.mapAttrs (name: _: secrets.${name}) terraform-secrets;
           script =
             {
-              lib,
               decrypt,
               deps,
+              lib,
               ...
             }:
             lib.concatMapStrings (name: ''
@@ -128,6 +121,13 @@ let
                 lib.escapeShellArg deps.${name}.file
               })"
             '') (lib.attrNames terraform-secrets);
+        };
+        # Always present (not left to opt in) - it backs `terraform.encryption` below, which every
+        # `<host>-tf` gets unconditionally (see that field's own comment for why).
+        open-tofu-state-passphrase = {
+          generator.script = { pkgs, ... }: "${pkgs.openssl}/bin/openssl rand -base64 32";
+          intermediary = true;
+          settings.terraform = "variable";
         };
       };
 
@@ -141,8 +141,6 @@ let
     # own module-type pass, which only den quirks bridge into (see this file's header comment), and
     # `age.secrets` isn't one.
     terranix = {
-      variable.OPEN_TOFU_STATE_PASSPHRASE.sensitive = true;
-
       terraform.encryption = {
         key_provider.pbkdf2.main.passphrase = "\${var.OPEN_TOFU_STATE_PASSPHRASE}";
 
@@ -168,6 +166,7 @@ let
         # `state.fallback.method = "method.unencrypted.migrate";` temporarily.
         state.method = "method.aes_gcm.main";
       };
+      variable.OPEN_TOFU_STATE_PASSPHRASE.sensitive = true;
     };
   };
 
@@ -181,19 +180,11 @@ let
   terranix-modules = config.flake.terranixModules or { };
 in
 {
-  flake-file.inputs.terranix = {
-    url = "github:terranix/terranix";
-    inputs.nixpkgs.follows = "nixpkgs";
-  };
-
-  imports = [ (inputs.terranix.flakeModule or { }) ];
-
   den = {
     classes.terranix = { };
 
     policies.host-to-terranix = { host, ... }: [
       (den.lib.policy.instantiate {
-        name = "${host.name}-tf";
         class = "terranix";
         instantiate = { modules, ... }: modules;
         # `-tf` suffix (rather than the bare host name) avoids colliding with the
@@ -204,6 +195,7 @@ in
           "terranixModules"
           "${host.name}-tf"
         ];
+        name = "${host.name}-tf";
       })
     ];
 
@@ -212,7 +204,11 @@ in
       terraform-secrets-aspect
     ];
   };
-
+  flake-file.inputs.terranix = {
+    inputs.nixpkgs.follows = "nixpkgs";
+    url = "github:terranix/terranix";
+  };
+  imports = [ (inputs.terranix.flakeModule or { }) ];
   # Guarded on `inputs ? terranix`: the first `nix run .#write-flake` pass after adding this
   # module runs before flake.nix/flake.lock actually have a `terranix` input, so the option this
   # sets (declared by terranix's own flakeModule, imported above) doesn't exist yet either.

--- a/modules/terranix.nix
+++ b/modules/terranix.nix
@@ -51,34 +51,23 @@
 # every host) is what actually keeps those out of the plaintext git history.
 {
   config,
+  lib,
   den,
   inputs,
-  lib,
   ...
 }:
 let
-  warnings-shim = {
-    options.warnings = lib.mkOption {
-      default = [ ];
-      type = lib.types.listOf lib.types.str;
-    };
-  };
-
   # kebab-case -> SCREAMING_SNAKE_CASE, e.g. `cloudflare-api-token` -> `CLOUDFLARE_API_TOKEN`.
   env-var-for = secret: lib.toUpper (lib.replaceStrings [ "-" ] [ "_" ] secret);
-
+  # The actual env var a `settings.terraform`-flagged secret surfaces as, per the two modes
+  # documented above.
+  terraform-env-var-for =
+    name: sec: if terraform-mode-of sec == "variable" then "TF_VAR_${env-var-for name}" else env-var-for name;
   # `sec.settings` is a declared option, default `null` - `a.b.c or default` short-circuits the
   # WHOLE chain (not just the last step), so this is safe even when `sec.settings` itself is
   # `null`. Returns `null` for anything not opted in, `true`/`"variable"` (or whatever else
   # `settings.terraform` was set to) otherwise.
   terraform-mode-of = sec: sec.settings.terraform or null;
-
-  # The actual env var a `settings.terraform`-flagged secret surfaces as, per the two modes
-  # documented above.
-  terraform-env-var-for =
-    name: sec:
-    if terraform-mode-of sec == "variable" then "TF_VAR_${env-var-for name}" else env-var-for name;
-
   # Collects every `settings.terraform`-flagged secret, across every aspect on a host, into that
   # host's own `"${host.name}-tf.env"` generated secret - lives outside any single aspect (like
   # virtual-host.nix/port-forward.nix's consumers) since it's shared plumbing, not owned by any one
@@ -105,11 +94,12 @@ let
         # evaluation handles that fine); a key's PRESENCE may not.
         "${host.name}-tf.env".generator = {
           dependencies = lib.mapAttrs (name: _: secrets.${name}) terraform-secrets;
+
           script =
             {
+              lib,
               decrypt,
               deps,
-              lib,
               ...
             }:
             lib.concatMapStrings (name: ''
@@ -122,6 +112,7 @@ let
               })"
             '') (lib.attrNames terraform-secrets);
         };
+
         # Always present (not left to opt in) - it backs `terraform.encryption` below, which every
         # `<host>-tf` gets unconditionally (see that field's own comment for why).
         open-tofu-state-passphrase = {
@@ -143,9 +134,7 @@ let
     terranix = {
       terraform.encryption = {
         key_provider.pbkdf2.main.passphrase = "\${var.OPEN_TOFU_STATE_PASSPHRASE}";
-
         method.aes_gcm.main.keys = "\${key_provider.pbkdf2.main}";
-
         # `method` is a STATIC TRAVERSAL, not a computed value - HCL's JSON spec requires this as
         # a plain string containing raw HCL syntax (`"method.aes_gcm.main"`), NOT a `"\${...}"`
         # template - the latter parses as a template expression and fails validate ("A single
@@ -166,10 +155,10 @@ let
         # `state.fallback.method = "method.unencrypted.migrate";` temporarily.
         state.method = "method.aes_gcm.main";
       };
+
       variable.OPEN_TOFU_STATE_PASSPHRASE.sensitive = true;
     };
   };
-
   # Read from the file's own top-level `config` (closed over here, not re-requested) for the same
   # reason dns.nix's `perSystem` does the same for `config.flake.nixosConfigurations`: `config` is
   # ALSO the name flake-parts binds to each per-system module's own (different) result, so
@@ -178,8 +167,21 @@ let
   # making `.flake.terranixModules` resolve to `{ }` and silently dropping every `<hostname>-tf`
   # package. Hoisting the lookup here, before that shadow exists, keeps both readable.
   terranix-modules = config.flake.terranixModules or { };
+  warnings-shim = {
+    options.warnings = lib.mkOption {
+      default = [ ];
+      type = lib.types.listOf lib.types.str;
+    };
+  };
 in
 {
+  flake-file.inputs.terranix = {
+    url = "github:terranix/terranix";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  imports = [ (inputs.terranix.flakeModule or { }) ];
+
   den = {
     classes.terranix = { };
 
@@ -187,6 +189,7 @@ in
       (den.lib.policy.instantiate {
         class = "terranix";
         instantiate = { modules, ... }: modules;
+
         # `-tf` suffix (rather than the bare host name) avoids colliding with the
         # `packages.<host>` each host already gets from Den's `nh` battery (quick-rebuild
         # shortcuts) - terranix's flake-module keys `packages.<system>.<key>` off this same
@@ -195,6 +198,7 @@ in
           "terranixModules"
           "${host.name}-tf"
         ];
+
         name = "${host.name}-tf";
       })
     ];
@@ -204,11 +208,7 @@ in
       terraform-secrets-aspect
     ];
   };
-  flake-file.inputs.terranix = {
-    inputs.nixpkgs.follows = "nixpkgs";
-    url = "github:terranix/terranix";
-  };
-  imports = [ (inputs.terranix.flakeModule or { }) ];
+
   # Guarded on `inputs ? terranix`: the first `nix run .#write-flake` pass after adding this
   # module runs before flake.nix/flake.lock actually have a `terranix` input, so the option this
   # sets (declared by terranix's own flakeModule, imported above) doesn't exist yet either.
@@ -218,15 +218,17 @@ in
       terranix.terranixConfigurations = lib.mapAttrs (
         key: modules:
         let
+          env-file = "secrets/generated/${host-name}-tf.env.age";
           # Every entry here is keyed `"${host.name}-tf"` (see `intoAttr` above), so stripping the
           # suffix recovers the host name without needing `host` itself in this scope.
           host-name = lib.removeSuffix "-tf" key;
-          env-file = "secrets/generated/${host-name}-tf.env.age";
         in
         {
           modules = modules ++ [ warnings-shim ];
+
           terraformWrapper = {
             package = pkgs.opentofu;
+
             # No-ops for hosts with no `settings.terraform`-flagged secrets (nothing to generate,
             # so the file never exists). Both tools are called by their full store path (not left
             # to PATH) so this works even outside the dev shell.

--- a/modules/treefmt-nix.nix
+++ b/modules/treefmt-nix.nix
@@ -2,28 +2,36 @@
 
 {
   flake-file.inputs.treefmt-nix = {
-    inputs.nixpkgs.follows = "nixpkgs";
     url = "github:numtide/treefmt-nix";
+    inputs.nixpkgs.follows = "nixpkgs";
   };
 
   imports = [ (inputs.treefmt-nix.flakeModule or { }) ];
 
   perSystem.treefmt = {
     flakeFormatter = true;
+
     programs = {
       nixf-diagnose.enable = true;
+
       nixfmt = {
         enable = true;
         strict = true;
         width = 120;
       };
+
       prettier = {
         enable = true;
+
         settings = {
           printWidth = 120;
           proseWrap = "always";
         };
       };
+
+      statix.enable = true;
     };
+
+    settings.excludes = [ "flake.nix" ];
   };
 }

--- a/modules/treefmt-nix.nix
+++ b/modules/treefmt-nix.nix
@@ -2,8 +2,8 @@
 
 {
   flake-file.inputs.treefmt-nix = {
-    url = "github:numtide/treefmt-nix";
     inputs.nixpkgs.follows = "nixpkgs";
+    url = "github:numtide/treefmt-nix";
   };
 
   imports = [ (inputs.treefmt-nix.flakeModule or { }) ];

--- a/modules/vm.nix
+++ b/modules/vm.nix
@@ -7,6 +7,7 @@
   perSystem = { pkgs, ... }: {
     packages.vm = pkgs.writeShellApplication {
       name = "vm";
+
       text = ''
         ${inputs.self.nixosConfigurations.harmony.config.system.build.vm}/bin/run-harmony-vm "$@"
       '';


### PR DESCRIPTION
## Summary
- Adds [Swarsel/pedantix](https://github.com/Swarsel/pedantix) as a treefmt formatter alongside nixfmt/prettier, enforcing consistent ordering of module function arguments and attribute set keys (tuned via `programs.pedantix.settings` to this repo's conventions: `config`/`lib`/`pkgs` first among args, `flake-file`/`includes`/`imports` first among attrs, sorted lists for `home.packages`/`includes`/`extraPackages`, etc.)
- Enables `statix` as an additional treefmt formatter for Nix lint auto-fixes (e.g. `inherit (x) y;` over `y = x.y;`)
- Excludes the auto-generated `flake.nix` from formatting
- Since treefmt already runs as a pre-commit hook in this repo, both tools are now part of the formatting check on every commit
- Reformats the whole repo to comply with the new rules (required on first enable, otherwise every future commit would fail the hook on pre-existing files)

## Test plan
- [x] `nix run .#write-flake` to regenerate `flake.nix`
- [x] `nix build .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel` succeeds
- [x] `nix build .#formatter.aarch64-darwin` succeeds
- [x] `nix flake check` passes
- [x] `treefmt --fail-on-change --no-cache` is idempotent (no further changes on a second run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)