### PR TITLE
fix(harmony): extend Authentik session and token validity to 30 days

### DIFF
--- a/modules/aspects/my/authentik.nix
+++ b/modules/aspects/my/authentik.nix
@@ -627,7 +627,15 @@
 
               # A standalone object, not flow-scoped - reused via three separate
               # `authentik_flow_stage_binding`s below rather than duplicated per flow.
-              authentik_stage_user_login.default.name = "login-user-login";
+              #
+              # `session_duration` overrides the provider default of `seconds=0` ("keep the
+              # session until the browser session ends" - i.e. no explicit expiry at all, just
+              # whatever the browser itself decides, which is what made logins feel like they
+              # expired unpredictably fast). A month gives a real, explicit ceiling instead.
+              authentik_stage_user_login.default = {
+                name = "login-user-login";
+                session_duration = "days=30";
+              };
 
               # Cross-references `mailgun_domain.default`, defined in mailgun.nix's own `terranix`
               # field - see that file's header comment for why each consumer owns its own mailbox
@@ -679,6 +687,11 @@
 
                     value = {
                       inherit (vh) name;
+                      # Default is `minutes=10` - the outpost re-checks/refreshes against this
+                      # cadence, and any friction in that silent refresh reads to a user as
+                      # getting logged out constantly. Matches `authentik_stage_user_login`'s
+                      # own bump above, capped by whichever expires first.
+                      access_token_validity = "days=30";
                       authorization_flow = "\${data.authentik_flow.default-authorization-flow.id}";
                       external_host = "https://${hostname-of vh}";
                       invalidation_flow = "\${data.authentik_flow.default-invalidation-flow.id}";
@@ -766,6 +779,14 @@
 
                     value = {
                       inherit (vh) name;
+                      # Default is `minutes=10` - same reasoning as `authentik_provider_proxy`'s
+                      # own bump above, so a native OIDC app (Immich/Nextcloud/Seerr) doesn't
+                      # force a re-login every 10 minutes either. Equal to (not under)
+                      # `refresh_token_validity`'s own default of `days=30` - harmless since
+                      # nothing here refreshes past the underlying authentik session anyway
+                      # (also capped at `days=30` above), but worth knowing if that default
+                      # ever changes independently.
+                      access_token_validity = "days=30";
 
                       allowed_redirect_uris = lib.concatMap (
                         hostname:


### PR DESCRIPTION
## Summary

- Authentik was logging users out unexpectedly fast. Root cause: neither the forward-auth proxy providers nor the OIDC providers had `access_token_validity` set, so both fell back to Authentik's provider default of 10 minutes, forcing frequent re-auth cycles. The core login session (`authentik_stage_user_login`) also had no explicit expiry — it just relied on "until the browser session ends", which is unpredictable across browsers.
- Set all three to an explicit, consistent 30-day ceiling: `authentik_stage_user_login.default.session_duration`, `authentik_provider_proxy.*.access_token_validity`, and `authentik_provider_oauth2.*.access_token_validity`.

## Notes for reviewer

- `access_token_validity` on the OIDC providers is now equal to (not under) `refresh_token_validity`'s own default of `days=30` — harmless today since nothing refreshes past the underlying Authentik session anyway (also capped at 30 days), but worth knowing if that default ever changes independently. Documented inline.
- This only takes effect on the next `terraform apply` for harmony (`nix run .#harmony-tf.plan`, then apply) — not applied as part of this PR.

## Test plan

- [x] `nix build .#packages.aarch64-darwin.harmony-tf.config` — terranix config evaluates cleanly with the new fields
- [x] `nix fmt` — no formatting changes needed
- [ ] `nix run .#harmony-tf.plan` / apply on harmony (manual, not run here since it touches live infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)