### PR TITLE
feat(ssh): set User omarshal for gerrit.ikarem.io

### DIFF
--- a/modules/aspects/users/oscar/work/ssh-client.nix
+++ b/modules/aspects/users/oscar/work/ssh-client.nix
@@ -33,10 +33,7 @@ in
         };
 
         "dev" = lib.hm.dag.entryBefore [ "meraki.com aliases" ] { HostName = "dev203.meraki.com"; };
-
-        "gerrit.ikarem.io" = {
-          User = "omarshal";
-        };
+        "gerrit.ikarem.io".User = "omarshal";
 
         "github-meraki" = {
           HostName = "github.com";

--- a/modules/aspects/users/oscar/work/ssh-client.nix
+++ b/modules/aspects/users/oscar/work/ssh-client.nix
@@ -34,6 +34,10 @@ in
 
         "dev" = lib.hm.dag.entryBefore [ "meraki.com aliases" ] { HostName = "dev203.meraki.com"; };
 
+        "gerrit.ikarem.io" = {
+          User = "omarshal";
+        };
+
         "github-meraki" = {
           HostName = "github.com";
           IdentitiesOnly = true;


### PR DESCRIPTION
## Summary
- Add an SSH match block for `gerrit.ikarem.io` in the work SSH client config, setting `User = "omarshal"` so work Gerrit connections authenticate as the right account.

## Test plan
- [ ] `nix build .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel`