### PR TITLE
fix(minecraft-servers): disable create-think-bigger

### DIFF
--- a/modules/aspects/users/oscar/minecraft-servers.nix
+++ b/modules/aspects/users/oscar/minecraft-servers.nix
@@ -74,7 +74,11 @@ let
       port = 25567;
 
       server = pkgs: {
-        enable = true;
+        # Crash-loops on boot: moonlight-1.21-2.18.13-neoforge.jar's moonlight-common.mixins.json
+        # has no "refmap" field, so Mixin can't resolve the embedded moonlight-common-refmap.json
+        # and PoiMixin's (required) injection fails, aborting the JVM before the world loads. Needs
+        # a mod-jar fix in mods/ (unmanaged by Nix) - disabled until then.
+        enable = false;
         package = pkgs.neoforgeServers.neoforge-1_21_1;
 
         serverProperties = {

--- a/modules/aspects/users/oscar/minecraft-servers.nix
+++ b/modules/aspects/users/oscar/minecraft-servers.nix
@@ -75,12 +75,7 @@ let
 
       server = pkgs: {
         enable = true;
-        # nix-minecraft's vanilla-servers.default.nix always builds `getLatest <requirement>`
-        # rather than the version 1.21.1 actually requires (Java 21), so bumping nix-minecraft
-        # silently jumped this server from JDK 21 to JDK 25 - which breaks the `moonlight` mod's
-        # `PoiMixin` injection ("Scanned 0 target(s). No refMap loaded.", crashing the server
-        # before it can start). Pinned back to the JDK this pack was actually built against.
-        package = pkgs.neoforgeServers.neoforge-1_21_1.override { jre_headless = pkgs.jdk21; };
+        package = pkgs.neoforgeServers.neoforge-1_21_1;
 
         serverProperties = {
           enable-rcon = true;

--- a/modules/aspects/users/oscar/minecraft-servers.nix
+++ b/modules/aspects/users/oscar/minecraft-servers.nix
@@ -75,7 +75,12 @@ let
 
       server = pkgs: {
         enable = true;
-        package = pkgs.neoforgeServers.neoforge-1_21_1;
+        # nix-minecraft's vanilla-servers.default.nix always builds `getLatest <requirement>`
+        # rather than the version 1.21.1 actually requires (Java 21), so bumping nix-minecraft
+        # silently jumped this server from JDK 21 to JDK 25 - which breaks the `moonlight` mod's
+        # `PoiMixin` injection ("Scanned 0 target(s). No refMap loaded.", crashing the server
+        # before it can start). Pinned back to the JDK this pack was actually built against.
+        package = pkgs.neoforgeServers.neoforge-1_21_1.override { jre_headless = pkgs.jdk21; };
 
         serverProperties = {
           enable-rcon = true;


### PR DESCRIPTION
## Summary

- `create-think-bigger` (NeoForge 1.21.1) has been crash-looping since it was investigated in #637 (closed without merging).
- Root cause (confirmed by running the server binary directly on harmony): `moonlight-1.21-2.18.13-neoforge.jar` in the world's `mods/` folder has a `moonlight-common.mixins.json` missing its `"refmap"` field, so Mixin can't resolve the embedded `moonlight-common-refmap.json`. `PoiMixin`'s injection is marked `required`, so the missing refmap is fatal instead of a warning, aborting the JVM before the world loads.
- This is a mod-jar problem in `mods/` (unmanaged by Nix, not something this flake can fix) — not a JDK or nix-minecraft issue (ruled both out in #637).
- Disabling the server (`enable = false`) until the mod jar is fixed/updated by hand next time it's played.

## Test plan

- [x] `nix eval` confirms `services.minecraft-servers.servers.create-think-bigger.enable` resolves to `false`.
- [x] `nix fmt` — no changes needed.
- [ ] Deploy via `nixos-rebuild switch` on harmony and confirm the unit is stopped/disabled and no longer crash-looping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)