### PR TITLE
fix(claude): disable flaky mcp-nixos test breaking Darwin builds

### DIFF
--- a/modules/aspects/my/claude.nix
+++ b/modules/aspects/my/claude.nix
@@ -39,6 +39,21 @@
         uv
       ];
 
+      nixpkgs.overlays = [
+        (_final: prev: {
+          # mcp-nixos's test suite has a non-hermetic test that scans
+          # whatever real file happens to come first in /nix/store (build-
+          # closure-dependent) and asserts its literal content never
+          # contains "Error" - trips on ordinary minified JS (e.g. a
+          # vendored highlight.js) and breaks the build unpredictably as
+          # nixpkgs revisions change the derivation's dependency closure.
+          # Reported upstream: https://github.com/utensils/mcp-nixos/issues/198
+          mcp-nixos = prev.mcp-nixos.overrideAttrs (old: {
+            disabledTests = (old.disabledTests or [ ]) ++ [ "test_read_text_file" ];
+          });
+        })
+      ];
+
       programs.claude-code = {
         enable = true;
 


### PR DESCRIPTION
## Summary

PR #600 (the nixpkgs bump from `421eebf` to `9bc0289`) failed its "Build Darwin hosts" check. Root cause is an upstream bug in the `mcp-nixos` package (used by `nixos.command` in [claude.nix](modules/aspects/my/claude.nix)), not anything in this repo's own code:

`tests/test_store.py::TestStoreReadTextFile::test_read_text_file` picks whichever `/nix/store/<entry>` directory happens to come first from an unsorted `os.listdir("/nix/store")` call, grabs the first small text file it finds, and asserts the literal string `"Error"` never appears in that file's *content*. Inside the Nix build sandbox, `/nix/store` only contains the derivation's build closure, so which file gets picked is effectively arbitrary and closure-dependent. This nixpkgs bump changed `mcp-nixos`'s dependency closure enough that the test landed on a vendored, minified `highlight.js` file — which, being ordinary JS, contains the substring `"Error"` (e.g. `new Error(...)`) — failing the assertion and cascading into a full Darwin system build failure.

Filed upstream: [utensils/mcp-nixos#198](https://github.com/utensils/mcp-nixos/issues/198)

## Changes

- Added an overlay in the `my.claude` `homeManager` block that overrides `mcp-nixos` to add `test_read_text_file` to `disabledTests`, matching the pattern the package itself already uses upstream for other non-hermetic/network-dependent tests (`test_valid_channel`).

## Verification

- `nix build .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel` succeeds end-to-end; `mcp-nixos`'s test suite now reports `282 passed, 2 deselected` with no failures.
- `nix fmt` run on the changed file.

## Test plan

- [ ] CI "Build Darwin hosts" check passes on this branch
- [ ] "Build Linux hosts" check remains passing (unaffected, but overlay applies cross-platform)

🤖 Generated with [Claude Code](https://claude.com/claude-code)