### PR TITLE
fix(nix): use stdenv.hostPlatform.isDarwin instead of deprecated stdenv.isDarwin

### DIFF
--- a/modules/aspects/users/oscar/oscar.nix
+++ b/modules/aspects/users/oscar/oscar.nix
@@ -137,11 +137,11 @@ in
                   # overlay; if not, bump the version pinned here.
                   assert old.version == "0.15.0" || throw "curl-cffi ${old.version}: re-check the Darwin rpath workaround in oscar.nix";
                   {
-                    doCheck = (old.doCheck or true) && !prev.stdenv.isDarwin;
+                    doCheck = (old.doCheck or true) && !prev.stdenv.hostPlatform.isDarwin;
 
                     postFixup =
                       (old.postFixup or "")
-                      + prev.lib.optionalString prev.stdenv.isDarwin ''
+                      + prev.lib.optionalString prev.stdenv.hostPlatform.isDarwin ''
                         for f in $(find "$out" -name "*.so"); do
                           if ! otool -L "$f" | grep -q "@rpath/libcurl-impersonate"; then
                             continue


### PR DESCRIPTION
## Summary
- Replace the two `stdenv.isDarwin` accesses in the curl-cffi Darwin rpath workaround (`modules/aspects/users/oscar/oscar.nix`) with `stdenv.hostPlatform.isDarwin`, silencing nixpkgs' eval-time deprecation warning.

## Why
Recent nixpkgs deprecated the `stdenv.isDarwin`/`stdenv.isLinux` shorthand in favor of `stdenv.hostPlatform.isDarwin`/`isLinux`, printing:
```
warning: stdenv.isDarwin is deprecated, use stdenv.hostPlatform.isDarwin instead
```

## Notes for reviewer
- This was the only place `stdenv.isDarwin`/`stdenv.isLinux` appeared anywhere in this repo's own `.nix` files (verified via repo-wide grep).
- A residual `stdenv.isLinux`/`stdenv.isDarwin` warning still appears on full config evals (e.g. `melaan`, `OMARSHAL-M-T2QF`), but it traces to the `nix-doom-emacs-unstraightened` flake input's package chain, not to code in this repo — out of scope here.
- Verified `nix fmt` makes no further changes and both `darwinConfigurations.OMARSHAL-M-T2QF` and `nixosConfigurations.melaan` still evaluate to a toplevel derivation successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)