### PR TITLE
fix(netdata): make netdata-api.htpasswd readable by nginx

### DIFF
--- a/modules/aspects/my/netdata.nix
+++ b/modules/aspects/my/netdata.nix
@@ -30,25 +30,34 @@ in
               intermediary = true;
             };
 
-            "netdata-api.htpasswd".generator = {
-              dependencies = { inherit (secrets) netdata-api-key; };
+            "netdata-api.htpasswd" = {
+              generator = {
+                dependencies = { inherit (secrets) netdata-api-key; };
 
-              # APR1-MD5 (`openssl passwd -apr1`), not bcrypt: nginx's auth_basic only verifies
-              # crypt/APR1-MD5/SHA hashes, not bcrypt, so `htpasswd -B` would produce a hash nginx
-              # can never match.
-              script =
-                {
-                  lib,
-                  pkgs,
-                  decrypt,
-                  deps,
-                  ...
-                }:
-                ''
-                  printf 'netdata:%s\n' "$(
-                    ${pkgs.openssl}/bin/openssl passwd -apr1 "$(${decrypt} ${lib.escapeShellArg deps.netdata-api-key.file})"
-                  )"
-                '';
+                # APR1-MD5 (`openssl passwd -apr1`), not bcrypt: nginx's auth_basic only verifies
+                # crypt/APR1-MD5/SHA hashes, not bcrypt, so `htpasswd -B` would produce a hash
+                # nginx can never match.
+                script =
+                  {
+                    lib,
+                    pkgs,
+                    decrypt,
+                    deps,
+                    ...
+                  }:
+                  ''
+                    printf 'netdata:%s\n' "$(
+                      ${pkgs.openssl}/bin/openssl passwd -apr1 "$(${decrypt} ${lib.escapeShellArg deps.netdata-api-key.file})"
+                    )"
+                  '';
+              };
+
+              group = "nginx";
+              # Read directly by nginx's worker process (auth_basic_user_file), not by a systemd
+              # service with its own user= - defaults to root:root mode 0400 otherwise, which
+              # nginx can't open (500s every request to the netdata-api vhost with a bare "open()
+              # ... Permission denied" in its error log).
+              owner = "nginx";
             };
           };
 


### PR DESCRIPTION
## Summary

Follow-up to #558. After deploying, `curl -u netdata:$TOKEN https://netdata-api.harmony.silverlight-nex.us/api/v1/alarms?active=true` returned a bare nginx 500 (no backend involvement).

Root cause: `netdata-api.htpasswd`'s `age.secrets` entry had no `owner`/`group`, so agenix defaulted the decrypted file to `root:root` mode `0400`. nginx's worker process (user `nginx`) can't open it for `auth_basic_user_file`, so every request to the vhost 500s before ever reaching Netdata.

Fix: set `owner = "nginx"; group = "nginx";` on that secret. No new secret generation/rekey needed — these only affect decrypt-time file permissions, not the ciphertext.

## Test plan

- [x] `nix build .#nixosConfigurations.harmony.config.system.build.toplevel` — builds clean
- [ ] Deploy `harmony` and confirm the API returns real data instead of a 500

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>