### PR TITLE
feat(neardrop): add NearDrop cask to MacBook, fix mkvtoolnix rename

### DIFF
--- a/modules/aspects/hosts/OMARSHAL-M-T2QF/OMARSHAL-M-T2QF.nix
+++ b/modules/aspects/hosts/OMARSHAL-M-T2QF/OMARSHAL-M-T2QF.nix
@@ -1,6 +1,9 @@
 { my, ... }: {
   den.aspects.OMARSHAL-M-T2QF = {
-    includes = with my; [ homebrew ];
+    includes = with my; [
+      homebrew
+      neardrop
+    ];
 
     darwin = {
       age.rekey.hostPubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJYml5zuvVCI6yKyiCz9Jx5wv9S4OrzZRltqzEH1NQdC";

--- a/modules/aspects/my/mkvtoolnix.nix
+++ b/modules/aspects/my/mkvtoolnix.nix
@@ -1,6 +1,6 @@
 {
   my.mkvtoolnix = {
-    darwin.homebrew.casks = [ "mkvtoolnix" ];
+    darwin.homebrew.casks = [ "mkvtoolnix-app" ];
     hmLinux = { pkgs, ... }: { home.packages = [ pkgs.mkvtoolnix ]; };
   };
 }

--- a/modules/aspects/my/neardrop.nix
+++ b/modules/aspects/my/neardrop.nix
@@ -1,0 +1,12 @@
+{
+  my.neardrop.darwin.homebrew = {
+    casks = [
+      {
+        name = "grishka/grishka/neardrop";
+        trusted = true;
+      }
+    ];
+
+    taps = [ "grishka/grishka" ];
+  };
+}


### PR DESCRIPTION
## Summary
- Add [NearDrop](https://github.com/grishka/NearDrop) (unofficial Nearby Share receiver) to the MacBook config. It has no official Homebrew Cask entry, so this taps the author's own repo (`grishka/grishka`) and marks the fully-qualified cask `trusted: true` so `brew bundle` can install it under Homebrew 6.0's new tap-trust requirement, without a manual `brew trust` step.
- Fix `mkvtoolnix` → `mkvtoolnix-app`, matching Homebrew's cask rename (was producing a rename warning on every `darwin-rebuild switch`).

## Test plan
- [x] `nix fmt` clean
- [x] `nix build .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel` succeeds
- [x] Verified the generated Brewfile contains `tap "grishka/grishka"` and `cask "grishka/grishka/neardrop", trusted: true`
- [ ] `darwin-rebuild switch --flake .#OMARSHAL-M-T2QF` on the actual machine (not run by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)