### PR TITLE
fix(stylix): disable regreet target to silence obsolete-option trace

### DIFF
--- a/modules/aspects/my/stylix.nix
+++ b/modules/aspects/my/stylix.nix
@@ -7,7 +7,15 @@
   my.stylix = {
     darwin.imports = [ (inputs.stylix.darwinModules.stylix or { }) ];
     homeManager = { home, ... }: builtins.seq home { imports = [ (inputs.stylix.homeModules.stylix or { }) ]; };
-    nixos.imports = [ (inputs.stylix.nixosModules.stylix or { }) ];
+
+    nixos = {
+      imports = [ (inputs.stylix.nixosModules.stylix or { }) ];
+      # No host uses greetd/regreet as its greeter (melaan is GDM, harmony is headless), and
+      # stylix's regreet target still writes to the `programs.regreet` option nixpkgs renamed to
+      # `services.displayManager.regreet`, which triggers an obsolete-option warning on every
+      # Linux host since the target auto-enables regardless of whether regreet is in use.
+      stylix.targets.regreet.enable = false;
+    };
 
     os = { pkgs, ... }: {
       stylix = {


### PR DESCRIPTION
## Summary
- `nixos-rebuild switch --flake .#harmony` (and every other NixOS host) prints `trace: Obsolete option \`programs.regreet' is used. It was renamed to \`services.displayManager.regreet'.` during evaluation.
- Traced this to stylix's `regreet` target, not our own config — it `autoEnable`s on every Linux host (`pkgs.stdenv.hostPlatform.isLinux`) regardless of whether a greeter is present, and it still writes to the `programs.regreet` option nixpkgs renamed to `services.displayManager.regreet`. Confirmed unfixed even on stylix's latest upstream `main`.
- No host actually uses greetd/regreet as its greeter (melaan uses GDM, harmony is headless with no display manager at all), so the target was pure noise everywhere it fired. Disabled `stylix.targets.regreet.enable` for all NixOS hosts instead of working around the warning.

## Test plan
- [x] `nix eval .#nixosConfigurations.harmony.config.system.build.toplevel.drvPath` — trace no longer appears (only a pre-existing, unrelated cross-arch build error remains, expected when evaluating an x86_64-linux host from aarch64-darwin)
- [x] `nix eval .#nixosConfigurations.melaan.config.system.build.toplevel.drvPath` — trace no longer appears
- [x] `nix eval .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel.drvPath` — evaluates cleanly
- [x] `nix fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)