### PR TITLE
feat(nh): show activation logs during nh switch

### DIFF
--- a/modules/aspects/my/nh.nix
+++ b/modules/aspects/my/nh.nix
@@ -1,12 +1,16 @@
 {
-  my.nh.homeManager.programs.nh = {
-    enable = true;
+  my.nh.homeManager = {
+    home.sessionVariables.NH_SHOW_ACTIVATION_LOGS = "1";
 
-    clean = {
+    programs.nh = {
       enable = true;
-      extraArgs = "--keep-since 7d";
-    };
 
-    flake = "github:OscarMarshall/dotfiles";
+      clean = {
+        enable = true;
+        extraArgs = "--keep-since 7d";
+      };
+
+      flake = "github:OscarMarshall/dotfiles";
+    };
   };
 }


### PR DESCRIPTION
## Summary
- `nh os switch` on harmony builds with visible progress (via `nix-output-monitor`), but the activation phase (`switch-to-configuration`) runs silently by default, which made long activations look hung with no feedback.
- Sets `NH_SHOW_ACTIVATION_LOGS=1` via `home.sessionVariables` so `nh os switch` (and `nh darwin switch` / `nh home switch`) stream the activation script's own output — units starting/stopping, etc.

## Test plan
- [x] `nix fmt` — no changes
- [x] `nix eval` confirms the session variable is wired through harmony's Home Manager config
- [ ] Verify on harmony: apply once with the old activation script for the var to take effect in-shell (or `export NH_SHOW_ACTIVATION_LOGS=1` before the next switch), then confirm activation output streams on `nh os switch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)