### PR TITLE
fix(netdata): stop misidentifying authentik as squid/jitsi exporters

### DIFF
--- a/modules/aspects/my/netdata-net-listeners.conf
+++ b/modules/aspects/my/netdata-net-listeners.conf
@@ -1,0 +1,553 @@
+disabled: no
+
+discoverer:
+  net_listeners: { }
+
+services:
+  - id: "activemq"
+    match: '{{ and (eq .Port "8161") (eq .Comm "activemq") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+      webadmin: admin
+
+  - id: "apache"
+    match: '{{ and (eq .Port "80" "8080") (eq .Comm "apache" "apache2" "httpd") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}/server-status?auto
+
+  - id: "apcupsd"
+    match: '{{ or (eq .Port "3551") (eq .Comm "apcupsd") }}'
+    config_template: |
+      name: local_{{.Port}}
+      address: {{.Address}}
+
+  - id: "beanstalk"
+    match: '{{ or (eq .Port "11300") (eq .Comm "beanstalkd") }}'
+    config_template: |
+      name: local
+      address: {{.Address}}
+
+  - id: "bind"
+    match: '{{ and (eq .Port "8653") (eq .Comm "bind" "named") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}/json/v1
+
+  - id: "boinc"
+    match: '{{ and (eq .Port "31416") (eq .Comm "boinc") }}'
+    config_template: |
+      name: local
+      address: {{.Address}}
+
+  - id: "cassandra"
+    match: '{{ and (eq .Port "7072") (glob .Cmdline "*cassandra*") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}/metrics
+
+  - id: "ceph"
+    match: '{{ and (eq .Port "8443") (eq .Comm "ceph-mgr") }}'
+    config_template: |
+      name: local
+      url: https://{{.Address}}
+
+  - id: "chrony"
+    match: '{{ and (eq .Port "323") (eq .Comm "chronyd") }}'
+    config_template: |
+      name: local
+      address: {{.Address}}
+
+  - id: "clickhouse"
+    match: '{{ and (eq .Port "8123") (eq .Comm "clickhouse-server") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+
+  - id: "cockroachdb"
+    match: '{{ and (eq .Port "8080") (eq .Comm "cockroach") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}/_status/vars
+
+  - id: "consul"
+    match: '{{ and (eq .Port "8500") (eq .Comm "consul") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+
+  - id: "coredns"
+    match: '{{ and (eq .Port "9153") (eq .Comm "coredns") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}/metrics
+
+  - id: "couchbase"
+    match: '{{ or (eq .Port "8091") (glob .Cmdline "*couchbase*") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+
+  - id: "couchdb"
+    match: '{{ or (eq .Port "5984") (glob .Cmdline "*couchdb*") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+      node: '_local'
+
+  - id: "dcgm"
+    match: '{{ eq .Comm "dcgm-exporter" }}'
+    config_template: |
+      name: local
+      update_every: 30
+      url: http://{{.Address}}/metrics
+
+  - id: "dnsdist"
+    match: '{{ and (eq .Port "8083") (eq .Comm "dnsdist") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+      headers:
+        X-API-Key: 'dnsdist-api-key'
+
+  - id: "dnsmasq"
+    match: '{{ and (eq .Protocol "UDP") (eq .Port "53") (eq .Comm "dnsmasq") }}'
+    config_template: |
+      name: local
+      protocol: udp
+      address: {{.Address}}
+
+  - id: "docker_engine"
+    match: '{{ and (eq .Port "9323") (eq .Comm "dockerd") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}/metrics
+
+  - id: "dovecot"
+    match: '{{ and (eq .Port "24242") (eq .Comm "dovecot") }}'
+    config_template: |
+      name: local
+      address: {{.Address}}
+
+  - id: "elasticsearch"
+    match: '{{ or (eq .Port "9200") (glob .Cmdline "*elasticsearch*" "*opensearch*") }}'
+    config_template: |
+      name: local
+      {{ if glob .Cmdline "*elastic*" -}}
+      url: http://{{.Address}}
+      {{ else -}}
+      url: https://{{.Address}}
+      tls_skip_verify: yes
+      username: admin
+      password: admin
+      {{ end -}}
+
+  - id: "envoy"
+    match: '{{ and (eq .Port "9901") (eq .Comm "envoy") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}/stats/prometheus
+
+  - id: "fluentd"
+    match: '{{ and (eq .Port "24220") (glob .Cmdline "*fluentd*") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+
+  - id: "freeradius"
+    match: '{{ and (eq .Port "18121") (eq .Comm "freeradius") }}'
+    config_template: |
+      name: local
+      address: {{.IPAddress}}
+      port: {{.Port}}
+      secret: adminsecret
+
+  - id: "gearman"
+    match: '{{ or (eq .Port "4730") (eq .Comm "gearmand") }}'
+    config_template: |
+      name: local
+      address: {{.Address}}
+
+  - id: "geth"
+    match: '{{ and (eq .Port "6060") (eq .Comm "geth") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}/debug/metrics/prometheus
+
+  - id: "haproxy"
+    match: '{{ and (eq .Port "8404") (eq .Comm "haproxy") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}/metrics
+
+  - id: "hddtemp"
+    match: '{{ and (eq .Port "7634") (eq .Comm "hddtemp") }}'
+    config_template: |
+      name: local
+      address: {{.Address}}
+
+  - id: "hdfs_namenode"
+    match: '{{ and (eq .Port "9870") (eq .Comm "hadoop") }}'
+    config_template: |
+      module: hdfs
+      name: namenode_local
+      url: http://{{.Address}}/jmx
+
+  - id: "hdfs_datanode"
+    match: '{{ and (eq .Port "9864") (eq .Comm "hadoop") }}'
+    config_template: |
+      module: hdfs
+      name: datanode_local
+      url: http://{{.Address}}/jmx
+
+  - id: "icecast"
+    match: '{{ and (eq .Port "8000") (eq .Comm "icecast") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+
+  - id: "ipfs"
+    match: '{{ and (eq .Port "5001") (eq .Comm "ipfs") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+
+  - id: "k8s_kubelet"
+    match: '{{ and (eq .Port "10250" "10255") (eq .Comm "kubelet") }}'
+    config_template: |
+      name: local
+      {{- if eq .Port "10255" }}
+      url: http://{{.Address}}/metrics
+      {{- else }}
+      url: https://{{.Address}}/metrics
+      tls_skip_verify: yes
+      {{- end }}
+
+  - id: "k8s_kubeproxy"
+    match: '{{ and (eq .Port "10249") (eq .Comm "kube-proxy") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}/metrics
+
+  - id: "lighttpd"
+    match: '{{ and (eq .Port "80" "8080") (eq .Comm "lighttpd") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}/server-status?auto
+
+  - id: "logstash"
+    match: '{{ and (eq .Port "9600") (glob .Cmdline "*logstash*") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+
+  - id: "maxscale"
+    match: '{{ or (eq .Port "8989") (eq .Comm "maxscale") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+
+  - id: "memcached"
+    match: '{{ or (eq .Port "11211") (eq .Comm "memcached") }}'
+    config_template: |
+      name: local
+      address: {{.Address}}
+
+  - id: "mongodb"
+    match: '{{ or (eq .Port "27017") (eq .Comm "mongod") }}'
+    config_template: |
+      name: local
+      uri: mongodb://{{.Address}}
+
+  - id: "monit"
+    match: '{{ or (eq .Port "2812") (eq .Comm "monit") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+      username: admin
+      password: monit
+
+  - id: "mysql"
+    match: '{{ or (eq .Port "3306") (eq .Comm "mysqld" "mariadbd") }}'
+    config_template: |
+      - name: local
+        dsn: netdata@unix(/var/run/mysqld/mysqld.sock)/
+      - name: local
+        dsn: netdata@tcp({{.Address}})/
+
+  - id: "nats"
+    match: '{{ and (eq .Port "8222") (eq .Comm "nats-server") }}'
+    config_template: |
+      - name: local
+        url: http://{{.Address}}
+
+  - id: "nginx"
+    match: '{{ and (eq .Port "80" "8080") (eq .Comm "nginx") }}'
+    config_template: |
+      - name: local
+        url: http://{{.Address}}/stub_status
+      - name: local
+        url: http://{{.Address}}/basic_status
+      - name: local
+        url: http://{{.Address}}/nginx_status
+      - name: local
+        url: http://{{.Address}}/status
+
+  - id: "nginxunit"
+    match: '{{ and (eq .Port "8000") (eq .Comm "unit") }}'
+    config_template: |
+      - name: local
+        url: http://{{.Address}}
+
+  - id: "ntpd"
+    match: '{{ or (eq .Port "123") (eq .Comm "ntpd") }}'
+    config_template: |
+      name: local
+      address: {{.Address}}
+      collect_peers: no
+
+  - id: "openldap"
+    match: '{{ eq .Comm "slapd" }}'
+    config_template: |
+      name: local
+      url: ldap://{{.Address}}
+
+  - id: "openvpn"
+    match: '{{ and (eq .Port "7505") (eq .Comm "openvpn") }}'
+    config_template: |
+      name: local
+      address: {{.Address}}
+
+  - id: "oracledb"
+    match: '{{ and (eq .Port "1521" "2484") (eq .Comm "tnslsnr") }}'
+    config_template: |
+      name: local
+      {{ if eq .Port "1521" -}}
+      dsn: 'oracle://username:password@{{.Address}}/XE'
+      {{ else -}}
+      dsn: 'oracle://username:password@{{.Address}}/XE?ssl=true&ssl verify=false'
+      {{ end -}}
+
+  - id: "pgbouncer"
+    match: '{{ or (eq .Port "6432") (eq .Comm "pgbouncer") }}'
+    config_template: |
+      name: local
+      dsn: postgres://netdata:postgres@{{.Address}}/pgbouncer
+
+  - id: "pihole"
+    match: '{{ and (eq .Port "80") (eq .Comm "pihole-FTL") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+
+  - id: "pika"
+    match: '{{ and (eq .Port "9221") (eq .Comm "pika") }}'
+    config_template: |
+      name: local
+      address: redis://@{{.IPAddress}}:{{.Port}}
+
+  - id: "postgres"
+    match: '{{ or (eq .Port "5432") (eq .Comm "postgres") }}'
+    config_template: |
+      - name: local
+        dsn: 'host=/var/run/postgresql dbname=postgres user=postgres'
+      - name: local
+        dsn: 'host=/var/run/postgresql dbname=postgres user=netdata'
+      - name: local
+        dsn: postgresql://netdata@{{.Address}}/postgres
+
+  - id: "powerdns"
+    match: '{{ and (eq .Port "8081") (eq .Comm "pdns_server") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+      headers:
+        X-API-KEY: secret
+
+  - id: "powerdns_recursor"
+    match: '{{ and (eq .Port "8081") (eq .Comm "pdns_recursor") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+      headers:
+        X-API-KEY: secret
+
+  - id: "proxysql"
+    match: '{{ or (eq .Port "6032") (eq .Comm "proxysql") }}'
+    config_template: |
+      name: local
+      dsn: stats:stats@tcp({{.Address}})/
+
+  - id: "puppet"
+    match: '{{ or (eq .Port "8140") (glob .Cmdline "*puppet-server*") }}'
+    config_template: |
+      name: local
+      url: https://{{.Address}}
+      tls_skip_verify: yes
+
+  - id: "rabbitmq"
+    match: '{{ or (eq .Port "15672") (glob .Cmdline "*rabbitmq*") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+      username: guest
+      password: guest
+      collect_queues_metrics: no
+
+  - id: "redis"
+    match: '{{ or (eq .Port "6379") (eq .Comm "redis-server") }}'
+    config_template: |
+      name: local
+      address: redis://@{{.Address}}
+
+  - id: "rethinkdb"
+    match: '{{ and (eq .Port "28015") (eq .Comm "rethinkdb") }}'
+    config_template: |
+      name: local
+      address: {{.Address}}
+
+  - id: "riak"
+    match: '{{ and (eq .Port "8098") (glob .Cmdline "*riak*") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}/stats
+
+  - id: "rspamd"
+    match: '{{ and (eq .Port "11334") (eq .Comm "rspamd") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+
+  - id: "squid"
+    match: '{{ and (eq .Port "3128") (eq .Comm "squid") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+
+  - id: "spigotmc"
+    match: '{{ and (eq .Port "25575") (glob .Cmdline "*spigot*") }}'
+    config_template: |
+      name: local
+      address: {{.Address}}
+
+  - id: "supervisord"
+    match: '{{ and (eq .Port "9001") (eq .Comm "supervisord") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}/RPC2
+
+  - id: "tomcat"
+    match: '{{ and (eq .Port "8080") (glob .Cmdline "*tomcat*") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+
+  - id: "tor"
+    match: '{{ and (eq .Port "9051") (eq .Comm "tor") }}'
+    config_template: |
+      name: local
+      address: {{.Address}}
+
+  - id: "traefik"
+    match: '{{ and (eq .Port "80" "8080") (eq .Comm "traefik") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}/metrics
+
+  - id: "typesense"
+    match: '{{ and (eq .Port "8108") (eq .Comm "typesense-server") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}
+      api_key: {{ trimPrefix "--api-key=" (regexFind "--api-key=[^ ]+" .Cmdline) -}}
+
+  - id: "unbound"
+    match: '{{ and (eq .Port "8953") (eq .Comm "unbound") }}'
+    config_template: |
+      name: local
+      address: {{.Address}}
+
+  - id: "upsd"
+    match: '{{ or (eq .Port "3493") (eq .Comm "upsd") }}'
+    config_template: |
+      name: local
+      address: {{.Address}}
+
+  - id: "uwsgi"
+    match: '{{ and (eq .Port "1717") (eq .Comm "uwsgi") }}'
+    config_template: |
+      name: local
+      address: {{.Address}}
+
+  - id: "vernemq"
+    match: '{{ and (eq .Port "8888") (glob .Cmdline "*vernemq*") }}'
+    config_template: |
+      name: local
+      url: http://{{.Address}}/metrics
+
+  - id: "yugabytedb"
+    match: '{{ and (eq .Port "7000" "9000" "12000" "13000") (or (glob .Cmdline "*YSQL*") (eq .Comm "yb-master" "yb-tserver")) }}'
+    config_template: |
+      - module: yugabytedb
+        {{ if eq .Port "7000" -}}
+        name: local_master
+        {{ else if eq .Port "9000" -}}
+        name: local_tserver
+        {{ else if eq .Port "12000" -}}
+        name: local_ycql
+        {{ else if eq .Port "13000" -}}
+        name: local_ysql
+        {{ else -}}
+        name: local
+        {{ end }}
+        url: http://{{.Address}}/prometheus-metrics
+
+  - id: "zookeeper"
+    match: '{{ or (eq .Port "2181" "2182") (glob .Cmdline "*zookeeper*") }}'
+    config_template: |
+      name: local
+      address: {{.Address}}
+
+  # authentik's embedded outpost (9001, HTTP metrics probe returns empty body) and its Django
+  # metrics endpoint (9301) both get misidentified by the generic "exporter" catch-all below -
+  # go.d's promPort() guesses port names from well-known third-party exporter defaults (9001 ->
+  # supervisord/jitsi-videobridge, 9301 -> squid-exporter) with no way to tell it's actually
+  # authentik on those ports. Skip both here (a service entry with no config_template drops the
+  # target before the catch-all runs) rather than actually monitoring authentik under a
+  # misleading "squid"/"jitsi" name.
+  - id: "skip-authentik-metrics-ports"
+    match: '{{ or (eq .Port "9001") (eq .Port "9301") }}'
+
+  - id: "exporter"
+    match: '{{ or (and (not (empty (promPort .Port))) (not (eq .Comm "docker-proxy"))) (glob .Comm "*exporter*") }}'
+    config_template: |
+      {{ $name := promPort .Port -}}
+      {{ if empty $name -}}
+      {{ $name = printf "%s_%s" .Comm .Port -}}
+      {{ end -}}
+      module: prometheus
+      name: {{$name}}_local
+      url: http://{{.Address}}/metrics
+      {{ if eq $name "caddy" -}}
+      expected_prefix: 'caddy_'
+      {{ else if eq $name "openethereum" -}}
+      expected_prefix: 'blockchaincache_'
+      {{ else if eq $name "crowdsec" -}}
+      expected_prefix: 'cs_'
+      {{ else if eq $name "netbox" -}}
+      expected_prefix: 'django_'
+      {{ else if eq $name "traefik" -}}
+      expected_prefix: 'traefik_'
+      {{ else if eq $name "ripe_atlas_exporter" -}}
+      expected_prefix: 'atlas_'
+      {{ else if eq $name "pushgateway" -}}
+      expected_prefix: 'pushgateway_'
+      selector:
+        allow:
+          - pushgateway_*
+      {{ else if eq $name "wireguard_exporter" -}}
+      expected_prefix: 'wireguard_exporter'
+      {{ else if eq $name "clickhouse" -}}
+      max_time_series: 3000
+      {{ end -}}

--- a/modules/aspects/my/netdata.nix
+++ b/modules/aspects/my/netdata.nix
@@ -90,7 +90,10 @@ in
             # returns an empty body (permanent "check failed: expected a valid start token, got
             # \"<\"" collector-status alerts), the other happens to return authentik's real
             # prometheus output but mislabeled as squid. There's no smaller/per-job override for
-            # this - see https://github.com/netdata/netdata/discussions/20921.
+            # this - see https://github.com/netdata/netdata/discussions/20921. Everything else in
+            # the file is an unmodified copy of upstream's matchers - a netdata package bump won't
+            # bring in any new upstream matchers added since, so re-diff against the new version's
+            # stock file if a legitimate third-party exporter stops auto-detecting after a bump.
             "go.d/sd/net_listeners.conf" = ./netdata-net-listeners.conf;
 
             # Stock health.d/systemdunits.conf ships every "unit in the failed state" template with

--- a/modules/aspects/my/netdata.nix
+++ b/modules/aspects/my/netdata.nix
@@ -82,6 +82,17 @@ in
           package = pkgs.netdata.override { withCloudUi = true; };
 
           configDir = {
+            # Stock file plus one added skip rule matching both port 9001 (authentik's embedded
+            # outpost) and port 9301 (authentik's Django metrics endpoint): go.d's generic
+            # "exporter" catch-all rule misidentifies both, guessing exporter identity from
+            # well-known third-party ports (9001 -> supervisord/jitsi-videobridge, 9301 ->
+            # squid-exporter) with no way to know it's actually authentik - one of those guesses
+            # returns an empty body (permanent "check failed: expected a valid start token, got
+            # \"<\"" collector-status alerts), the other happens to return authentik's real
+            # prometheus output but mislabeled as squid. There's no smaller/per-job override for
+            # this - see https://github.com/netdata/netdata/discussions/20921.
+            "go.d/sd/net_listeners.conf" = ./netdata-net-listeners.conf;
+
             # Stock health.d/systemdunits.conf ships every "unit in the failed state" template with
             # `chart labels: unit_name=!*` - Netdata's simple-pattern matching treats a bare `!*` as
             # "reject every value, nothing left to accept", so by design none of these ever match any


### PR DESCRIPTION
## Summary

- Netdata's own logs on harmony show recurring `check failed: failed to parse prometheus metrics: expected a valid start token, got "<"` for a job named `jitsi_videobridge_exporter_local`, plus a `squid_exporter_local` job that (mostly) succeeds but is mislabeled.
- Root cause: go.d's `net_listeners` service discovery has a generic "exporter" catch-all rule that guesses exporter identity purely from well-known third-party default ports (`promPort()`), with no way to know what's actually running there. Verified directly on harmony:
  - Port 9001 (guessed: jitsi-videobridge/supervisord) is actually authentik's embedded outpost (`x-powered-by: authentik`), which returns an empty 200 body — permanently failing prometheus parsing on every discovery cycle.
  - Port 9301 (guessed: squid-exporter) is actually authentik's own Django `/metrics` endpoint (`django_db_*`, `django_http_*` series) — it happens to be valid Prometheus text, so it "succeeds," just under the wrong name.
- There's no smaller per-job override for this in netdata — the only supported mechanism is a full replacement of `go.d/sd/net_listeners.conf` ([confirmed upstream](https://github.com/netdata/netdata/discussions/20921)).

## Change

- Adds `modules/aspects/my/netdata-net-listeners.conf`: the stock file (netdata 2.10.3) plus one added skip rule for ports 9001 and 9301, placed just before the generic "exporter" catch-all so those two ports are dropped from discovery entirely instead of being mislabeled.
- Wires it in via `services.netdata.configDir."go.d/sd/net_listeners.conf"` in [netdata.nix](modules/aspects/my/netdata.nix), following the same override pattern already used for `health_alarm_notify.conf`.
- Everything else in the file is an unmodified copy of upstream's matchers (postgres, redis, memcached, etc. all still auto-detect normally) — this is a maintenance trade-off (future netdata bumps that add new matchers won't show up here until this file is refreshed), noted inline in netdata.nix.

## Test plan

- [x] `nix eval` confirms `services.netdata.configDir."go.d/sd/net_listeners.conf"` resolves to a real store path containing the skip rule.
- [x] `nix fmt` — no changes needed beyond auto-merging the `configDir` attrs.
- [ ] Deploy via `nixos-rebuild switch` on harmony and confirm `squid_exporter_local`/`jitsi_videobridge_exporter_local` no longer appear as go.d jobs, and authentik's real metrics endpoints are simply left unmonitored (as intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)