### PR TITLE
fix(ids): pin readarr/satisfactory-server/qbittorrent ids clear of dynamic allocation

### DIFF
--- a/modules/aspects/hosts/harmony/harmony.nix
+++ b/modules/aspects/hosts/harmony/harmony.nix
@@ -58,9 +58,9 @@
     ];
 
     # The shared `books` dataset (used by both Bookshelf instances), `movies` (radarr.nix), `shows`
-    # (sonarr.nix), `pictures` (immich.nix), and `documents` (paperless.nix) are declared in their
-    # owning aspects instead of here - see bookshelf.nix's own comment on why that's the more
-    # correct owner.
+    # (sonarr.nix), `pictures` (immich.nix), `documents` (paperless.nix), and `torrents`
+    # (qbittorrent.nix) are declared in their owning aspects instead of here - see bookshelf.nix's
+    # own comment on why that's the more correct owner.
     dataset =
       map
         (name: {
@@ -72,7 +72,6 @@
         [
           "backups"
           "music"
-          "torrents"
           "yarg-charts"
         ];
 

--- a/modules/aspects/my/bookshelf.nix
+++ b/modules/aspects/my/bookshelf.nix
@@ -38,10 +38,14 @@ let
       dataset = [
         {
           inherit name;
+          # Owned by the same dedicated `readarr` user/group declared below - the container runs as
+          # readarr via PUID/PGID, and needs write access to its own `/config`.
+          group = "readarr";
           pool = "metalminds";
           # This instance's own container needs its `/config` dataset to actually exist (and be
           # mounted) before it starts - see zfs.nix's own `units` field comment.
           units = [ "podman-${name}" ];
+          user = "readarr";
         }
         {
           # Owned by a dedicated `readarr` user/group (declared below) shared by BOTH instances, so
@@ -61,19 +65,26 @@ let
         # qbittorrent.nix's own service user) rather than accepting the image's own undocumented
         # built-in "abc" (911:911) - both instances' containers run as this user via PUID/PGID
         # below, so whichever one writes to the shared `/books` root folder, the other can too.
-        # `uid`/`gid` are pinned explicitly (983, the next one down from
-        # satisfactory-server.nix's 984 and qbittorrent.nix's 985) rather than left to NixOS's own
-        # dynamic system-user allocation, which only resolves a UID at activation time - too late
-        # to bake into the container's own PUID/PGID env vars below, which need a value at build
-        # time.
+        # `uid`/`gid` are pinned explicitly rather than left to NixOS's own dynamic system-user
+        # allocation, which only resolves an id at activation time - too late to bake into the
+        # container's own PUID/PGID env vars below, which need a value at build time. Pinned to
+        # 31000 (alongside satisfactory-server.nix's 31001 and qbittorrent.nix's 31002) rather than
+        # some number under 1000: NixOS's dynamic allocator (nixos/modules/config/update-users-groups.pl)
+        # only ever draws from 400-999 (system users/groups) and 1000-29999 (normal users), so
+        # anything >= 30000 can never collide with an id it hands out - unlike this trio's previous
+        # 983/984/985, which happened to land inside that first range and collided in practice: both
+        # nix-minecraft's dynamically-allocated `minecraft` group and the unrelated `mandb` system
+        # user ended up sharing 984 with satisfactory-server.nix's old pin. 30000-30032 is ALSO
+        # reserved (statically, not dynamically) for Nix's own `nixbld`/`nixbld1..32` build users
+        # (`ids.uids.nixbld`) - hence starting this block at 31000 rather than 30000 itself.
         users = {
-          groups.readarr.gid = 983;
+          groups.readarr.gid = 31000;
 
           users.readarr = {
             description = "Bookshelf (Readarr) service user";
             group = "readarr";
             isSystemUser = true;
-            uid = 983;
+            uid = 31000;
           };
         };
 

--- a/modules/aspects/my/qbittorrent.nix
+++ b/modules/aspects/my/qbittorrent.nix
@@ -21,6 +21,22 @@ in
       global ? false,
     }:
     { host, ... }: {
+      # Moved here from harmony.nix's own host-level `dataset` list (see its comment) - `user`/
+      # `group` here means zfs.nix's generic dataset-quirk consumer chowns `/metalminds/torrents`
+      # itself to qbittorrent on every activation, the same way books/satisfactory-server.nix's own
+      # datasets self-heal. Non-recursive though (just the dataset root) - doesn't reach into
+      # existing subdirectories/files, so a uid/gid change (like this one) still needs a one-time
+      # manual `chown -R` to fix already-written content.
+      dataset = {
+        group = "qbittorrent";
+        guestAccess = true;
+        name = "torrents";
+        pool = "metalminds";
+        samba = true;
+        units = [ "qbittorrent" ];
+        user = "qbittorrent";
+      };
+
       nixos =
         {
           config,
@@ -219,14 +235,18 @@ in
           };
 
           users = {
-            groups.qbittorrent.gid = 985;
+            # See bookshelf.nix's comment on readarr's own pinned id for why 31002 (rather than a
+            # number under 1000, which is what this used to be pinned to and how it collided with
+            # both nix-minecraft's dynamically-allocated `minecraft` group and the unrelated
+            # `mandb` system user).
+            groups.qbittorrent.gid = 31002;
 
             users = {
               qbittorrent = {
                 description = "qBittorrent service user";
                 group = "qbittorrent";
                 isSystemUser = true;
-                uid = 985;
+                uid = 31002;
               };
             }
             // (lib.genAttrs administrators (user: {

--- a/modules/aspects/my/qbittorrent.nix
+++ b/modules/aspects/my/qbittorrent.nix
@@ -22,11 +22,13 @@ in
     }:
     { host, ... }: {
       # Moved here from harmony.nix's own host-level `dataset` list (see its comment) - `user`/
-      # `group` here means zfs.nix's generic dataset-quirk consumer chowns `/metalminds/torrents`
-      # itself to qbittorrent on every activation, the same way books/satisfactory-server.nix's own
-      # datasets self-heal. Non-recursive though (just the dataset root) - doesn't reach into
-      # existing subdirectories/files, so a uid/gid change (like this one) still needs a one-time
-      # manual `chown -R` to fix already-written content.
+      # `group` here means zfs.nix's generic dataset-quirk consumer recursively chowns
+      # `/metalminds/torrents` to qbittorrent on every activation, the same way
+      # books/satisfactory-server.nix's own datasets self-heal - no manual `chown -R` needed even
+      # after a uid/gid change like this one. `torrents` is a fine candidate for that despite
+      # holding 15T: it's a torrent client's data, so almost all of that is a handful of large
+      # files rather than a huge file count - the actual cost the recursive walk (see zfs.nix's own
+      # `user`/`group` field comment) warns to watch out for.
       dataset = {
         group = "qbittorrent";
         guestAccess = true;

--- a/modules/aspects/my/satisfactory-server.nix
+++ b/modules/aspects/my/satisfactory-server.nix
@@ -26,12 +26,16 @@ in
       };
 
       users = {
-        groups.satisfactory-server.gid = 984;
+        # See bookshelf.nix's comment on readarr's own pinned id for why 31001 (rather than a
+        # number under 1000, which is what this used to be pinned to and how it collided with both
+        # nix-minecraft's dynamically-allocated `minecraft` group and the unrelated `mandb` system
+        # user).
+        groups.satisfactory-server.gid = 31001;
 
         users.satisfactory-server = {
           group = "satisfactory-server";
           isSystemUser = true;
-          uid = 984;
+          uid = 31001;
         };
       };
 

--- a/modules/aspects/my/zfs.nix
+++ b/modules/aspects/my/zfs.nix
@@ -16,10 +16,14 @@
 #                 pkgs-derived values.
 #   samba       - (optional, bool) share it via Samba - see samba.nix.
 #   guestAccess - (optional, bool) allow guest (unauthenticated) Samba access - see samba.nix.
-#   user/group  - (optional) chown the dataset's root directory to this user:group once created -
+#   user/group  - (optional) recursively chown the dataset to this user:group on every activation -
 #                 for a dataset a container-based service needs to write into as some UID/GID other
 #                 than root (e.g. a shared library directory two containers both write into). Both
-#                 fields must be given together, or neither.
+#                 fields must be given together, or neither. Recursive (not just the dataset root)
+#                 so a uid/gid repin self-heals existing content too, not just newly-created files -
+#                 the tradeoff is a full tree walk on every activation, not just when the dataset is
+#                 first created, so avoid this for datasets expected to hold a very large number of
+#                 files.
 #   options     - (optional, attrset) ZFS property name/value pairs (e.g. `{ compression = "lz4";
 #                 quota = "10G"; }`), passed as `-o property=value` flags to `zfs create`. Only
 #                 applied at CREATION time, same as `zfs create` itself - not retroactively applied
@@ -76,7 +80,7 @@
                     || ${defaultZfsPackage}/bin/zfs create -p${createOptions} ${lib.escapeShellArg "${d.pool}/${d.name}"}
                 ''
                 + lib.optionalString (d ? user) ''
-                  ${pkgs.coreutils}/bin/chown ${lib.escapeShellArg "${d.user}:${d.group}"} ${lib.escapeShellArg "/${d.pool}/${d.name}"}
+                  ${pkgs.coreutils}/bin/chown -R ${lib.escapeShellArg "${d.user}:${d.group}"} ${lib.escapeShellArg "/${d.pool}/${d.name}"}
                 ''
               );
 


### PR DESCRIPTION
## Summary

While debugging `minecraft-server-vanilla.service` on harmony (separately fixed in #719), I noticed `satisfactory-server`'s files on disk showed up as group `satisfactory-server` even for `minecraft-server`-owned files — turned out `nix-minecraft`'s dynamically-allocated `minecraft` group and `satisfactory-server`'s statically-pinned gid had both landed on `984`. A second, independent collision with the system's `mandb` user (also dynamically allocated to uid `984`) confirmed this wasn't a one-off.

- `readarr` (983), `satisfactory-server` (984), and `qbittorrent` (985) were all pinned inside NixOS's own dynamic system-user allocation range (400-999 per `nixos/modules/config/update-users-groups.pl`), so they were always one dynamic allocation away from colliding with something.
- Re-pinned all three to `31000`/`31001`/`31002` — clear of both NixOS's dynamic pools (400-999 system, 1000-29999 normal users) *and* Nix's own static `nixbld`/`nixbld1..32` reservation (`30000`-`30032`), which a first attempt at `30000`-`30002` collided with.

## Other changes

- Moved the `torrents` dataset declaration from `harmony.nix`'s generic host-level list into `qbittorrent.nix` (matching the existing `books`/`bookshelf.nix` precedent already documented in this repo), and gave it — plus bookshelf's two per-instance `/config` datasets — a `user`/`group`, so `zfs.nix`'s dataset quirk keeps their on-disk ownership self-healing on every `nixos-rebuild switch` instead of needing a manual `chown` after every id change.
- Made that quirk's chown recursive (`-R`). It previously only fixed a dataset's root directory, which was enough right after `zfs create` but silently left existing content on an already-populated dataset unfixed after a uid/gid change. This is a shared quirk, so it also now runs recursively for every other dataset with `user`/`group` set (radarr, sonarr, immich, home-assistant, paperless, cross-seed) — harmless, but worth a reviewer's awareness since a couple of those (movies, photo library) hold a lot of files, so switches touching those hosts may get marginally slower.

## Deployment note

Harmony's on-disk ownership for `readarr`/`satisfactory-server`/`qbittorrent` still needs to catch up to the new ids. Once this merges, on harmony:

```bash
sudo systemctl stop podman-bookshelf-ebooks.service podman-bookshelf-audiobooks.service podman-satisfactory-server.service qbittorrent.service qbittorrent-portforward.timer

sudo nixos-rebuild switch --flake .#harmony

sudo systemctl restart podman-bookshelf-ebooks.service podman-bookshelf-audiobooks.service podman-satisfactory-server.service qbittorrent.service
sudo systemctl start qbittorrent-portforward.timer
```

The recursive dataset-quirk chown (this PR) fixes existing on-disk ownership automatically during `switch` — no manual `chown` needed.

## Test plan

- [x] `nix build .#nixosConfigurations.harmony.config.system.build.toplevel` evaluates cleanly (uid/gid uniqueness assertions pass; build itself hits a pre-existing, unrelated cross-arch limitation building Doom Emacs for x86_64-linux from this aarch64-darwin machine)
- [x] `nix fmt` clean
- [ ] `sudo nixos-rebuild switch --flake .#harmony` on the actual host, followed by verifying `podman-bookshelf-ebooks`, `podman-bookshelf-audiobooks`, `podman-satisfactory-server`, and `qbittorrent` all come back up healthy with corrected file ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)