### PR TITLE
Automate terraform provider version bumps via Renovate

### DIFF
--- a/.github/workflows/terraform-provider-lock.yml
+++ b/.github/workflows/terraform-provider-lock.yml
@@ -37,11 +37,14 @@ jobs:
           extra_nix_config: |
             accept-flake-config = true
 
+      # No authToken: this job only needs to PULL prebuilt artifacts for speed, never push, so it
+      # doesn't need (and shouldn't be handed) a secret capable of writing to the cache - especially
+      # since pull_request_target grants this workflow access to repo secrets even for PRs whose
+      # branch content it doesn't control.
       - name: Setup Nix cache
         uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: oscarmarshall
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           extraPullNames: nix-community
 
       # `.init` generates and symlinks config.tf.json (gitignored, so it doesn't exist in a fresh

--- a/.github/workflows/terraform-provider-lock.yml
+++ b/.github/workflows/terraform-provider-lock.yml
@@ -7,10 +7,15 @@ name: Refresh Terraform provider lock
 # (see the "keep these PRs from automerging" decision in renovate.json's terraform-provider packageRule).
 on:
   pull_request:
+    # `labeled` is required, not just belt-and-suspenders: Renovate applies labels via a separate
+    # API call after the PR is already open, so the `opened` event fires before the
+    # `terraform-provider` label exists - without `labeled`, this job would never run until some
+    # later `synchronize` (e.g. Renovate rebasing the PR).
     types:
       - opened
       - reopened
       - synchronize
+      - labeled
 
 permissions:
   contents: write

--- a/.github/workflows/terraform-provider-lock.yml
+++ b/.github/workflows/terraform-provider-lock.yml
@@ -1,0 +1,66 @@
+name: Refresh Terraform provider lock
+
+# Renovate's terraform-provider customManager (see renovate.json) only rewrites the exact `version`
+# pin in the .nix source - it can't run `tofu init -upgrade` itself, so harmony-tf/.terraform.lock.hcl
+# would otherwise drift out of sync with the PR that bumped the pin. This job does that refresh and
+# pushes it back onto the same PR, so the lock-file diff review happens alongside the version bump
+# (see the "keep these PRs from automerging" decision in renovate.json's terraform-provider packageRule).
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  refresh-lock:
+    if: >
+      github.actor == 'renovate[bot]' && github.event.pull_request.user.login == 'renovate[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'terraform-provider')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+
+      - name: Setup Nix cache
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: oscarmarshall
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extraPullNames: nix-community
+
+      # `.init` generates and symlinks config.tf.json (gitignored, so it doesn't exist in a fresh
+      # checkout) and runs a plain `tofu init`; `.terraform` is the raw wrapper with args forwarded,
+      # so chaining the two is equivalent to `tofu init -upgrade` against the regenerated config.
+      # Neither step needs the `harmony-tf.env` secrets bundle - that's only for plan/apply.
+      - name: Refresh harmony-tf lock file
+        run: |
+          nix run .#harmony-tf.init
+          nix run .#harmony-tf.terraform -- init -upgrade
+
+      - name: Commit lock file if changed
+        run: |
+          if git diff --quiet -- harmony-tf/.terraform.lock.hcl; then
+            echo "Lock file already up to date."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add harmony-tf/.terraform.lock.hcl
+          git commit -m "chore(harmony-tf): refresh provider lock file"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/terraform-provider-lock.yml
+++ b/.github/workflows/terraform-provider-lock.yml
@@ -34,8 +34,8 @@ jobs:
     steps:
       # persist-credentials: false - this job runs `nix build`/`nix run` against PR-controlled Nix
       # code below, so the push token (a PAT, see the commit step) shouldn't sit in .git/config for
-      # that untrusted code to read. The default GITHUB_TOKEN here is read-only anyway; the PAT is
-      # supplied explicitly, and only for the one step that actually needs to push.
+      # that untrusted code to read, even though this workflow's own `contents: write` permission
+      # would let it. That token is supplied explicitly, and only for the one step that pushes.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -72,11 +72,11 @@ jobs:
 
       - name: Commit lock file if changed
         env:
-          # Commits pushed with the default GITHUB_TOKEN don't trigger other workflows (e.g. Test),
-          # which would leave this commit itself untested - same PAT-fallback pattern format.yml
-          # already uses for its own auto-commit push. Passed only to this step (see the checkout
-          # step's persist-credentials: false above), via an authenticated URL rather than
-          # `git config`, so it never touches disk.
+          # Falls back to github.token if secrets.PAT isn't set, same as format.yml's own
+          # auto-commit push - but that fallback means the commit won't trigger other workflows
+          # (e.g. Test), leaving it untested; set the PAT secret for that to actually happen.
+          # Passed only to this step (see the checkout step's persist-credentials: false above),
+          # via an authenticated URL rather than `git config`, so it never touches disk.
           GH_TOKEN: ${{ secrets.PAT || github.token }}
         run: |
           if git diff --quiet -- harmony-tf/.terraform.lock.hcl; then

--- a/.github/workflows/terraform-provider-lock.yml
+++ b/.github/workflows/terraform-provider-lock.yml
@@ -30,6 +30,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Commits pushed with the default GITHUB_TOKEN don't trigger other workflows (e.g. Test),
+          # which would leave the lock-file commit itself untested - same PAT-fallback pattern
+          # format.yml already uses for its own auto-commit push.
+          token: ${{ secrets.PAT || github.token }}
 
       - name: Install Nix
         uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
@@ -45,14 +49,20 @@ jobs:
           name: oscarmarshall
           extraPullNames: nix-community
 
-      # `.init` generates and symlinks config.tf.json (gitignored, so it doesn't exist in a fresh
-      # checkout) and runs a plain `tofu init`; `.terraform` is the raw wrapper with args forwarded,
-      # so chaining the two is equivalent to `tofu init -upgrade` against the regenerated config.
-      # Neither step needs the `harmony-tf.env` secrets bundle - that's only for plan/apply.
+      # Deliberately NOT `nix run .#harmony-tf.init`/`.terraform` - both go through the same wrapped
+      # `tofu` binary, whose prefixText (modules/terranix.nix) unconditionally tries to `agenix view`
+      # secrets/generated/harmony-tf.env.age when the file exists. That file IS committed, so it's
+      # present in this checkout, but CI has no YubiKey/age identity to decrypt it with, and that
+      # step would fail. Building the generated config.tf.json directly and driving a plain
+      # `opentofu` binary bypasses the wrapper - and its secret handling - entirely; `init -upgrade`
+      # never needed provider credentials anyway (see the header comment above).
       - name: Refresh harmony-tf lock file
         run: |
-          nix run .#harmony-tf.init
-          nix run .#harmony-tf.terraform -- init -upgrade
+          config="$(nix build .#harmony-tf.config --no-link --print-out-paths)"
+          mkdir -p harmony-tf
+          ln -sf "$config" harmony-tf/config.tf.json
+          cd harmony-tf
+          nix run nixpkgs#opentofu -- init -upgrade
 
       - name: Commit lock file if changed
         run: |

--- a/.github/workflows/terraform-provider-lock.yml
+++ b/.github/workflows/terraform-provider-lock.yml
@@ -6,7 +6,7 @@ name: Refresh Terraform provider lock
 # pushes it back onto the same PR, so the lock-file diff review happens alongside the version bump
 # (see the "keep these PRs from automerging" decision in renovate.json's terraform-provider packageRule).
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -38,9 +38,7 @@ jobs:
             accept-flake-config = true
 
       # No authToken: this job only needs to PULL prebuilt artifacts for speed, never push, so it
-      # doesn't need (and shouldn't be handed) a secret capable of writing to the cache - especially
-      # since pull_request_target grants this workflow access to repo secrets even for PRs whose
-      # branch content it doesn't control.
+      # doesn't need (and shouldn't be handed) a secret capable of writing to the cache.
       - name: Setup Nix cache
         uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:

--- a/.github/workflows/terraform-provider-lock.yml
+++ b/.github/workflows/terraform-provider-lock.yml
@@ -32,13 +32,14 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'terraform-provider')
     runs-on: ubuntu-latest
     steps:
+      # persist-credentials: false - this job runs `nix build`/`nix run` against PR-controlled Nix
+      # code below, so the push token (a PAT, see the commit step) shouldn't sit in .git/config for
+      # that untrusted code to read. The default GITHUB_TOKEN here is read-only anyway; the PAT is
+      # supplied explicitly, and only for the one step that actually needs to push.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          # Commits pushed with the default GITHUB_TOKEN don't trigger other workflows (e.g. Test),
-          # which would leave the lock-file commit itself untested - same PAT-fallback pattern
-          # format.yml already uses for its own auto-commit push.
-          token: ${{ secrets.PAT || github.token }}
+          persist-credentials: false
 
       - name: Install Nix
         uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
@@ -70,6 +71,13 @@ jobs:
           nix run nixpkgs#opentofu -- init -upgrade
 
       - name: Commit lock file if changed
+        env:
+          # Commits pushed with the default GITHUB_TOKEN don't trigger other workflows (e.g. Test),
+          # which would leave this commit itself untested - same PAT-fallback pattern format.yml
+          # already uses for its own auto-commit push. Passed only to this step (see the checkout
+          # step's persist-credentials: false above), via an authenticated URL rather than
+          # `git config`, so it never touches disk.
+          GH_TOKEN: ${{ secrets.PAT || github.token }}
         run: |
           if git diff --quiet -- harmony-tf/.terraform.lock.hcl; then
             echo "Lock file already up to date."
@@ -79,4 +87,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add harmony-tf/.terraform.lock.hcl
           git commit -m "chore(harmony-tf): refresh provider lock file"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" \
+            HEAD:${{ github.event.pull_request.head.ref }}

--- a/modules/aspects/my/authentik.nix
+++ b/modules/aspects/my/authentik.nix
@@ -330,7 +330,7 @@ in
 
             terraform.required_providers.authentik = {
               source = "goauthentik/authentik";
-              version = "~> 2026";
+              version = "2026.5.0";
             };
 
             variable = {

--- a/modules/aspects/my/dns.nix
+++ b/modules/aspects/my/dns.nix
@@ -125,7 +125,7 @@
 
         terraform.required_providers.cloudflare = {
           source = "cloudflare/cloudflare";
-          version = "~> 5";
+          version = "5.22.0";
         };
       };
   };

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,23 @@
       ],
       "autoReplaceStringTemplate": "image = \"{{{depName}}}:{{{newValue}}}@{{{newDigest}}}\"",
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/.+\\.nix$/"],
+      "matchStrings": [
+        "(?<=required_providers\\.[a-zA-Z0-9_-]+\\s*=\\s*\\{\\r?\\n)(?<indent1>[ \\t]*)source\\s*=\\s*\"(?<depName>[^\"]+)\";\\r?\\n(?<indent2>[ \\t]*)version\\s*=\\s*\"(?<currentValue>[^\"]+)\";"
+      ],
+      "autoReplaceStringTemplate": "{{{indent1}}}source = \"{{{depName}}}\";\n{{{indent2}}}version = \"{{{newValue}}}\";",
+      "datasourceTemplate": "terraform-provider",
+      "versioningTemplate": "hashicorp"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["terraform-provider"],
+      "automerge": false,
+      "addLabels": ["terraform-provider"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -17,9 +17,9 @@
       "customType": "regex",
       "managerFilePatterns": ["/.+\\.nix$/"],
       "matchStrings": [
-        "(?<=required_providers\\.[a-zA-Z0-9_-]+\\s*=\\s*\\{\\r?\\n)(?<indent1>[ \\t]*)source\\s*=\\s*\"(?<depName>[^\"]+)\";\\r?\\n(?<indent2>[ \\t]*)version\\s*=\\s*\"(?<currentValue>[^\"]+)\";"
+        "(?<indent0>[ \\t]*)terraform\\.required_providers\\.(?<providerAttr>[a-zA-Z0-9_-]+)\\s*=\\s*\\{\\r?\\n(?<indent1>[ \\t]*)source\\s*=\\s*\"(?<depName>[^\"]+)\";\\r?\\n(?<indent2>[ \\t]*)version\\s*=\\s*\"(?<currentValue>[^\"]+)\";"
       ],
-      "autoReplaceStringTemplate": "{{{indent1}}}source = \"{{{depName}}}\";\n{{{indent2}}}version = \"{{{newValue}}}\";",
+      "autoReplaceStringTemplate": "{{{indent0}}}terraform.required_providers.{{{providerAttr}}} = {\n{{{indent1}}}source = \"{{{depName}}}\";\n{{{indent2}}}version = \"{{{newValue}}}\";",
       "datasourceTemplate": "terraform-provider",
       "versioningTemplate": "hashicorp"
     }


### PR DESCRIPTION
## Summary
- Pin the `cloudflare` and `authentik` terraform provider versions exactly (`5.22.0`, `2026.5.0`) instead of `~>` ranges, matching `meraki`'s existing exact pin.
- Add a Renovate `customManager` in `renovate.json` that finds and bumps `terraform.required_providers.<name>` blocks in `.nix` files, using the `terraform-provider` datasource and `hashicorp` versioning. Renovate's built-in `terraform` manager only scans literal `.tf`/`.tf.json` files, which this repo doesn't have (terranix generates them from Nix at apply time), so a regex customManager is the only way to reach these version strings. RE2 (Renovate's regex engine) doesn't support lookbehind, so the match captures the full `terraform.required_providers.<name> = {` line rather than asserting it via lookaround.
- Label these PRs `terraform-provider` and disable automerge for them (`packageRules`), since the lock file and any resulting Terraform state changes need to be reviewed and merged alongside the version bump, not auto-merged separately.
- Add `.github/workflows/terraform-provider-lock.yml`: on a labeled Renovate PR, builds the generated `config.tf.json` via `nix build .#harmony-tf.config` and runs a plain `nixpkgs#opentofu -- init -upgrade` against it, then pushes a commit refreshing `harmony-tf/.terraform.lock.hcl` onto the same PR branch if it changed. This deliberately bypasses `nix run .#harmony-tf.init`/`.terraform` - both go through the same wrapped `tofu` binary, whose `prefixText` unconditionally tries to `agenix view` the committed `harmony-tf.env.age` secret when present, which CI has no YubiKey/age identity to decrypt. No secrets are needed for this job since `init -upgrade` doesn't touch provider credentials, and it uses a PAT fallback for the push (matching `format.yml`'s pattern) so the resulting commit actually triggers `Test` instead of going unverified under the default `GITHUB_TOKEN`.

## Why
Terraform provider versions were pinned inside `.nix` files with no automated way to keep them current - Dependabot's `terraform` ecosystem and Renovate's built-in `terraform` manager both require literal HCL/JSON files on disk. This wires up the existing Renovate setup (already used for Docker image tags) to reach these Nix-embedded pins too, and closes the remaining gap (the lock file) with a small, narrowly-scoped workflow.

## Test plan
- [ ] Confirm `renovate.json` validates and Renovate picks up a real provider update, opening a labeled, non-automerging PR
- [ ] Confirm `terraform-provider-lock.yml` triggers on that PR (including on label-add, not just open/sync), refreshes `harmony-tf/.terraform.lock.hcl`, and pushes the commit successfully without needing any credentials
- [ ] `nix flake check` / CI build passes on this branch