### PR TITLE
fix(renovate): restore image tags for digest-pinned containers

### DIFF
--- a/modules/aspects/my/bookshelf.nix
+++ b/modules/aspects/my/bookshelf.nix
@@ -37,7 +37,7 @@ let
           #   curl -sH "Authorization: Bearer $(curl -s 'https://ghcr.io/token?scope=repository:pennydreadful/bookshelf:pull' | jq -r .token)" \
           #     -H "Accept: application/vnd.docker.distribution.manifest.v2+json" -D - -o /dev/null \
           #     https://ghcr.io/v2/pennydreadful/bookshelf/manifests/hardcover
-          image = "ghcr.io/pennydreadful/bookshelf@sha256:388eecc94362580eae31ee0a454be6af516f8a311f8432a521c202fb475f4359";
+          image = "ghcr.io/pennydreadful/bookshelf:hardcover@sha256:388eecc94362580eae31ee0a454be6af516f8a311f8432a521c202fb475f4359";
 
           ports =
             let

--- a/modules/aspects/my/storyteller.nix
+++ b/modules/aspects/my/storyteller.nix
@@ -40,7 +40,7 @@ in
           # storyteller-platform doesn't cut stable releases, so there's nothing more specific to
           # pin to. Re-resolve via the GitLab registry API if bumping:
           #   curl -s "https://gitlab.com/api/v4/projects/67994333/registry/repositories/8429296/tags/latest"
-          image = "registry.gitlab.com/storyteller-platform/storyteller@sha256:a15609ec102de6aace73b5aae3794f7f8e9f40ed3ac2f57e923ef72daa505668";
+          image = "registry.gitlab.com/storyteller-platform/storyteller:latest@sha256:a15609ec102de6aace73b5aae3794f7f8e9f40ed3ac2f57e923ef72daa505668";
 
           ports =
             let


### PR DESCRIPTION
## Summary

- Renovate was warning `Failed to look up docker package ghcr.io/pennydreadful/bookshelf@sha256: no-result` for `modules/aspects/my/bookshelf.nix`.
- Root cause: `bookshelf.nix` and `storyteller.nix` pin their container images as `image@sha256:digest` with no tag. Renovate's `custom.regex` manager in `renovate.json` matches `depName` as everything before the first colon — with no tag present, that colon is the one inside `sha256:`, so `depName` ends up as `ghcr.io/pennydreadful/bookshelf@sha256` (and equivalently for storyteller), which fails to resolve.
- Fix: restore the tags the code comments already describe (`hardcover` for bookshelf, `latest` for storyteller) so the image strings look like `name:tag@sha256:digest`, matching every other pinned image in the repo and letting the regex parse correctly.

## Test plan

- [x] `nix-instantiate --parse` on both changed files to confirm they still parse.
- [ ] Confirm Renovate no longer emits the docker lookup warning for these two files on its next run.