### PR TITLE
feat(zen-browser): disable address autofill

### DIFF
--- a/modules/aspects/users/oscar/zen-browser.nix
+++ b/modules/aspects/users/oscar/zen-browser.nix
@@ -12,7 +12,6 @@ in
 
         policies = {
           AutofillAddressEnabled = false;
-
           # Updates come from `nix flake update` + rebuild; the browser's own
           # updater can't write into the read-only /nix/store install anyway.
           DisableAppUpdate = true;

--- a/modules/aspects/users/oscar/zen-browser.nix
+++ b/modules/aspects/users/oscar/zen-browser.nix
@@ -11,6 +11,8 @@ in
         darwinDefaultsId = "app.zen-browser.zen";
 
         policies = {
+          AutofillAddressEnabled = false;
+
           # Updates come from `nix flake update` + rebuild; the browser's own
           # updater can't write into the read-only /nix/store install anyway.
           DisableAppUpdate = true;


### PR DESCRIPTION
## Summary
- Adds `AutofillAddressEnabled = false` to Zen's browser policies for the `oscar` user.

## Why
Zen was prompting to save an address despite login-saving already being disabled (`OfferToSaveLogins = false`, `signon.rememberSignons = false`). Those only cover password saving — address autofill has its own separate enterprise policy (`AutofillAddressEnabled`), which wasn't previously set.

## Test plan
- [ ] `darwin-rebuild switch --flake .#OMARSHAL-M-T2QF`
- [ ] Confirm Zen no longer offers to save addresses on form submission