### PR TITLE
fix(openai): switch ChatGPT desktop app from nixpkgs to Homebrew cask

### DIFF
--- a/modules/aspects/my/openai.nix
+++ b/modules/aspects/my/openai.nix
@@ -1,31 +1,18 @@
-{
-  lib,
-  den,
-  inputs,
-  my,
-  ...
-}:
-{
+{ inputs, my, ... }: {
   flake-file.inputs.codex-cli-nix = {
     url = "github:sadjow/codex-cli-nix";
     inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  my.openai =
-    {
-      chatgpt ? false,
-    }:
-    {
-      includes = [ my.mcp-servers ] ++ lib.optional chatgpt (den._.unfree [ "chatgpt" ]);
+  my.openai = {
+    includes = [ my.mcp-servers ];
 
-      homeManager = { pkgs, ... }: {
-        home.packages = lib.optional chatgpt pkgs.chatgpt;
-
-        programs.codex = {
-          enable = true;
-          package = inputs.codex-cli-nix.packages.${pkgs.stdenv.hostPlatform.system}.codex;
-          enableMcpIntegration = true;
-        };
+    homeManager = { pkgs, ... }: {
+      programs.codex = {
+        enable = true;
+        package = inputs.codex-cli-nix.packages.${pkgs.stdenv.hostPlatform.system}.codex;
+        enableMcpIntegration = true;
       };
     };
+  };
 }

--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -79,6 +79,7 @@ in
       darwin = {
         homebrew.casks = [
           "arc"
+          "chatgpt"
           "domzilla-caffeine"
           "proton-mail"
         ];

--- a/modules/aspects/users/oscar/work/work.nix
+++ b/modules/aspects/users/oscar/work/work.nix
@@ -32,7 +32,7 @@ in
       includes = lib.optionals (scope.work or false) (
         builtins.attrValues den.aspects.oscar.provides.work.provides
         ++ (lib.optional (scope.graphical or false) my.slack)
-        ++ [ (my.openai { chatgpt = scope.graphical or false; }) ]
+        ++ [ my.openai ]
       );
 
       homeManager = { pkgs, ... }: {


### PR DESCRIPTION
## Summary

- nixpkgs' `chatgpt` package tracks OpenAI's old, pre-Codex-merge release feed (`persistent.oaistatic.com/sidekick/public`). The merged ChatGPT/Codex desktop app ships through a different channel (`persistent.oaistatic.com/codex-app-prod`, bundle id `com.openai.codex`) that only Homebrew's cask currently tracks — nixpkgs has no path to it yet.
- Adds the `chatgpt` Homebrew cask in `oscar.nix` and drops the nix-built `pkgs.chatgpt` package, along with the now-unused `chatgpt` toggle on `my.openai` and its unfree-license allowance. The cask auto-upgrades via the existing `homebrew.onActivation` config.
- `my.openai` no longer needs to be a parameterized function, so it's simplified to a plain attrset.

## Test plan

- [x] `nix build .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel` succeeds
- [x] `nix fmt` clean
- [ ] `darwin-rebuild switch --flake .#OMARSHAL-M-T2QF` on the target machine to confirm the nix-built ChatGPT app is removed and the Homebrew cask remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)