### PR TITLE
feat(harmony): add Wizarr for Plex invite management

### DIFF
--- a/modules/aspects/hosts/harmony/harmony.nix
+++ b/modules/aspects/hosts/harmony/harmony.nix
@@ -33,6 +33,9 @@
       (sonarr { administrators = [ "oscar" ]; })
       (storyteller { global = true; })
       (tautulli { })
+      # Global (not LAN-only like tautulli/profilarr/etc.) since its whole purpose is inviting
+      # people who don't have LAN/VPN access yet to join Plex.
+      (wizarr { global = true; })
       (zfs [ "metalminds" ])
       boot
       cross-seed

--- a/modules/aspects/my/wizarr.nix
+++ b/modules/aspects/my/wizarr.nix
@@ -20,7 +20,9 @@ in
             # public invite ones (`bypassAuthPaths`) - Wizarr's own login would be pure redundancy
             # for the admin panel and would otherwise block the whole point of the public invite
             # flow, so it's turned off entirely rather than left to coexist with forward-auth.
-            DISABLE_BUILTIN_AUTH = "true";
+            # Capitalized "True" (not "true") - Wizarr's own SSO docs specify this exact casing,
+            # and its env parsing is case-sensitive.
+            DISABLE_BUILTIN_AUTH = "True";
             TZ = config.time.timeZone;
           };
 
@@ -45,15 +47,17 @@ in
 
         # Invite links have to work for people who don't have an Authentik account yet (the whole
         # point of Wizarr), so its public join/onboarding routes and the static assets they need
-        # bypass the forward-auth gate below - matching the "important!" whitelist Wizarr's own
-        # reverse-proxy docs call out for exactly this setup (Authelia/Authentik in front).
+        # bypass the forward-auth gate below - the exact "Authentik/Other" patterns Wizarr's own
+        # reverse-proxy docs call out for this setup (`($|/.*)`, not `(/.*)?`, so e.g. `/setupfoo`
+        # doesn't also slip through).
         bypassAuthPaths = [
-          "^/j(oin)?(/.*)?"
-          "^/static(/.*)?"
-          "^/setup(/.*)?"
-          "^/wizard(/.*)?"
-          "^/image-proxy(/.*)?"
-          "^/cinema-posters(/.*)?"
+          "^/join($|/.*)"
+          "^/j($|/.*)"
+          "^/static($|/.*)"
+          "^/setup($|/.*)"
+          "^/wizard($|/.*)"
+          "^/image-proxy($|/.*)"
+          "^/cinema-posters($|/.*)"
         ];
 
         group = "Infra";

--- a/modules/aspects/my/wizarr.nix
+++ b/modules/aspects/my/wizarr.nix
@@ -1,0 +1,68 @@
+let
+  port = 5690;
+in
+{
+  my.wizarr =
+    {
+      global ? false,
+    }:
+    { host, ... }: {
+      dataset = {
+        name = "wizarr";
+        pool = "metalminds";
+        units = [ "podman-wizarr" ];
+      };
+
+      nixos = { config, ... }: {
+        virtualisation.oci-containers.containers.wizarr = {
+          environment = {
+            # Authentik's forward-auth (`protected` below) already gates every path except the
+            # public invite ones (`bypassAuthPaths`) - Wizarr's own login would be pure redundancy
+            # for the admin panel and would otherwise block the whole point of the public invite
+            # flow, so it's turned off entirely rather than left to coexist with forward-auth.
+            DISABLE_BUILTIN_AUTH = "true";
+            TZ = config.time.timeZone;
+          };
+
+          # Pinned to the current "v2026.7.1" tag's amd64 digest - re-resolve if bumping:
+          #   curl -sH "Authorization: Bearer $(curl -s 'https://ghcr.io/token?scope=repository:wizarrrr/wizarr:pull' | jq -r .token)" \
+          #     -H "Accept: application/vnd.oci.image.index.v1+json" \
+          #     https://ghcr.io/v2/wizarrrr/wizarr/manifests/<tag> | jq -r '.manifests[] | select(.platform.architecture == "amd64") | .digest'
+          image = "ghcr.io/wizarrrr/wizarr:v2026.7.1@sha256:be7087954f92badb16248073a347aadc771577a98c9c0c16b4cc010b143bbf50";
+
+          ports =
+            let
+              port' = toString port;
+            in
+            [ "127.0.0.1:${port'}:${port'}" ];
+
+          volumes = [ "/metalminds/wizarr:/data" ];
+        };
+      };
+
+      virtual-host = {
+        inherit global port;
+
+        # Invite links have to work for people who don't have an Authentik account yet (the whole
+        # point of Wizarr), so its public join/onboarding routes and the static assets they need
+        # bypass the forward-auth gate below - matching the "important!" whitelist Wizarr's own
+        # reverse-proxy docs call out for exactly this setup (Authelia/Authentik in front).
+        bypassAuthPaths = [
+          "^/j(oin)?(/.*)?"
+          "^/static(/.*)?"
+          "^/setup(/.*)?"
+          "^/wizard(/.*)?"
+          "^/image-proxy(/.*)?"
+          "^/cinema-posters(/.*)?"
+        ];
+
+        group = "Infra";
+        homepage.description = "Plex invite management";
+        host = host.name;
+        icon = "wizarr.svg";
+        label = "Wizarr";
+        name = "wizarr";
+        protected = true;
+      };
+    };
+}


### PR DESCRIPTION
## Summary
- Add a `my.wizarr` aspect (`modules/aspects/my/wizarr.nix`), run as an OCI container (`ghcr.io/wizarrrr/wizarr`, no nixpkgs package exists) since it's a Node/Python app with no packaged release
- Gate the admin panel behind Authentik forward-auth (`protected = true`) like the other admin tools, but whitelist Wizarr's public invite/onboarding routes (`/j`, `/join`, `/static`, `/setup`, `/wizard`, `/image-proxy`, `/cinema-posters`) per its own reverse-proxy docs, so invitees without an Authentik account can still redeem invite links
- `DISABLE_BUILTIN_AUTH=True` since Authentik is already the sole gate for everything else
- `global = true` (unlike tautulli/profilarr) since invite links need to work for people outside the LAN/VPN — that's the whole point of the app
- Include it on `harmony`

## Test plan
- [x] `nix eval` the harmony config: container definition, nginx vhost + all bypass-auth locations, systemd unit ordering (`podman-wizarr` waits on `zfs-dataset-metalminds-wizarr`), ACME cert unit all resolve correctly
- [x] `nix fmt` clean
- [ ] `sudo nixos-rebuild switch --flake .#harmony` on the actual host and confirm the container comes up and the invite flow works end-to-end (needs the real host)

Closes #647.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
