### PR TITLE
feat(kibana): add work-only ~/.kibana.env with LDAP secret

### DIFF
--- a/modules/aspects/users/oscar/work/kibana.nix
+++ b/modules/aspects/users/oscar/work/kibana.nix
@@ -1,0 +1,14 @@
+{
+  den.aspects.oscar.provides.work.provides.kibana.homeManager = { config, ... }: {
+    age.secrets.meraki-ldap-password.rekeyFile = ../../../../../secrets/meraki-ldap-password.age;
+
+    # Sourced by hand (`source ~/.kibana.env`) before hitting the Kibana API - the password is
+    # substituted at source time via an unquoted `$(cat ...)`, not baked into the store, so the
+    # file itself never carries the secret in plaintext.
+    home.file.".kibana.env".text = ''
+      export KIBANA_URL=https://kibana.ikarem.io/
+      export KIBANA_USER=omarshal
+      export KIBANA_PASSWORD="$(cat ${config.age.secrets.meraki-ldap-password.path})"
+    '';
+  };
+}

--- a/modules/aspects/users/oscar/work/kibana.nix
+++ b/modules/aspects/users/oscar/work/kibana.nix
@@ -2,9 +2,10 @@
   den.aspects.oscar.provides.work.provides.kibana.homeManager = { config, ... }: {
     age.secrets.meraki-ldap-password.rekeyFile = ../../../../../secrets/meraki-ldap-password.age;
 
-    # Sourced by hand (`source ~/.kibana.env`) before hitting the Kibana API - the password is
-    # substituted at source time via an unquoted `$(cat ...)`, not baked into the store, so the
-    # file itself never carries the secret in plaintext.
+    # Sourced by hand (`source ~/.kibana.env`) before hitting the Kibana API - `path` above is an
+    # unexpanded shell snippet (e.g. Darwin's `$(getconf DARWIN_USER_TEMP_DIR)/agenix/...`), left
+    # unquoted inside `cat` so the shell expands it at source time. The password itself is only
+    # ever read from the decrypted secret then, so this file never carries it in plaintext.
     home.file.".kibana.env".text = ''
       export KIBANA_URL=https://kibana.ikarem.io/
       export KIBANA_USER=omarshal

--- a/secrets/meraki-ldap-password.age
+++ b/secrets/meraki-ldap-password.age
@@ -1,0 +1,8 @@
+age-encryption.org/v1
+-> piv-p256 SP/5Og A/b6STypXsx4tUfFJwW/6xLLgqYUW3VX9dqm+ToG+g9X
+/lD/RKUpt+cUsPQrYDXwoEv4Bg/jC/I/0xAp8DwdMZI
+-> ubX-grease <|lM2Xx (_\9
+HvJleAA6FV7YfTwKOFiwUc5gRfQd49LjvJ7w/icUgjnV3KLoHffpXdW9iCyxO5/o
+ZExEbSBU
+--- Cgrx7k1+7M3mZ0bebM9YucRy5XQ3/ulia5ubN5Fy1fY
+NDm’yL4;èa"RÉ6¦ŒJ‚jB>¤,šì§vgçÜìŒ‘Õ¾ÙeÚÒØS"!

--- a/secrets/rekeyed/OMARSHAL-M-T2QF-home-oscar/b86f7bcb7fe3be6426c57ccd2362929a-meraki-ldap-password.age
+++ b/secrets/rekeyed/OMARSHAL-M-T2QF-home-oscar/b86f7bcb7fe3be6426c57ccd2362929a-meraki-ldap-password.age
@@ -1,0 +1,9 @@
+age-encryption.org/v1
+-> ssh-ed25519 E584hw S9Ky+iQ5n4N9dd0/c1zjU59gEJ1FLzeP/J7E0tEavkE
+N4fd1bDsgqjQXITxOEtR4l6aooJrYP8Sp8jnI0Stnnk
+-> i$P-grease CF<D k
+ijSSdAKfs2G8H59nnWGEfybCc6nzYgj7VZoHyLFpiPCLNi+UvFXoWWlLtyaO4eUj
+z/uDfVFv0bfpzWNq8/6tbcWYmZcm8lt1ooGzH7rl5aqX81mcWQ
+--- PFeEOddjYjtPKy/ssgFAkV81eR/2cjeIsaKUxRUWxDY
+›«<ŞôZ6œêeÿƒ¥z.‡aÇ3¹~(ed4Íh
+'¢çÒ;À­õ™¬$!3‘W÷&

--- a/secrets/rekeyed/dev203.meraki.com/b86f7bcb7fe3be6426c57ccd2362929a-meraki-ldap-password.age
+++ b/secrets/rekeyed/dev203.meraki.com/b86f7bcb7fe3be6426c57ccd2362929a-meraki-ldap-password.age
@@ -1,0 +1,8 @@
+age-encryption.org/v1
+-> ssh-ed25519 E584hw +NA3urNOoNoPfhkkPDuLONG0qs/JZjHoVY2p8MIys3g
+oqlJF0NMj15Eh/LgqK9rCbiq6D0nCnPf478w2AgKP60
+-> Dsg/m:7-grease
+KpltqF+EC/iuioi81Ca2gQ3fL/qpVuE/kHlZCtLDW/p7FtPoC+/rHs2inqSO9J4X
+uuq5O2OLcAq75X9i
+--- /WTa2bn2JWNjGkaklZeYXGjW+oirtOsOea4kIScPz30
+[6¶Ï8tw+Ã^Í¢åhIñÕ¸EP"£5Ú§ôx?œì08Ôm†ÞQ¦‡€º¸–$q7`


### PR DESCRIPTION
## Summary
- Adds a `kibana` aspect under `den.aspects.oscar.provides.work.provides` that writes `~/.kibana.env` (`KIBANA_URL`, `KIBANA_USER`, `KIBANA_PASSWORD`) only on hosts/homes with `work = true` (`OMARSHAL-M-T2QF` and `omarshal@dev203.meraki.com`), auto-picked up by the existing `provides.work` includes mechanism.
- Adds a new `meraki-ldap-password` agenix secret, rekeyed to both work nodes.
- The password is substituted at *source* time via an unquoted `$(cat ${config.age.secrets...path})`, matching the existing pattern in `claude.nix`, so the plaintext is never written into the Nix store.

## Test plan
- [x] `nix build .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel` succeeds
- [x] `nix eval` confirms `~/.kibana.env` is present for both work configs and absent on non-work hosts (`melaan`)
- [x] `nix eval` confirms correct unquoted secret-path expansion on both Darwin (`getconf DARWIN_USER_TEMP_DIR`) and standalone Home Manager (`XDG_RUNTIME_DIR`)
- [x] `agenix rekey -a` successfully rekeyed `meraki-ldap-password` to both work nodes
- [x] `nix fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)