### PR TITLE
Audit override/workaround comments for staleness, guard or drop them

### DIFF
--- a/modules/aspects/my/bat.nix
+++ b/modules/aspects/my/bat.nix
@@ -2,13 +2,7 @@
   my.bat.homeManager = { pkgs, ... }: {
     programs.bat = {
       enable = true;
-
-      extraPackages = [
-        (pkgs.bat-extras.core.overrideAttrs (_: {
-          doCheck = false;
-          nativeCheckInputs = [ ];
-        }))
-      ];
+      extraPackages = [ pkgs.bat-extras.core ];
     };
   };
 }

--- a/modules/aspects/my/claude.nix
+++ b/modules/aspects/my/claude.nix
@@ -39,21 +39,6 @@
         uv
       ];
 
-      nixpkgs.overlays = [
-        (_final: prev: {
-          # mcp-nixos's test suite has a non-hermetic test that scans
-          # whatever real file happens to come first in /nix/store (build-
-          # closure-dependent) and asserts its literal content never
-          # contains "Error" - trips on ordinary minified JS (e.g. a
-          # vendored highlight.js) and breaks the build unpredictably as
-          # nixpkgs revisions change the derivation's dependency closure.
-          # Reported upstream: https://github.com/utensils/mcp-nixos/issues/198
-          mcp-nixos = prev.mcp-nixos.overrideAttrs (old: {
-            disabledTests = (old.disabledTests or [ ]) ++ [ "test_read_text_file" ];
-          });
-        })
-      ];
-
       programs.claude-code = {
         enable = true;
 

--- a/modules/aspects/my/seerr.nix
+++ b/modules/aspects/my/seerr.nix
@@ -3,10 +3,10 @@ let
   # Seerr has no released OIDC support yet (seerr-team/seerr#2715 is still open). Build from
   # michaelhthomas's PR branch until it lands in a release, then drop this override.
   oidcFork = {
-    hash = "sha256-JchL4DJk/DrveZthiawtNJW2tDtr66e3k+EaS+iPJp8=";
+    hash = "sha256-6HR1OMqwaDds0B8u6iA/LTcxF9qtuywzhYsdJ0e3Mkw=";
     owner = "michaelhthomas";
     repo = "seerr";
-    rev = "0078a482c9e2a1144069af5d196660e392940ea0";
+    rev = "aebd4433738ff01a471642210537bb4e1020d1c2";
   };
   port = 5055;
 in
@@ -62,27 +62,36 @@ in
               mv "$settings.tmp" "$settings"
             '';
           };
-          package = pkgs.seerr.overrideAttrs (old: rec {
-            pname = "seerr";
+          package = pkgs.seerr.overrideAttrs (
+            old:
+            # Pinned so a seerr version bump forces a check of whether upstream has released OIDC
+            # support (seerr-team/seerr#2715, still an open, unmerged PR as of 2026-08-24) - if so,
+            # drop the oidcFork override above and go back to the stock package.
+            assert
+              old.version == "3.4.1"
+              || throw "seerr.nix: pkgs.seerr is now ${old.version} (was 3.4.1) - re-check whether seerr-team/seerr#2715 (OIDC support) has merged/released; if so, drop the oidcFork override.";
+            rec {
+              pname = "seerr";
 
-            pnpmDeps = pkgs.fetchPnpmDeps {
-              inherit pname src version;
-              fetcherVersion = 3;
-              hash = "sha256-7nBkeXGJfDRSvNesOjOK+Mtzp6SlBvbytyfsQl9eh/Y=";
-              pnpm = pkgs.pnpm_10.override { nodejs-slim = pkgs.nodejs-slim_22; };
-            };
+              pnpmDeps = pkgs.fetchPnpmDeps {
+                inherit pname src version;
+                fetcherVersion = 3;
+                hash = "sha256-sraOsE7jPhSpidcV5X6l8xvHkPGUPoNSN2/6UTMymTs=";
+                pnpm = pkgs.pnpm_10.override { nodejs-slim = pkgs.nodejs-slim_22; };
+              };
 
-            src = pkgs.fetchFromGitHub {
-              inherit (oidcFork)
-                hash
-                owner
-                repo
-                rev
-                ;
-            };
+              src = pkgs.fetchFromGitHub {
+                inherit (oidcFork)
+                  hash
+                  owner
+                  repo
+                  rev
+                  ;
+              };
 
-            version = "unstable-2026-07-12";
-          });
+              version = "unstable-2026-07-31";
+            }
+          );
         in
         {
           services.seerr = {


### PR DESCRIPTION
## Summary

Follow-up to an audit of this repo's `override`/`workaround`-flavored Nix comments for ones with no way to detect when they're no longer needed. Two already had the right pattern (`assert old.version == "X" || throw "re-check..."`, in `oscar.nix` and `minecraft-servers.nix`); this PR brings three more workarounds in line, after actually checking upstream state for each:

- **`bat.nix`** — dropped the `doCheck = false` override on `bat-extras.core` (added in #182 to work around a Darwin CI sandbox failure in its nushell-backed tests). A fresh, force-rebuilt (no substitutes) build of the exact pinned version on Darwin now passes all 45 tests clean, so the workaround looks stale.
- **`claude.nix`** — dropped the `mcp-nixos` overlay that disabled `test_read_text_file` (added in #615 for [utensils/mcp-nixos#198](https://github.com/utensils/mcp-nixos/issues/198)). That issue was fixed upstream in mcp-nixos `v3.0.0` via [utensils/mcp-nixos#154](https://github.com/utensils/mcp-nixos/pull/154) — exactly the version nixpkgs currently pins. A local build of stock `nixpkgs#mcp-nixos` with checks enabled passes 369/369 (1 skipped), including the previously-disabled test.
- **`seerr.nix`** — added a version-pinned `assert` guard on the OIDC fork override, matching the existing pattern. [seerr-team/seerr#2715](https://github.com/seerr-team/seerr/pull/2715) (native OIDC support) is still open/unmerged, so the workaround is still needed - the assert just makes the next `pkgs.seerr` version bump force a re-check instead of carrying it forward silently. Also re-pinned the fork branch, which had been rebased onto a newer upstream base since the last pin (same underlying patch, new commit hash) - updated `rev`/`hash`/`pnpmDeps.hash` accordingly.

## Verification

- `nix build .#darwinConfigurations.OMARSHAL-M-T2QF.config.system.build.toplevel` succeeds end-to-end (exercises the `bat.nix` and `claude.nix` changes).
- Force-rebuilt `bat-extras.core`'s exact derivation with no substitutes - all 45 library tests pass.
- Built stock `nixpkgs#mcp-nixos` with checks enabled - 369 passed, 1 skipped, 0 failures.
- Verified `seerr.nix`'s new `oidcFork` pin (`rev`/`hash`) and `pnpmDeps.hash` by evaluating/building against this repo's actual pinned nixpkgs (the `seerr` package itself is x86_64-linux-only and couldn't be built end-to-end from this aarch64-darwin machine - no Linux builder configured).
- `nix fmt` run on all changed files.

## Test plan

- [ ] CI "Build Darwin hosts" check passes (bat.nix/claude.nix)
- [ ] CI "Build Linux hosts" check passes (seerr.nix, harmony)

🤖 Generated with [Claude Code](https://claude.com/claude-code)