### PR TITLE
feat(pedantix): unquote identifier attr/inherit names

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1351,11 +1351,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1784836877,
-        "narHash": "sha256-Cl3isSZw4YL/wIVLKV7/iUIVxtEEMPYCT4CWw+iPCP4=",
+        "lastModified": 1785459394,
+        "narHash": "sha256-6KHAEEhcylONrG9GKFsZzyNGJqj82IuCq3eefopTsd0=",
         "owner": "Swarsel",
         "repo": "pedantix",
-        "rev": "cfb564b6c4b41ce7c2b7cc17b9709e332ac81916",
+        "rev": "91464672e038a77c8dc64c68d26128859ca10870",
         "type": "github"
       },
       "original": {

--- a/modules/aspects/my/homepage.nix
+++ b/modules/aspects/my/homepage.nix
@@ -56,9 +56,9 @@ in
 
           bookmarks = [
             {
-              "Servers" = [
+              Servers = [
                 {
-                  "Harmony" = [
+                  Harmony = [
                     {
                       abbr = "HA";
                       href = "https://${urlFor hosts.homepage}";

--- a/modules/aspects/my/nextcloud.nix
+++ b/modules/aspects/my/nextcloud.nix
@@ -96,7 +96,7 @@ in
             # Compiled to /var/lib/postfix/conf/sasl_passwd.db; the plaintext source is the secret
             # itself (see its declaration above) since its only content is credentials, not a mix of
             # public config and a secret value to template together.
-            mapFiles."sasl_passwd" = config.age.secrets.nextcloud-postfix-smtp-passwd.path;
+            mapFiles.sasl_passwd = config.age.secrets.nextcloud-postfix-smtp-passwd.path;
 
             settings.main = {
               # Restricts every postfix listener (including `submission`/`smtps`, left disabled

--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -124,7 +124,7 @@ in
             settings.git_protocol = "ssh";
           };
 
-          ssh.settings."github-personal" = {
+          ssh.settings.github-personal = {
             HostName = "github.com";
             IdentitiesOnly = true;
             IdentityFile = "${./id_ed25519_personal.pub}";

--- a/modules/aspects/users/oscar/work/ssh-client.nix
+++ b/modules/aspects/users/oscar/work/ssh-client.nix
@@ -32,10 +32,10 @@ in
           User = "omarshal";
         };
 
-        "dev" = lib.hm.dag.entryBefore [ "meraki.com aliases" ] { HostName = "dev203.meraki.com"; };
+        dev = lib.hm.dag.entryBefore [ "meraki.com aliases" ] { HostName = "dev203.meraki.com"; };
         "gerrit.ikarem.io".User = "omarshal";
 
-        "github-meraki" = {
+        github-meraki = {
           HostName = "github.com";
           IdentitiesOnly = true;
           IdentityFile = "${./id_ed25519_meraki.pub}";

--- a/modules/pedantix.nix
+++ b/modules/pedantix.nix
@@ -52,11 +52,17 @@
         ];
 
         merge = true;
+        name-style = "identifier";
         sort = true;
       };
 
       formatter = "off";
-      inherits.sort = true;
+
+      inherits = {
+        name-style = "identifier";
+        sort = true;
+      };
+
       lets.sort = true;
 
       overrides = [


### PR DESCRIPTION
## Summary
- Set Pedantix's new `name-style = "identifier"` setting on `attrs` and `inherits` so attribute/inherit names that are valid Nix identifiers get unquoted (e.g. `"Servers"` -> `Servers`), while non-identifier strings (like `"gerrit.ikarem.io"`) stay quoted.
- Bumped the pinned `pedantix` flake input, since `name-style` didn't exist yet at the previously locked revision.
- Ran `nix fmt`, which reformatted 5 other files to match the new rule.

## Test plan
- [x] `nix-instantiate --parse modules/pedantix.nix`
- [x] `nix fmt` runs clean and produces the expected unquoting diffs