### PR TITLE
fix(logseq): don't follow our nixpkgs for nix-logseq-git-flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1040,9 +1040,7 @@
         "flake-parts": "flake-parts_5",
         "git-hooks": "git-hooks_2",
         "import-tree": "import-tree_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
+        "nixpkgs": "nixpkgs_2",
         "opam-nix": "opam-nix",
         "opam-repository": "opam-repository"
       },
@@ -1216,6 +1214,22 @@
       }
     },
     "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1783279667,
         "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
@@ -1485,7 +1499,7 @@
         "nix-logseq-git-flake": "nix-logseq-git-flake",
         "nix-minecraft": "nix-minecraft",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "pedantix": "pedantix",
         "ragenix": "ragenix",
         "stylix": "stylix",

--- a/flake.nix
+++ b/flake.nix
@@ -77,10 +77,7 @@
       url = "github:nix-community/nix-index-database";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    nix-logseq-git-flake = {
-      url = "github:Bad3r/nix-logseq-git-flake";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    nix-logseq-git-flake.url = "github:Bad3r/nix-logseq-git-flake";
     nix-minecraft = {
       url = "github:Infinidoge/nix-minecraft";
       inputs = {

--- a/modules/aspects/my/logseq.nix
+++ b/modules/aspects/my/logseq.nix
@@ -1,9 +1,6 @@
 { inputs, ... }: {
   flake-file = {
-    inputs.nix-logseq-git-flake = {
-      url = "github:Bad3r/nix-logseq-git-flake";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    inputs.nix-logseq-git-flake.url = "github:Bad3r/nix-logseq-git-flake";
 
     nixConfig = {
       extra-substituters = [ "https://nix-logseq-git-flake.cachix.org" ];


### PR DESCRIPTION
## Summary
- Removed `inputs.nixpkgs.follows = "nixpkgs"` from the `nix-logseq-git-flake` input in [modules/aspects/my/logseq.nix](modules/aspects/my/logseq.nix) — following our nixpkgs pins the flake to a nixpkgs revision not covered by its own binary cache (`nix-logseq-git-flake.cachix.org`), forcing local rebuilds instead of cache hits.
- Regenerated `flake.nix` via `nix run .#write-flake`.
- Updated `flake.lock` via `nix flake lock` so `nix-logseq-git-flake` now locks its own `nixpkgs` input independently.

## Test plan
- [x] `nix run .#write-flake` regenerated `flake.nix` cleanly
- [x] `nix flake lock` succeeded and only touched `nix-logseq-git-flake`'s `nixpkgs` sub-input