### PR TITLE
feat(harmony): add external service links to homepage dashboard

### DIFF
--- a/modules/aspects/my/homepage.nix
+++ b/modules/aspects/my/homepage.nix
@@ -66,6 +66,40 @@ in
                 }
               ];
             }
+            # External consoles for services harmony manages as code via terranix (see
+            # modules/terranix.nix) but that don't run ON harmony, so they have no `virtual-host`
+            # entry of their own to derive a tile from.
+            {
+              "External Services" = [
+                {
+                  Cloudflare = [
+                    {
+                      abbr = "CF";
+                      href = "https://dash.cloudflare.com/";
+                      icon = "cloudflare.svg";
+                    }
+                  ];
+                }
+                {
+                  Mailgun = [
+                    {
+                      abbr = "MG";
+                      href = "https://app.mailgun.com/";
+                      icon = "mailgun.svg";
+                    }
+                  ];
+                }
+                {
+                  Meraki = [
+                    {
+                      abbr = "MK";
+                      href = "https://dashboard.meraki.com/";
+                      icon = "meraki.svg";
+                    }
+                  ];
+                }
+              ];
+            }
           ];
 
           environmentFiles = [ config.age.secrets."homepage-dashboard.env".path ];


### PR DESCRIPTION
## Summary
- Add an "External Services" bookmarks group to harmony's Homepage dashboard with tiles for Cloudflare, Mailgun, and Meraki
- These services are managed as code via terranix (see `modules/terranix.nix`) but don't run on harmony itself, so they have no `virtual-host` entry to derive a dashboard tile from automatically

## Test plan
- [x] `nix eval .#nixosConfigurations.harmony.config.services.homepage-dashboard.bookmarks --json` shows the new "External Services" group alongside the existing "Servers" group
- [x] `nix fmt` reports no formatting changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)