### PR TITLE
ssh-client: derive per-host SSH aliases from declared lan-ip

### DIFF
--- a/modules/aspects/my/ssh-client.nix
+++ b/modules/aspects/my/ssh-client.nix
@@ -34,7 +34,13 @@ in
           };
         }
       ) lanHosts;
-      aspect = user.aspect or home.aspect or null;
+      aspect =
+        if user != null then
+          user.aspect
+        else if home != null then
+          home.aspect
+        else
+          null;
     in
     {
       homeManager.programs.ssh = {

--- a/modules/aspects/my/ssh-client.nix
+++ b/modules/aspects/my/ssh-client.nix
@@ -1,19 +1,60 @@
+# Hosts that declare a `lan-ip` (see modules/den.nix) get a same-named SSH alias for free, but only
+# for whoever has an account there under the same den aspect as whoever's applying this config -
+# i.e. the same person, matched by aspect identity rather than by username, since the username on
+# each side can differ (e.g. omarshal on work machines vs oscar elsewhere). `ssh harmony` then
+# resolves to that host's LAN IP and logs in as whatever that matching account is actually named.
+{ config, lib, ... }:
+let
+  lanHosts = lib.pipe config.den.hosts [
+    builtins.attrValues
+    (map builtins.attrValues)
+    lib.flatten
+    (builtins.filter (host: host ? lan-ip))
+  ];
+in
 {
-  my.ssh-client.homeManager.programs.ssh = {
-    enable = true;
-    enableDefaultConfig = false;
+  my.ssh-client =
+    {
+      home ? null,
+      user ? null,
+      ...
+    }:
+    let
+      aliases = lib.concatMap (
+        host:
+        let
+          matchingUser = lib.findFirst (u: u.aspect == aspect) null (builtins.attrValues host.users);
+        in
+        lib.optional (matchingUser != null) {
+          inherit (host) name;
 
-    settings."*" = {
-      AddKeysToAgent = "no";
-      Compression = false;
-      ControlMaster = "no";
-      ControlPath = "~/.ssh/master-%r@%n:%p";
-      ControlPersist = "no";
-      ForwardAgent = false;
-      HashKnownHosts = false;
-      ServerAliveCountMax = 3;
-      ServerAliveInterval = 0;
-      UserKnownHostsFile = "~/.ssh/known_hosts";
+          value = {
+            HostName = host.lan-ip;
+            User = matchingUser.userName;
+          };
+        }
+      ) lanHosts;
+      aspect = user.aspect or home.aspect or null;
+    in
+    {
+      homeManager.programs.ssh = {
+        enable = true;
+        enableDefaultConfig = false;
+
+        settings = lib.listToAttrs aliases // {
+          "*" = {
+            AddKeysToAgent = "no";
+            Compression = false;
+            ControlMaster = "no";
+            ControlPath = "~/.ssh/master-%r@%n:%p";
+            ControlPersist = "no";
+            ForwardAgent = false;
+            HashKnownHosts = false;
+            ServerAliveCountMax = 3;
+            ServerAliveInterval = 0;
+            UserKnownHostsFile = "~/.ssh/known_hosts";
+          };
+        };
+      };
     };
-  };
 }

--- a/modules/aspects/my/ssh-client.nix
+++ b/modules/aspects/my/ssh-client.nix
@@ -34,13 +34,7 @@ in
           };
         }
       ) lanHosts;
-      aspect =
-        if user != null then
-          user.aspect
-        else if home != null then
-          home.aspect
-        else
-          null;
+      aspect = user.aspect or home.aspect or null;
     in
     {
       homeManager.programs.ssh = {


### PR DESCRIPTION
## Summary
- `ssh <hostname>` now works for any den host that declares a `lan-ip` (e.g. `harmony`, see `modules/den.nix`), without hardcoding the address in a user aspect.
- The alias is generated only when that host has an account under the same den aspect as whoever's applying the config (i.e. the same person), and logs in as that account's actual configured username rather than assuming it matches the local machine's username.
- A future host just needs a `lan-ip` to get its alias for free — no per-user config to touch.

## Test plan
- [x] `nix fmt` on the changed file
- [x] `nix eval` the resulting `programs.ssh.settings.harmony` across all four real targets (OMARSHAL-M-T2QF, melaan, harmony itself, and the standalone `omarshal@dev203.meraki.com` home) — all resolve to `HostName = 10.10.10.16; User = "oscar"`, confirming the aspect-based username lookup works even where the local username differs (`omarshal` on dev203).
- [x] Confirmed adelline's Home Manager config (different aspect, no matching account on harmony) gets no `harmony` alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)