### PR TITLE
fix(melaan): enable avahi mDNS for network printer discovery

### DIFF
--- a/modules/aspects/hosts/melaan/melaan.nix
+++ b/modules/aspects/hosts/melaan/melaan.nix
@@ -21,6 +21,11 @@
       age.rekey.hostPubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILqFHtkApjVtbJj4hR4sEyHJhwrZ74+gR3OviJk9VxYb";
 
       services = {
+        avahi = {
+          enable = true;
+          nssmdns4 = true;
+        };
+
         flatpak.enable = true;
         openssh.enable = true;
         printing.enable = true;


### PR DESCRIPTION
## Summary
- Enable `services.avahi` (with `nssmdns4`) on melaan alongside the existing `services.printing.enable`.
- Fixes the HP OfficeJet Pro 9010's print dialog hanging forever on "Getting printer information..." — IPP Everywhere/driverless network printing resolves the printer's `.local` hostname and queries its capabilities via mDNS/DNS-SD, which requires `avahi-daemon`. It was never enabled anywhere in this config.
- `services.avahi.openFirewall` defaults to `true`, so UDP 5353 opens automatically; no extra firewall change needed.

## Test plan
- [ ] `nix eval` confirms `services.avahi.enable` / `services.avahi.nssmdns4` / `services.printing.enable` are all `true` for melaan (verified in-session).
- [ ] `sudo nixos-rebuild switch --flake .#melaan` and confirm the print dialog now resolves the OfficeJet's info instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)