### PR TITLE
feat(mkvtoolnix): use homebrew cask on Darwin instead of nixpkgs

### DIFF
--- a/modules/aspects/my/mkvtoolnix.nix
+++ b/modules/aspects/my/mkvtoolnix.nix
@@ -1,0 +1,6 @@
+{
+  my.mkvtoolnix = {
+    darwin.homebrew.casks = [ "mkvtoolnix" ];
+    hmLinux = { pkgs, ... }: { home.packages = [ pkgs.mkvtoolnix ]; };
+  };
+}

--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -69,6 +69,7 @@ in
         my.discord
         my.doc-browser
         my.ghostty
+        my.mkvtoolnix
         my.orca-slicer
         my.programmer-dvorak
         my.prusa-slicer
@@ -104,7 +105,6 @@ in
           ]
           ++ lib.optionals (scope.graphical or false) [
             inkscape
-            mkvtoolnix
             mpv
             prismlauncher
           ];


### PR DESCRIPTION
## Summary
- Moves mkvtoolnix into its own `my.mkvtoolnix` aspect, following the existing pattern used by `orca-slicer`/`prusa-slicer`/`discord`: homebrew cask on Darwin, nixpkgs package on Linux.
- Removes the inline `mkvtoolnix` entry from the shared home-manager package list in `oscar.nix` and includes the new aspect for graphical scopes instead.

## Test plan
- [x] `nix fmt`
- [x] `nix build .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel --no-link` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)