### PR TITLE
fix(netdata): make netdata-secrets.env readable by the netdata user

### DIFF
--- a/modules/aspects/my/netdata.nix
+++ b/modules/aspects/my/netdata.nix
@@ -89,6 +89,11 @@ in
             source "${config.age.secrets."netdata-secrets.env".path}"
             SEND_DISCORD="YES"
             DEFAULT_RECIPIENT_DISCORD="alarms"
+
+            # No local MTA on this host; Netdata Cloud already sends email
+            # notifications, so don't bother with alarm-notify.sh's own
+            # (broken, sendmail-dependent) email path.
+            SEND_EMAIL="NO"
           '';
 
           # smartmontools gives the smartctl collector S.M.A.R.T. access to individual disks

--- a/modules/aspects/my/netdata.nix
+++ b/modules/aspects/my/netdata.nix
@@ -103,21 +103,33 @@ in
           rekeyFile = ../../../secrets/discord-webhook-url.age;
         };
 
-        "netdata-secrets.env".generator = {
-          dependencies = { inherit (secrets) discord-webhook-url; };
+        "netdata-secrets.env" = {
+          generator = {
+            dependencies = { inherit (secrets) discord-webhook-url; };
 
-          script =
-            {
-              lib,
-              decrypt,
-              deps,
-              ...
-            }:
-            ''
-              printf 'DISCORD_WEBHOOK_URL="%s"\n' "$(
-                ${decrypt} ${lib.escapeShellArg deps.discord-webhook-url.file}
-              )"
-            '';
+            script =
+              {
+                lib,
+                decrypt,
+                deps,
+                ...
+              }:
+              ''
+                printf 'DISCORD_WEBHOOK_URL="%s"\n' "$(
+                  ${decrypt} ${lib.escapeShellArg deps.discord-webhook-url.file}
+                )"
+              '';
+          };
+
+          # netdata.service runs as the `netdata` user, and alarm-notify.sh sources this file
+          # directly (not via systemd LoadCredential), so it needs to be readable by that user
+          # rather than the agenix default of root-only - same class of bug as
+          # netdata-api.htpasswd needing owner = "nginx" above, just for the service itself this
+          # time instead of nginx. Root-caused on the deployed harmony after most
+          # apcupsd_last_collected_secs alarm transitions showed exec_code: 1/EXEC_FAILED on their
+          # Discord notification - alarm-notify.sh couldn't read DISCORD_WEBHOOK_URL from a
+          # root-only file while running as `netdata`.
+          owner = "netdata";
         };
       };
 


### PR DESCRIPTION
## Summary

While investigating intermittent, self-resolving `apcupsd_last_collected_secs` warnings, most of that alarm's transitions in Netdata's alert log showed `exec_code: 1` with an `EXEC_FAILED` flag on the Discord notification — the notification itself was silently failing to send.

**Fix 1 — `netdata-secrets.env` permissions.** Its `age.secrets` entry had no `owner`, so agenix defaulted the decrypted file to `root:root`. `netdata.service` runs as the `netdata` user, and `alarm-notify.sh` sources this file directly (not via systemd `LoadCredential`), so it couldn't read `DISCORD_WEBHOOK_URL` and the notification script exited non-zero. Same class of bug as `netdata-api.htpasswd` needing `owner = "nginx"` (#560) — just for the service itself this time instead of nginx.

**Fix 2 — disable alarm-notify's email path.** Found while re-checking on the deployed host: `harmony` has no local MTA, so `alarm-notify.sh`'s sendmail-dependent email path was failing regardless of the permission fix above. Netdata Cloud already delivers email notifications, so the local path has nothing to do — `SEND_EMAIL="NO"` turns it off.

## Test plan

- [x] `nix build .#nixosConfigurations.harmony.config.system.build.toplevel` — builds clean
- [ ] Deploy `harmony` and confirm Discord notifications for future alarm transitions succeed (`exec_code: 0`)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>