### PR TITLE
feat(codex): add PagerDuty MCP server for work profile

### DIFF
--- a/modules/aspects/users/oscar/work/work.nix
+++ b/modules/aspects/users/oscar/work/work.nix
@@ -59,6 +59,34 @@ in
 
             startup_timeout_sec = 30;
           };
+
+          pagerduty = {
+            bearer_token_env_var = "PAGERDUTY_USER_API_KEY";
+
+            enabled_tools = [
+              "get_alert_from_incident"
+              "get_escalation_policy"
+              "get_incident"
+              "get_past_incidents"
+              "get_related_incidents"
+              "get_service"
+              "get_team"
+              "get_user_data"
+              "list_alerts_from_incident"
+              "list_escalation_policies"
+              "list_incident_change_events"
+              "list_incident_notes"
+              "list_incidents"
+              "list_log_entries"
+              "list_oncalls"
+              "list_services"
+              "list_team_members"
+              "list_users"
+            ];
+
+            startup_timeout_sec = 30;
+            url = "https://mcp.pagerduty.com/mcp";
+          };
         };
       };
     };


### PR DESCRIPTION
## Summary
- Add a `pagerduty` entry to `programs.codex.settings.mcp_servers` in the work Codex profile, exposing PagerDuty's hosted MCP server (`https://mcp.pagerduty.com/mcp`) with a curated set of read-only tools (incidents, alerts, escalation policies, on-calls, services, teams, users).
- Auth follows the existing `bearer_token_env_var` pattern (`PAGERDUTY_USER_API_KEY`, supplied via the user's shell environment, same as `GRAFANA_*` above it).

## Notes
This originated from a Codex-generated worktree. The worktree's branch had drifted ~24 commits behind `main` and carried two stale, already-superseded commits (a `den` flake bump and a secrets rekey) picked up from its base checkout rather than from this task. Those were dropped — this PR contains only the actual change (the uncommitted `work.nix` diff), rebased cleanly onto current `main`.

## Test plan
- [x] `nix fmt` (attrs alphabetized by the formatter)
- [x] `nix eval .#darwinConfigurations.OMARSHAL-M-T2QF.config.home-manager.users.oscar.programs.codex.settings.mcp_servers.pagerduty --json` evaluates and matches the intended config
- [ ] `darwin-rebuild switch` on a work-scoped host to confirm the MCP server starts once `PAGERDUTY_USER_API_KEY` is set