### PR TITLE
fix(cross-seed): pin build to nodejs_22 to avoid better-sqlite3 GC crash

### DIFF
--- a/modules/aspects/my/cross-seed.nix
+++ b/modules/aspects/my/cross-seed.nix
@@ -25,7 +25,6 @@
       {
         services.cross-seed = {
           enable = true;
-          group = "qbittorrent";
 
           # better-sqlite3 (pinned to 11.5.0 by cross-seed) segfaults on GC under the default
           # nodejs (24.x) - see https://github.com/NixOS/nixpkgs/issues/553680. Upstream fixed
@@ -44,9 +43,9 @@
             assert
               defaultNodejs.version != pkgs.nodejs_22.version
               || throw "my.cross-seed: nixpkgs' unoverridden cross-seed now builds against nodejs ${defaultNodejs.version} (matching nodejs_22) - the nodejs override is no longer needed, remove it.";
-            pkgs.cross-seed.override {
-              buildNpmPackage = pkgs.buildNpmPackage.override { nodejs = pkgs.nodejs_22; };
-            };
+            pkgs.cross-seed.override { buildNpmPackage = pkgs.buildNpmPackage.override { nodejs = pkgs.nodejs_22; }; };
+
+          group = "qbittorrent";
 
           settings = {
             linkDirs = [ "/metalminds/torrents/link-dir" ];

--- a/modules/aspects/my/cross-seed.nix
+++ b/modules/aspects/my/cross-seed.nix
@@ -13,6 +13,7 @@
       {
         config,
         lib,
+        pkgs,
         torrent-client,
         ...
       }:
@@ -25,6 +26,27 @@
         services.cross-seed = {
           enable = true;
           group = "qbittorrent";
+
+          # better-sqlite3 (pinned to 11.5.0 by cross-seed) segfaults on GC under the default
+          # nodejs (24.x) - see https://github.com/NixOS/nixpkgs/issues/553680. Upstream fixed
+          # this in https://github.com/NixOS/nixpkgs/pull/556114 by pinning cross-seed's build to
+          # nodejs_22, but that fix hasn't reached nixpkgs-unstable yet, so pin it here too.
+          #
+          # Fires once nixpkgs' unoverridden `cross-seed` itself builds against nodejs_22 (the fix
+          # this override works around lands upstream): at that point the override above is dead
+          # weight, so drop it (and this assertion) back down to `pkgs.cross-seed`.
+          package =
+            let
+              defaultNodejs = lib.findFirst (
+                p: (p.pname or "") == "nodejs" || (p.pname or "") == "nodejs-slim"
+              ) (throw "cross-seed.nix: couldn't find cross-seed's nodejs nativeBuildInput") pkgs.cross-seed.nativeBuildInputs;
+            in
+            assert
+              defaultNodejs.version != pkgs.nodejs_22.version
+              || throw "my.cross-seed: nixpkgs' unoverridden cross-seed now builds against nodejs ${defaultNodejs.version} (matching nodejs_22) - the nodejs override is no longer needed, remove it.";
+            pkgs.cross-seed.override {
+              buildNpmPackage = pkgs.buildNpmPackage.override { nodejs = pkgs.nodejs_22; };
+            };
 
           settings = {
             linkDirs = [ "/metalminds/torrents/link-dir" ];


### PR DESCRIPTION
## Summary

- `cross-seed.service` was crash-looping on harmony: it starts up, logs in to qBittorrent, validates its config, and then aborts ~1 minute later during "Indexing client torrents for reverse lookup..." with `Assertion failed: (env) != nullptr` in `node::RemoveEnvironmentCleanupHook`, called from `better-sqlite3`'s `Statement::~Statement()`, and dumps core.
- Root cause: `cross-seed` pins `better-sqlite3@11.5.0`, whose native addon isn't compatible with the GC/cleanup-hook changes in Node.js 24 — a `Statement` object gets finalized during garbage collection and the process aborts. nixpkgs builds `cross-seed` with the default `nodejs` (24.19.0 on our pinned rev), so every run eventually hits this.
- This is a known, already-fixed nixpkgs bug: [NixOS/nixpkgs#553680](https://github.com/NixOS/nixpkgs/issues/553680), fixed upstream in [#556114](https://github.com/NixOS/nixpkgs/pull/556114) by pinning `cross-seed`'s build to `nodejs_22`. That merged into nixpkgs `master` today but hasn't reached `nixpkgs-unstable` yet (our pinned rev is ~1200 commits behind it), so this PR mirrors the same override locally until the flake input catches up.
- Adds an `assert` that throws once nixpkgs' own unoverridden `cross-seed` build already matches `nodejs_22` (i.e. the upstream fix has landed in our pinned nixpkgs), so the override gets flagged for removal instead of silently lingering as dead weight — same pattern as #719's `jre_headless` override/assertion.

## Verification

- `nix eval` on `nixosConfigurations.harmony.config.services.cross-seed.package` evaluates cleanly and resolves to `cross-seed-6.13.7`.
- Built the overridden package directly on harmony (native x86_64-linux, not cross-eval): it resolved to the exact same cached derivation nixpkgs' own upstream fix produces (`nodejs-22.23.2`), pulled straight from `cache.nixos.org` — no local compilation needed.
- Manually confirmed the assertion fires correctly by simulating the "upstream fixed" state (overriding the default package to nodejs_22 and re-running the check) and confirming it throws the expected removal message.
- Not yet deployed to harmony — `sudo nixos-rebuild switch --flake .#harmony` still needs to run there to actually bring `cross-seed` back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)