### PR TITLE
feat(nextcloud): upgrade to Nextcloud 34

### DIFF
--- a/modules/aspects/my/nextcloud.nix
+++ b/modules/aspects/my/nextcloud.nix
@@ -38,7 +38,7 @@ in
             };
 
             enable = true;
-            package = pkgs.nextcloud33;
+            package = pkgs.nextcloud34;
             database.createLocally = true;
             datadir = "/metalminds/nextcloud"; # holds both config/ (config.php) and data/ (user files)
 


### PR DESCRIPTION
## Summary
- Bumps harmony's Nextcloud service from `pkgs.nextcloud33` to `pkgs.nextcloud34` (34.0.1) in [`modules/aspects/my/nextcloud.nix`](modules/aspects/my/nextcloud.nix).
- No `flake.lock` change needed — the pinned `nixpkgs` commit already carries `nextcloud34`.

## Test plan
- [x] `nix eval` confirms `services.nextcloud.package.version` == `"34.0.1"` on the `harmony` config
- [x] `extraApps` (`richdocuments`, `user_oidc`) still resolve against the new package set
- [x] `nextcloud-occ-setup` systemd unit still evaluates
- [x] `nix fmt` — no changes
- [ ] Full `nixos-rebuild switch --flake .#harmony` (or equivalent build) on a Linux host/builder — not possible from this aarch64-darwin sandbox due to an unrelated pre-existing `doom-emacs` derivation that can't cross-build without a remote builder

Note: `nix flake check` currently fails on an unrelated, pre-existing DNS-uniqueness check (`harmony`/`melaan` both resolving `localhost` for some `global` service) that also fails on `main` — not touched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)