### PR TITLE
fix(arr-stack): replace IP-based local-auth bypass with auth.method = External

### DIFF
--- a/modules/aspects/my/bookshelf.nix
+++ b/modules/aspects/my/bookshelf.nix
@@ -27,11 +27,19 @@ let
 
       nixos = {
         virtualisation.oci-containers.containers.${name} = {
-          # Bookshelf only reaches this vhost via nginx over loopback (its port isn't opened in
-          # the firewall), so every request it sees is "local" -- this drops Bookshelf's own login
-          # screen (it's a Readarr fork and shares Readarr's `<APPNAME>__AUTH__REQUIRED` setting)
-          # in favor of the Authentik forward-auth gate in front of it, rather than stacking both.
-          environment.READARR__AUTH__REQUIRED = "DisabledForLocalAddresses";
+          # Bookshelf only reaches this vhost via nginx (its port isn't opened in the firewall),
+          # and every such request already passed the Authentik forward-auth gate in front of it -
+          # so Bookshelf's own login is pure redundancy. `READARR__AUTH__REQUIRED =
+          # "DisabledForLocalAddresses"` used to paper over that by treating loopback-proxied
+          # requests as local, but ASP.NET Core's forwarded-headers middleware (Bookshelf is a
+          # Readarr fork and shares its auth code) rewrites the remote address from nginx's
+          # X-Forwarded-For header before that check runs, so "local" actually tracked the real
+          # client's address - true from the LAN, false the moment access came from anywhere else,
+          # which is why the login started reappearing. `READARR__AUTH__METHOD = "External"`
+          # (unlisted in Readarr/Bookshelf's own UI, but a real, supported value) sidesteps the IP
+          # heuristic entirely: it treats every request as already authenticated, full stop,
+          # leaving Authentik as the sole real gate - matching what this was always supposed to do.
+          environment.READARR__AUTH__METHOD = "External";
           # Pinned to the current "hardcover" tag's digest (Hardcover-sourced metadata, higher
           # quality than the Goodreads-compatible "softcover" variant) -- re-resolve if bumping:
           #   curl -sH "Authorization: Bearer $(curl -s 'https://ghcr.io/token?scope=repository:pennydreadful/bookshelf:pull' | jq -r .token)" \

--- a/modules/aspects/my/bookshelf.nix
+++ b/modules/aspects/my/bookshelf.nix
@@ -27,19 +27,27 @@ let
 
       nixos = {
         virtualisation.oci-containers.containers.${name} = {
-          # Bookshelf only reaches this vhost via nginx (its port isn't opened in the firewall),
-          # and every such request already passed the Authentik forward-auth gate in front of it -
-          # so Bookshelf's own login is pure redundancy. `READARR__AUTH__REQUIRED =
-          # "DisabledForLocalAddresses"` used to paper over that by treating loopback-proxied
-          # requests as local, but ASP.NET Core's forwarded-headers middleware (Bookshelf is a
-          # Readarr fork and shares its auth code) rewrites the remote address from nginx's
-          # X-Forwarded-For header before that check runs, so "local" actually tracked the real
-          # client's address - true from the LAN, false the moment access came from anywhere else,
-          # which is why the login started reappearing. `READARR__AUTH__METHOD = "External"`
-          # (unlisted in Readarr/Bookshelf's own UI, but a real, supported value) sidesteps the IP
-          # heuristic entirely: it treats every request as already authenticated, full stop,
-          # leaving Authentik as the sole real gate - matching what this was always supposed to do.
-          environment.READARR__AUTH__METHOD = "External";
+          environment = {
+            # Bookshelf only reaches this vhost via nginx (its port isn't opened in the firewall),
+            # and every such request already passed the Authentik forward-auth gate in front of it -
+            # so Bookshelf's own login is pure redundancy. `READARR__AUTH__REQUIRED =
+            # "DisabledForLocalAddresses"` used to paper over that by treating loopback-proxied
+            # requests as local, but ASP.NET Core's forwarded-headers middleware (Bookshelf is a
+            # Readarr fork and shares its auth code) rewrites the remote address from nginx's
+            # X-Forwarded-For header before that check runs, so "local" actually tracked the real
+            # client's address - true from the LAN, false the moment access came from anywhere else,
+            # which is why the login started reappearing. `READARR__AUTH__METHOD = "External"`
+            # (unlisted in Readarr/Bookshelf's own UI, but a real, supported value) sidesteps the IP
+            # heuristic entirely: it treats every request as already authenticated, full stop,
+            # leaving Authentik as the sole real gate - matching what this was always supposed to do.
+            # `READARR__AUTH__REQUIRED` is pinned to "Enabled" alongside it (rather than left unset)
+            # so nothing falls back to Bookshelf's own persisted config.xml value, which could still
+            # be the old "DisabledForLocalAddresses" - it's moot once `METHOD` already authenticates
+            # every request, but keeps that heuristic from silently reappearing if it ever weren't.
+            READARR__AUTH__METHOD = "External";
+            READARR__AUTH__REQUIRED = "Enabled";
+          };
+
           # Pinned to the current "hardcover" tag's digest (Hardcover-sourced metadata, higher
           # quality than the Goodreads-compatible "softcover" variant) -- re-resolve if bumping:
           #   curl -sH "Authorization: Bearer $(curl -s 'https://ghcr.io/token?scope=repository:pennydreadful/bookshelf:pull' | jq -r .token)" \

--- a/modules/aspects/my/prowlarr.nix
+++ b/modules/aspects/my/prowlarr.nix
@@ -17,11 +17,19 @@
             environmentFiles = [ config.age.secrets."prowlarr.env".path ];
 
             settings = {
-              # Prowlarr only reaches this vhost via nginx over loopback (its port isn't opened in
-              # the firewall), so every request it sees is "local" — this drops Prowlarr's own
-              # login screen in favor of the Authentik forward-auth gate in front of it, rather
-              # than stacking both.
-              auth.required = "DisabledForLocalAddresses";
+              # Prowlarr only reaches this vhost via nginx (its port isn't opened in the
+              # firewall), and every such request already passed the Authentik forward-auth gate
+              # in front of it - so Prowlarr's own login is pure redundancy.
+              # `auth.required = "DisabledForLocalAddresses"` used to paper over that by treating
+              # loopback-proxied requests as local, but ASP.NET Core's forwarded-headers
+              # middleware rewrites the remote address from nginx's X-Forwarded-For header before
+              # that check runs, so "local" actually tracked the real client's address - true from
+              # the LAN, false the moment access came from anywhere else, which is why the login
+              # started reappearing. `auth.method = "External"` (unlisted in Prowlarr's own UI,
+              # but a real, supported value) sidesteps the IP heuristic entirely: Prowlarr treats
+              # every request as already authenticated, full stop, leaving Authentik as the sole
+              # real gate - matching what this was always supposed to do.
+              auth.method = "External";
               server = { inherit port; };
             };
           };

--- a/modules/aspects/my/prowlarr.nix
+++ b/modules/aspects/my/prowlarr.nix
@@ -28,8 +28,16 @@
               # started reappearing. `auth.method = "External"` (unlisted in Prowlarr's own UI,
               # but a real, supported value) sidesteps the IP heuristic entirely: Prowlarr treats
               # every request as already authenticated, full stop, leaving Authentik as the sole
-              # real gate - matching what this was always supposed to do.
-              auth.method = "External";
+              # real gate - matching what this was always supposed to do. `required` is pinned to
+              # "Enabled" alongside it (rather than left unset) so nothing falls back to
+              # Prowlarr's own persisted config.xml value, which could still be the old
+              # "DisabledForLocalAddresses" - it's moot once `method` already authenticates every
+              # request, but keeps that heuristic from silently reappearing if it ever weren't.
+              auth = {
+                method = "External";
+                required = "Enabled";
+              };
+
               server = { inherit port; };
             };
           };

--- a/modules/aspects/my/radarr.nix
+++ b/modules/aspects/my/radarr.nix
@@ -13,10 +13,18 @@ in
         services.radarr = {
           enable = true;
           environmentFiles = [ config.age.secrets."radarr.env".path ];
-          # Radarr only reaches this vhost via nginx over loopback (its port isn't opened in the
-          # firewall), so every request it sees is "local" — this drops Radarr's own login screen
-          # in favor of the Authentik forward-auth gate in front of it, rather than stacking both.
-          settings.auth.required = "DisabledForLocalAddresses";
+          # Radarr only reaches this vhost via nginx (its port isn't opened in the firewall), and
+          # every such request already passed the Authentik forward-auth gate in front of it - so
+          # Radarr's own login is pure redundancy. `auth.required = "DisabledForLocalAddresses"`
+          # used to paper over that by treating loopback-proxied requests as local, but ASP.NET
+          # Core's forwarded-headers middleware rewrites the remote address from nginx's
+          # X-Forwarded-For header before that check runs, so "local" actually tracked the real
+          # client's address - true from the LAN, false the moment access came from anywhere else,
+          # which is why the login started reappearing. `auth.method = "External"` (unlisted in
+          # Radarr's own UI, but a real, supported value) sidesteps the IP heuristic entirely:
+          # Radarr treats every request as already authenticated, full stop, leaving Authentik as
+          # the sole real gate - matching what this was always supposed to do.
+          settings.auth.method = "External";
         };
 
         users.users = {

--- a/modules/aspects/my/radarr.nix
+++ b/modules/aspects/my/radarr.nix
@@ -13,6 +13,7 @@ in
         services.radarr = {
           enable = true;
           environmentFiles = [ config.age.secrets."radarr.env".path ];
+
           # Radarr only reaches this vhost via nginx (its port isn't opened in the firewall), and
           # every such request already passed the Authentik forward-auth gate in front of it - so
           # Radarr's own login is pure redundancy. `auth.required = "DisabledForLocalAddresses"`
@@ -23,8 +24,15 @@ in
           # which is why the login started reappearing. `auth.method = "External"` (unlisted in
           # Radarr's own UI, but a real, supported value) sidesteps the IP heuristic entirely:
           # Radarr treats every request as already authenticated, full stop, leaving Authentik as
-          # the sole real gate - matching what this was always supposed to do.
-          settings.auth.method = "External";
+          # the sole real gate - matching what this was always supposed to do. `required` is
+          # pinned to "Enabled" alongside it (rather than left unset) so nothing falls back to
+          # Radarr's own persisted config.xml value, which could still be the old
+          # "DisabledForLocalAddresses" - it's moot once `method` already authenticates every
+          # request, but keeps that heuristic from silently reappearing if it ever weren't.
+          settings.auth = {
+            method = "External";
+            required = "Enabled";
+          };
         };
 
         users.users = {

--- a/modules/aspects/my/sonarr.nix
+++ b/modules/aspects/my/sonarr.nix
@@ -13,10 +13,18 @@
         services.sonarr = {
           enable = true;
           environmentFiles = [ config.age.secrets."sonarr.env".path ];
-          # Sonarr only reaches this vhost via nginx over loopback (its port isn't opened in the
-          # firewall), so every request it sees is "local" — this drops Sonarr's own login screen
-          # in favor of the Authentik forward-auth gate in front of it, rather than stacking both.
-          settings.auth.required = "DisabledForLocalAddresses";
+          # Sonarr only reaches this vhost via nginx (its port isn't opened in the firewall), and
+          # every such request already passed the Authentik forward-auth gate in front of it - so
+          # Sonarr's own login is pure redundancy. `auth.required = "DisabledForLocalAddresses"`
+          # used to paper over that by treating loopback-proxied requests as local, but ASP.NET
+          # Core's forwarded-headers middleware rewrites the remote address from nginx's
+          # X-Forwarded-For header before that check runs, so "local" actually tracked the real
+          # client's address - true from the LAN, false the moment access came from anywhere else,
+          # which is why the login started reappearing. `auth.method = "External"` (unlisted in
+          # Sonarr's own UI, but a real, supported value) sidesteps the IP heuristic entirely:
+          # Sonarr treats every request as already authenticated, full stop, leaving Authentik as
+          # the sole real gate - matching what this was always supposed to do.
+          settings.auth.method = "External";
         };
 
         users.users = {

--- a/modules/aspects/my/sonarr.nix
+++ b/modules/aspects/my/sonarr.nix
@@ -13,6 +13,7 @@
         services.sonarr = {
           enable = true;
           environmentFiles = [ config.age.secrets."sonarr.env".path ];
+
           # Sonarr only reaches this vhost via nginx (its port isn't opened in the firewall), and
           # every such request already passed the Authentik forward-auth gate in front of it - so
           # Sonarr's own login is pure redundancy. `auth.required = "DisabledForLocalAddresses"`
@@ -23,8 +24,15 @@
           # which is why the login started reappearing. `auth.method = "External"` (unlisted in
           # Sonarr's own UI, but a real, supported value) sidesteps the IP heuristic entirely:
           # Sonarr treats every request as already authenticated, full stop, leaving Authentik as
-          # the sole real gate - matching what this was always supposed to do.
-          settings.auth.method = "External";
+          # the sole real gate - matching what this was always supposed to do. `required` is
+          # pinned to "Enabled" alongside it (rather than left unset) so nothing falls back to
+          # Sonarr's own persisted config.xml value, which could still be the old
+          # "DisabledForLocalAddresses" - it's moot once `method` already authenticates every
+          # request, but keeps that heuristic from silently reappearing if it ever weren't.
+          settings.auth = {
+            method = "External";
+            required = "Enabled";
+          };
         };
 
         users.users = {


### PR DESCRIPTION
## Summary

- Fixes double-login on the arr stack (Radarr, Sonarr, Prowlarr, Bookshelf) behind Authentik's forward-auth gate.
- `auth.required = "DisabledForLocalAddresses"` decided "local" from `RemoteIpAddress` *after* ASP.NET Core's forwarded-headers middleware rewrites it from nginx's `X-Forwarded-For` header — so it was really tracking the real connecting client's address, not nginx's loopback hop. That only counted as "local" when reached from the LAN, breaking silently the moment access came from anywhere else, which is why each app's own login started reappearing.
- Switches all four to `auth.method = "External"` — a real, supported value (unlisted in each app's own settings UI) that makes the app treat every request as already authenticated, independent of network path, leaving Authentik as the sole real auth gate.

## Test plan

- [x] `nix build .#nixosConfigurations.harmony.config.system.build.toplevel` succeeds
- [x] `nix fmt` reports no changes needed
- [ ] `sudo nixos-rebuild switch --flake .#harmony` on harmony and confirm single sign-on (no more app-native login prompt) for Radarr, Sonarr, Prowlarr, and Bookshelf

🤖 Generated with [Claude Code](https://claude.com/claude-code)