### PR TITLE
feat(darwin): add Colima/Docker dev environment, fix GUI-app PATH

### DIFF
--- a/modules/aspects/defaults.nix
+++ b/modules/aspects/defaults.nix
@@ -14,7 +14,10 @@ let
   # No-ops on NixOS hosts - `darwin`-class content there is never merged into the option tree.
   guiPath = {
     darwin = { config, ... }: {
-      launchd.user.envVariables.PATH = "${config.system.primaryUserHome}/.nix-profile/bin:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+      # Ordered to match the interactive shell's own PATH (fish -c 'echo $PATH') - Nix profiles
+      # first, then the standard macOS dirs, then Homebrew last (my.homebrew is enabled on this
+      # host; GUI apps need its /opt/homebrew/{bin,sbin} too, not just Nix's).
+      launchd.user.envVariables.PATH = "${config.system.primaryUserHome}/.nix-profile/bin:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/opt/homebrew/sbin";
     };
   };
   hmPlatforms =

--- a/modules/aspects/defaults.nix
+++ b/modules/aspects/defaults.nix
@@ -6,6 +6,17 @@
   ...
 }:
 let
+  # GUI-launched processes (e.g. an app opened from Spotlight/Dock, not a fish shell) are spawned
+  # by launchd directly - they never source fish's PATH, and nix-darwin's `environment.variables`
+  # only reaches shell-initialized processes too. `launchd.user.envVariables` is nix-darwin's own
+  # mechanism for the launchd-spawned case: it runs `launchctl setenv` on every activation (see
+  # nix-darwin's modules/system/launchd.nix), which is picked up immediately, no relogin needed.
+  # No-ops on NixOS hosts - `darwin`-class content there is never merged into the option tree.
+  guiPath = {
+    darwin = { config, ... }: {
+      launchd.user.envVariables.PATH = "${config.system.primaryUserHome}/.nix-profile/bin:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+    };
+  };
   hmPlatforms =
     { aspect-chain, ... }:
     den._.forward {
@@ -90,6 +101,7 @@ in
 
       host = {
         includes = [
+          guiPath
           my.fonts
           my.nix
           nixosSecrets

--- a/modules/aspects/my/colima.nix
+++ b/modules/aspects/my/colima.nix
@@ -1,0 +1,40 @@
+{
+  my.colima.hmDarwin = { pkgs, ... }: {
+    # docker-compose (the Go-based Compose V2) supplies the standalone `docker-compose` binary
+    # that Dashboard's `script/spring` still shells out to. `docker compose` (the subcommand)
+    # needs no separate wiring - nixpkgs' `docker` bundles it (and buildx) as CLI plugins by
+    # default (`composeSupport`/`buildxSupport` in nixpkgs' docker derivation).
+    home.packages = [
+      pkgs.docker
+      pkgs.docker-compose
+    ];
+
+    programs.docker-cli.enable = true;
+
+    services.colima = {
+      enable = true;
+
+      # `isService` runs colima as a per-user LaunchAgent (RunAtLoad + KeepAlive), so it's up
+      # after login without a manual `colima start` and without re-running on every
+      # nix-darwin/home-manager activation - only when the generated LaunchAgent plist actually
+      # changes. `isActive`/`setDockerHost` make this profile's context the one Docker resolves
+      # by default (every host also gets GUI-launched processes onto this same PATH - see the
+      # `guiPath` default in modules/aspects/defaults.nix).
+      profiles.default = {
+        isActive = true;
+        isService = true;
+        setDockerHost = true;
+
+        settings = {
+          cpu = 6;
+          disk = 100;
+          memory = 6;
+          mountType = "virtiofs";
+          rosetta = true;
+          runtime = "docker";
+          vmType = "vz";
+        };
+      };
+    };
+  };
+}

--- a/modules/aspects/users/oscar/work/work.nix
+++ b/modules/aspects/users/oscar/work/work.nix
@@ -32,7 +32,10 @@ in
       includes = lib.optionals (scope.work or false) (
         builtins.attrValues den.aspects.oscar.provides.work.provides
         ++ (lib.optional (scope.graphical or false) my.slack)
-        ++ [ my.openai ]
+        ++ [
+          my.colima
+          my.openai
+        ]
       );
 
       homeManager = { pkgs, ... }: {


### PR DESCRIPTION
## Summary

- Adds a declarative Docker/Colima dev environment for the Meraki Dashboard project's containerized Rails/RSpec workflow: Colima, Docker CLI, and Docker Compose installed via nixpkgs (no Homebrew), using home-manager's `services.colima` and `programs.docker-cli` modules so the VM settings, LaunchAgent, and active Docker context are all Nix-managed rather than requiring a one-time `colima start`/`docker context use colima`.
- Fixes GUI-launched processes (anything opened from Spotlight/Dock, not a fish shell - e.g. Codex) never seeing Nix-installed packages: `launchctl getenv PATH` was empty on this Mac before this change. Fixed via nix-darwin's `launchd.user.envVariables`, applied to every host by default (`den.schema.host.includes`) since the gap affects every home-manager package, not just Docker tooling.
- Wired into `den.aspects.oscar.provides.work`, so it only applies on `scope.work` machines (this Mac and `dev203`), and only actually materializes on Darwin - the `hmDarwin`/`darwin` classes are no-ops on the NixOS home node.

## Details

Colima profile settings match the requested `colima start --cpus 6 --memory 6 --disk 100 --vm-type vz --vz-rosetta --mount-type virtiofs --runtime docker` exactly, generated declaratively as `~/.config/colima/default/colima.yaml`. The profile runs as a per-user LaunchAgent (`RunAtLoad` + `KeepAlive.SuccessfulExit`), so it comes up at login and stays up - it does not restart on every `darwin-rebuild switch`, only when the generated LaunchAgent plist actually changes.

`docker compose` (the subcommand) needs no extra wiring - nixpkgs' `docker` package bundles compose/buildx as CLI plugins by default. `docker-compose` (the standalone binary Dashboard's `script/spring` still shells out to) comes from the separate `docker-compose` package.

No registry credentials or secrets are touched - Artifactory auth stays exactly as it is today, outside Nix.

## Test plan

- [x] `nix build .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel` succeeds
- [x] Inspected generated `colima.yaml`, the `colima-default` LaunchAgent plist, and `~/.docker/config.json` (`currentContext: colima`) in the build output - all match the intended config
- [x] Confirmed `config.launchd.user.envVariables.PATH` is populated on the Darwin build
- [x] `nix eval .#nixosConfigurations.harmony...` / `melaan...` still evaluate cleanly with the new default-host include (the `darwin`-class content genuinely never reaches the NixOS option tree)
- [ ] Not yet applied to the running system (`darwin-rebuild switch`) or verified against the actual Colima VM/`docker info`/GUI-app PATH on the live machine

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>