### PR TITLE
fix(auto-upgrade): skip auto-upgrade run when checkout isn't cleanly on main

### DIFF
--- a/modules/aspects/my/auto-upgrade.nix
+++ b/modules/aspects/my/auto-upgrade.nix
@@ -15,10 +15,12 @@ in
       };
 
       # Skip this run - rather than failing it - when the checkout this generation was
-      # switched from isn't cleanly at main's tip: uncommitted changes (dirty), unpushed/
-      # unmerged commits (behind), or diverged history (diverged). Otherwise the timer would
-      # silently switch a host back to main mid-test. Being merely behind main (the normal
-      # case the timer exists to fix) is not blocked.
+      # switched from isn't cleanly at (or behind) main's tip: uncommitted changes (dirty),
+      # unpushed/unmerged commits (behind), diverged history (diverged), or an unknown compare
+      # result (e.g. transient API failure, rate limit, or a rev GitHub can't find). Otherwise
+      # the timer would silently switch a host back to main mid-test. Being merely behind main
+      # (the normal case the timer exists to fix) is not blocked - this is an allow-list so
+      # anything other than that confirmed-safe status fails closed.
       systemd.services.nixos-upgrade.serviceConfig.ExecCondition = pkgs.writeShellScript "nixos-upgrade-on-main" ''
         ${
           if rev != null then
@@ -37,7 +39,8 @@ in
         }
 
         case "$status" in
-          behind | diverged) exit 1 ;;
+          ahead | identical) ;;
+          *) exit 1 ;;
         esac
 
         ${lib.optionalString isDirty "exit 1"}

--- a/modules/aspects/my/auto-upgrade.nix
+++ b/modules/aspects/my/auto-upgrade.nix
@@ -1,9 +1,46 @@
+{ lib, self, ... }:
+let
+  isDirty = self ? dirtyRev;
+  # Extract the base commit SHA: self.rev when clean, or strip the "-dirty" suffix
+  # from self.dirtyRev (available in Nix >= 2.11) when dirty.
+  rev = self.rev or (if self ? dirtyRev then builtins.substring 0 40 self.dirtyRev else null);
+in
 {
   my.auto-upgrade = { allowReboot }: {
-    nixos.system.autoUpgrade = {
-      inherit allowReboot;
-      enable = true;
-      flake = "github:OscarMarshall/dotfiles";
+    nixos = { config, pkgs, ... }: {
+      system.autoUpgrade = {
+        inherit allowReboot;
+        enable = true;
+        flake = "github:OscarMarshall/dotfiles";
+      };
+
+      # Skip this run - rather than failing it - when the checkout this generation was
+      # switched from isn't cleanly at main's tip: uncommitted changes (dirty), unpushed/
+      # unmerged commits (behind), or diverged history (diverged). Otherwise the timer would
+      # silently switch a host back to main mid-test. Being merely behind main (the normal
+      # case the timer exists to fix) is not blocked.
+      systemd.services.nixos-upgrade.serviceConfig.ExecCondition = pkgs.writeShellScript "nixos-upgrade-on-main" ''
+        ${
+          if rev != null then
+            ''
+              status=$(
+                ${pkgs.curl}/bin/curl -sf \
+                  --connect-timeout 2 --max-time 3 \
+                  -H "Authorization: token $(${pkgs.coreutils}/bin/cat ${config.age.secrets.nix-github-access-token.path} 2>/dev/null || true)" \
+                  "https://api.github.com/repos/OscarMarshall/dotfiles/compare/${rev}...main" |
+                  ${pkgs.jq}/bin/jq -r '.status // empty' 2>/dev/null || true
+              )
+            ''
+          else
+            ""
+        }
+
+        case "$status" in
+          behind | diverged) exit 1 ;;
+        esac
+
+        ${lib.optionalString isDirty "exit 1"}
+      '';
     };
   };
 }

--- a/modules/aspects/my/auto-upgrade.nix
+++ b/modules/aspects/my/auto-upgrade.nix
@@ -22,6 +22,9 @@ in
       # (the normal case the timer exists to fix) is not blocked - this is an allow-list so
       # anything other than that confirmed-safe status fails closed.
       systemd.services.nixos-upgrade.serviceConfig.ExecCondition = pkgs.writeShellScript "nixos-upgrade-on-main" ''
+        ${lib.optionalString isDirty "exit 1"}
+
+        status=""
         ${
           if rev != null then
             ''
@@ -42,8 +45,6 @@ in
           ahead | identical) ;;
           *) exit 1 ;;
         esac
-
-        ${lib.optionalString isDirty "exit 1"}
       '';
     };
   };

--- a/modules/aspects/my/auto-upgrade.nix
+++ b/modules/aspects/my/auto-upgrade.nix
@@ -23,10 +23,11 @@ in
         ${
           if rev != null then
             ''
+              github_token="$(${pkgs.coreutils}/bin/cat ${config.age.secrets.nix-github-access-token.path} 2>/dev/null || true)"
               status=$(
                 ${pkgs.curl}/bin/curl -sf \
                   --connect-timeout 2 --max-time 3 \
-                  -H "Authorization: token $(${pkgs.coreutils}/bin/cat ${config.age.secrets.nix-github-access-token.path} 2>/dev/null || true)" \
+                  ''${github_token:+-H "Authorization: token $github_token"} \
                   "https://api.github.com/repos/OscarMarshall/dotfiles/compare/${rev}...main" |
                   ${pkgs.jq}/bin/jq -r '.status // empty' 2>/dev/null || true
               )


### PR DESCRIPTION
## Summary

- `nixos.system.autoUpgrade`'s systemd timer always fetches `github:OscarMarshall/dotfiles` (main), regardless of which local branch a host's current generation was switched from - if you switch harmony/melaan to a feature branch to test it, the timer would eventually run anyway and silently switch the host back to main mid-test.
- Add an `ExecCondition` on `nixos-upgrade.service` that reuses [`starship.nix`](modules/aspects/my/starship.nix)'s GitHub-compare mechanism (`self.rev`/`dirtyRev` vs. `main`, same compare API and GitHub token) to skip - not fail - the run when the checkout is dirty, behind (unpushed/unmerged commits), or diverged.
- Being merely `ahead` of main (main has newer commits than us - the normal case the auto-upgrade timer exists to fix) is left unblocked.

## Test plan

- [x] `nix fmt` on the changed file
- [x] `nix eval .#nixosConfigurations.{harmony,melaan}.config.systemd.services.nixos-upgrade.serviceConfig.ExecCondition` resolves to a valid derivation for both hosts
- [x] Inspected the generated script (`nix derivation show`) and confirmed the interpolated rev/dirty state and `bash -n` syntax are correct
- [ ] Not build-tested end-to-end (this Mac can't build the x86_64-linux NixOS toplevel without a remote builder - confirmed the same Doom Emacs cross-arch failure exists on unmodified `main`, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)